### PR TITLE
Add support for BOM

### DIFF
--- a/bom/build.gradle.kts
+++ b/bom/build.gradle.kts
@@ -1,0 +1,103 @@
+plugins {
+    `java-platform`
+}
+
+group = "io.github.jan-tennert.supabase"
+version = Versions.SUPABASEKT
+description = "A Kotlin Multiplatform Supabase Framework"
+
+val bomProject = project
+
+val excludedModules = listOf("androidDemo", "desktopDemo", "webDemo")
+
+fun shouldIncludeInBom(candidateProject: Project) =
+    excludedModules.all { !candidateProject.name.contains(it) } &&
+            candidateProject.name != bomProject.name
+
+rootProject.subprojects.filter(::shouldIncludeInBom).forEach { bomProject.evaluationDependsOn(it.path) }
+
+dependencies {
+    constraints {
+        rootProject.subprojects.filter { project ->
+            // Only declare dependencies on projects that will have publications
+            shouldIncludeInBom(project) && project.tasks.findByName("publish")?.enabled == true
+        }.forEach { api(project(it.path)) }
+    }
+}
+
+signing {
+    val signingKey = providers
+        .environmentVariable("GPG_SIGNING_KEY")
+        .orElse(File(System.getenv("GPG_PATH") ?: "").let {
+            try {
+                it.readText()
+            } catch(_: Exception) {
+                ""
+            }
+        })
+        .forUseAtConfigurationTime()
+    val signingPassphrase = providers
+        .environmentVariable("GPG_SIGNING_PASSPHRASE")
+        .forUseAtConfigurationTime()
+
+    if (signingKey.isPresent && signingPassphrase.isPresent) {
+        useInMemoryPgpKeys(signingKey.get(), signingPassphrase.get())
+        val extension = extensions
+            .getByName("publishing") as PublishingExtension
+        sign(extension.publications)
+    }
+}
+publishing {
+    repositories {
+        maven {
+            name = "Oss"
+            setUrl {
+                "https://s01.oss.sonatype.org/service/local/staging/deployByRepositoryId/${Publishing.REPOSITORY_ID}"
+            }
+            credentials {
+                username = Publishing.SONATYPE_USERNAME
+                password = Publishing.SONATYPE_PASSWORD
+            }
+        }
+        maven {
+            name = "Snapshot"
+            setUrl { "https://s01.oss.sonatype.org/content/repositories/snapshots/" }
+            credentials {
+                username = Publishing.SONATYPE_USERNAME
+                password = Publishing.SONATYPE_PASSWORD
+            }
+        }
+    }
+
+    publications {
+        create<MavenPublication>("bom") {
+            from(components["javaPlatform"])
+            pom {
+                name.set("supabase-kt")
+                description.set("A Kotlin Multiplatform Supabase Framework")
+                url.set("https://github.com/supabase-community/supabase-kt")
+                licenses {
+                    license {
+                        name.set("GPL-3.0")
+                        url.set("https://www.gnu.org/licenses/gpl-3.0.en.html")
+                    }
+                }
+                issueManagement {
+                    system.set("Github")
+                    url.set("https://github.com/supabase-community/supabase-kt/issues")
+                }
+                scm {
+                    connection.set("https://github.com/supabase-community/supabase-kt.git")
+                    url.set("https://github.com/supabase-community/supabase-kt")
+                }
+                developers {
+                    developer {
+                        name.set("TheRealJanGER")
+                        email.set("jan.m.tennert@gmail.com")
+                    }
+                }
+            }
+        }
+    }
+}
+

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -22,6 +22,7 @@ include(":androidDemo")
 include("Storage")
 include("Realtime")
 include("Functions")
+include("bom")
 project(":GoTrue").name = "gotrue-kt"
 project(":Postgrest").name = "postgrest-kt"
 project(":Storage").name = "storage-kt"


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR adds support for a BOM dependency (#20), which you can include in gradle using

```kotlin
implementation(platform("io.github.jan.supabase:bom:VERSION"))
implementation("io.github.jan.supabase:gotrue-kt")
//and other supabase-kt dependencies
```
**or Kotlin MPP projects:**
```kotlin
implementation(project.dependencies.platform("io.github.jan.supabase:bom:VERSION"))
```

This PR should work as is, tested on maven local

