### PR TITLE
Rework the way plugins interact with Supabase APIs

### DIFF
--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/AuthenticatedSupabaseApi.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/AuthenticatedSupabaseApi.kt
@@ -8,7 +8,7 @@ import io.ktor.client.request.headers
 import io.ktor.client.statement.HttpResponse
 
 class AuthenticatedSupabaseApi(
-    resolveUrl: (String) -> String,
+    resolveUrl: (path: String) -> String,
     supabaseClient: SupabaseClient,
 ): SupabaseApi(resolveUrl, supabaseClient) {
 
@@ -23,6 +23,20 @@ class AuthenticatedSupabaseApi(
 
 }
 
-fun SupabaseClient.authenticatedSupabaseApi(baseUrl: String) = AuthenticatedSupabaseApi({ baseUrl + it }, this)
+/**
+ * Creates a [AuthenticatedSupabaseApi] with the given [baseUrl]. Requires [GoTrue] to authenticate requests
+ * All requests will be resolved relative to this url
+ */
+fun SupabaseClient.authenticatedSupabaseApi(baseUrl: String) = authenticatedSupabaseApi { baseUrl + it }
 
-fun SupabaseClient.authenticatedSupabaseApi(plugin: MainPlugin<*>) = AuthenticatedSupabaseApi(plugin::resolveUrl, this)
+/**
+ * Creates a [AuthenticatedSupabaseApi] for the given [plugin]. Requires [GoTrue] to authenticate requests
+ * All requests will be resolved using the [MainPlugin.resolveUrl] function
+ */
+fun SupabaseClient.authenticatedSupabaseApi(plugin: MainPlugin<*>) = authenticatedSupabaseApi(plugin::resolveUrl)
+
+/**
+ * Creates a [AuthenticatedSupabaseApi] with the given [resolveUrl] function. Requires [GoTrue] to authenticate requests
+ * All requests will be resolved using this function
+ */
+fun SupabaseClient.authenticatedSupabaseApi(resolveUrl: (path: String) -> String) = AuthenticatedSupabaseApi(resolveUrl, this)

--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/AuthenticatedSupabaseApi.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/AuthenticatedSupabaseApi.kt
@@ -1,29 +1,25 @@
 package io.github.jan.supabase.gotrue
 
 import io.github.jan.supabase.SupabaseClient
-import io.github.jan.supabase.network.SupabaseHttpClient
+import io.github.jan.supabase.network.SupabaseApi
 import io.github.jan.supabase.plugins.MainPlugin
 import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.client.request.headers
 import io.ktor.client.statement.HttpResponse
 
 class AuthenticatedSupabaseApi(
-    private val resolveUrl: (String) -> String,
-    private val supabaseClient: SupabaseClient,
-): SupabaseHttpClient() {
+    resolveUrl: (String) -> String,
+    supabaseClient: SupabaseClient,
+): SupabaseApi(resolveUrl, supabaseClient) {
 
-    override suspend fun request(url: String, builder: HttpRequestBuilder.() -> Unit): HttpResponse {
-        return supabaseClient.httpClient.request(resolveUrl(url)) {
-            builder.invoke(this)
-            supabaseClient.gotrue.currentSessionOrNull()?.let {
-                headers {
-                    append("Authorization", "Bearer ${it.accessToken}")
-                }
+    override suspend fun request(url: String, builder: HttpRequestBuilder.() -> Unit): HttpResponse = super.request(url) {
+        supabaseClient.gotrue.currentSessionOrNull()?.let {
+            headers {
+                append("Authorization", "Bearer ${it.accessToken}")
             }
         }
+        builder()
     }
-
-    operator fun plus(endpoint: String) = AuthenticatedSupabaseApi({ resolveUrl(endpoint) + it }, supabaseClient)
 
 }
 

--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/AuthenticatedSupabaseApi.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/AuthenticatedSupabaseApi.kt
@@ -1,0 +1,32 @@
+package io.github.jan.supabase.gotrue
+
+import io.github.jan.supabase.SupabaseClient
+import io.github.jan.supabase.network.SupabaseHttpClient
+import io.github.jan.supabase.plugins.MainPlugin
+import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.client.request.headers
+import io.ktor.client.statement.HttpResponse
+
+class AuthenticatedSupabaseApi(
+    private val resolveUrl: (String) -> String,
+    private val supabaseClient: SupabaseClient,
+): SupabaseHttpClient() {
+
+    override suspend fun request(url: String, builder: HttpRequestBuilder.() -> Unit): HttpResponse {
+        return supabaseClient.httpClient.request(resolveUrl(url)) {
+            builder.invoke(this)
+            supabaseClient.gotrue.currentSessionOrNull()?.let {
+                headers {
+                    append("Authorization", "Bearer ${it.accessToken}")
+                }
+            }
+        }
+    }
+
+    operator fun plus(endpoint: String) = AuthenticatedSupabaseApi({ resolveUrl(endpoint) + it }, supabaseClient)
+
+}
+
+fun SupabaseClient.authenticatedSupabaseApi(baseUrl: String) = AuthenticatedSupabaseApi({ baseUrl + it }, this)
+
+fun SupabaseClient.authenticatedSupabaseApi(plugin: MainPlugin<*>) = AuthenticatedSupabaseApi(plugin::resolveUrl, this)

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/Postgrest.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/Postgrest.kt
@@ -1,6 +1,7 @@
 package io.github.jan.supabase.postgrest
 
 import io.github.jan.supabase.SupabaseClient
+import io.github.jan.supabase.gotrue.authenticatedSupabaseApi
 import io.github.jan.supabase.plugins.MainConfig
 import io.github.jan.supabase.plugins.MainPlugin
 import io.github.jan.supabase.plugins.SupabasePluginProvider
@@ -44,6 +45,8 @@ internal class PostgrestImpl(override val supabaseClient: SupabaseClient, overri
 
     override val PLUGIN_KEY: String
         get() = Postgrest.key
+
+    val api = supabaseClient.authenticatedSupabaseApi(this)
 
     override fun from(table: String): PostgrestBuilder {
         return PostgrestBuilder(this, table)

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/PostgrestResult.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/PostgrestResult.kt
@@ -3,12 +3,14 @@ package io.github.jan.supabase.postgrest.query
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.decodeFromJsonElement
+import kotlin.jvm.JvmInline
 
 /**
  * Represents the result from a postgrest request
  * @param body The body of the response. Can be decoded using [decodeAs] or [decodeAsOrNull]
  */
-data class PostgrestResult(val body: JsonElement, val statusCode: Int) {
+@JvmInline
+value class PostgrestResult(val body: JsonElement) {
 
     /**
      * Decodes [body] as [T] using [json]

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/Realtime.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/Realtime.kt
@@ -6,7 +6,6 @@ import io.github.jan.supabase.SupabaseClientBuilder
 import io.github.jan.supabase.annotiations.SupabaseInternal
 import io.github.jan.supabase.gotrue.GoTrue
 import io.github.jan.supabase.gotrue.SessionStatus
-import io.github.jan.supabase.network.KtorSupabaseHttpClient
 import io.github.jan.supabase.plugins.MainConfig
 import io.github.jan.supabase.plugins.MainPlugin
 import io.github.jan.supabase.plugins.SupabasePluginProvider
@@ -14,7 +13,6 @@ import io.github.jan.supabase.supabaseJson
 import io.ktor.client.plugins.websocket.DefaultClientWebSocketSession
 import io.ktor.client.plugins.websocket.WebSockets
 import io.ktor.client.plugins.websocket.sendSerialized
-import io.ktor.client.plugins.websocket.webSocketSession
 import io.ktor.serialization.kotlinx.KotlinxWebsocketSerializationConverter
 import io.ktor.websocket.Frame
 import io.ktor.websocket.readText
@@ -166,7 +164,7 @@ internal class RealtimeImpl(override val supabaseClient: SupabaseClient, overrid
         updateStatus(Realtime.Status.CONNECTING)
         val realtimeUrl = config.customRealtimeURL ?: (prefix + supabaseClient.supabaseUrl + ("/realtime/v${Realtime.API_VERSION}/websocket?apikey=${supabaseClient.supabaseKey}&vsn=1.0.0"))
          try {
-            ws = (supabaseClient.httpClient as KtorSupabaseHttpClient).httpClient.webSocketSession(realtimeUrl) //this is just temporary
+            ws = supabaseClient.httpClient.webSocketSession(realtimeUrl)
             updateStatus(Realtime.Status.CONNECTED)
             Napier.i { "Connected to realtime websocket!" }
             listenForMessages()

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/Realtime.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/Realtime.kt
@@ -166,7 +166,7 @@ internal class RealtimeImpl(override val supabaseClient: SupabaseClient, overrid
         updateStatus(Realtime.Status.CONNECTING)
         val realtimeUrl = config.customRealtimeURL ?: (prefix + supabaseClient.supabaseUrl + ("/realtime/v${Realtime.API_VERSION}/websocket?apikey=${supabaseClient.supabaseKey}&vsn=1.0.0"))
          try {
-            ws = (supabaseClient.httpClient as KtorSupabaseHttpClient).httpClient.webSocketSession(realtimeUrl)
+            ws = (supabaseClient.httpClient as KtorSupabaseHttpClient).httpClient.webSocketSession(realtimeUrl) //this is just temporary
             updateStatus(Realtime.Status.CONNECTED)
             Napier.i { "Connected to realtime websocket!" }
             listenForMessages()

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/Realtime.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/Realtime.kt
@@ -6,6 +6,7 @@ import io.github.jan.supabase.SupabaseClientBuilder
 import io.github.jan.supabase.annotiations.SupabaseInternal
 import io.github.jan.supabase.gotrue.GoTrue
 import io.github.jan.supabase.gotrue.SessionStatus
+import io.github.jan.supabase.network.KtorSupabaseHttpClient
 import io.github.jan.supabase.plugins.MainConfig
 import io.github.jan.supabase.plugins.MainPlugin
 import io.github.jan.supabase.plugins.SupabasePluginProvider
@@ -165,7 +166,7 @@ internal class RealtimeImpl(override val supabaseClient: SupabaseClient, overrid
         updateStatus(Realtime.Status.CONNECTING)
         val realtimeUrl = config.customRealtimeURL ?: (prefix + supabaseClient.supabaseUrl + ("/realtime/v${Realtime.API_VERSION}/websocket?apikey=${supabaseClient.supabaseKey}&vsn=1.0.0"))
          try {
-            ws = supabaseClient.httpClient.webSocketSession(realtimeUrl)
+            ws = (supabaseClient.httpClient as KtorSupabaseHttpClient).httpClient.webSocketSession(realtimeUrl)
             updateStatus(Realtime.Status.CONNECTED)
             Napier.i { "Connected to realtime websocket!" }
             listenForMessages()

--- a/src/commonMain/kotlin/io/github/jan/supabase/SupabaseClient.kt
+++ b/src/commonMain/kotlin/io/github/jan/supabase/SupabaseClient.kt
@@ -1,15 +1,12 @@
 package io.github.jan.supabase
 
 import io.github.aakira.napier.Napier
+import io.github.jan.supabase.network.KtorSupabaseHttpClient
+import io.github.jan.supabase.network.SupabaseHttpClient
 import io.github.jan.supabase.plugins.PluginManager
 import io.github.jan.supabase.plugins.SupabasePlugin
-import io.ktor.client.HttpClient
 import io.ktor.client.HttpClientConfig
 import io.ktor.client.engine.HttpClientEngine
-import io.ktor.client.plugins.DefaultRequest
-import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
-import io.ktor.client.request.headers
-import io.ktor.serialization.kotlinx.json.json
 
 /**
  * The main class to interact with Supabase.
@@ -41,7 +38,7 @@ sealed interface SupabaseClient {
     /**
      * The http client used to interact with the supabase api
      */
-    val httpClient: HttpClient
+    val httpClient: SupabaseHttpClient
 
     /**
      * Releases all resources held by the [httpClient] and all plugins the [pluginManager]
@@ -77,40 +74,10 @@ internal class SupabaseClientImpl(
         key to value(this)
     })
 
-    override val httpClient = if(httpEngine != null) {
-        HttpClient(httpEngine) {
-            install(DefaultRequest) {
-                headers {
-                    if(supabaseKey.isNotBlank()) {
-                        append("apikey", supabaseKey)
-                    }
-                }
-                port = 443
-            }
-            install(ContentNegotiation) {
-                json(supabaseJson)
-            }
-            httpConfigOverrides.forEach { it.invoke(this) }
-        }
-    } else {
-        HttpClient {
-            install(DefaultRequest) {
-                headers {
-                    if(supabaseKey.isNotBlank()) {
-                        append("apikey", supabaseKey)
-                    }
-                }
-                port = 443
-            }
-            install(ContentNegotiation) {
-                json(supabaseJson)
-            }
-            httpConfigOverrides.forEach { it.invoke(this) }
-        }
-    }
+    override val httpClient = KtorSupabaseHttpClient(supabaseKey, httpConfigOverrides, httpEngine)
 
     override suspend fun close() {
-        httpClient.close()
+        httpClient.httpClient.close()
         pluginManager.closeAllPlugins()
     }
 

--- a/src/commonMain/kotlin/io/github/jan/supabase/SupabaseClient.kt
+++ b/src/commonMain/kotlin/io/github/jan/supabase/SupabaseClient.kt
@@ -2,7 +2,6 @@ package io.github.jan.supabase
 
 import io.github.aakira.napier.Napier
 import io.github.jan.supabase.network.KtorSupabaseHttpClient
-import io.github.jan.supabase.network.SupabaseHttpClient
 import io.github.jan.supabase.plugins.PluginManager
 import io.github.jan.supabase.plugins.SupabasePlugin
 import io.ktor.client.HttpClientConfig
@@ -38,7 +37,7 @@ sealed interface SupabaseClient {
     /**
      * The http client used to interact with the supabase api
      */
-    val httpClient: SupabaseHttpClient
+    val httpClient: KtorSupabaseHttpClient
 
     /**
      * Releases all resources held by the [httpClient] and all plugins the [pluginManager]
@@ -77,7 +76,7 @@ internal class SupabaseClientImpl(
     override val httpClient = KtorSupabaseHttpClient(supabaseKey, httpConfigOverrides, httpEngine)
 
     override suspend fun close() {
-        httpClient.httpClient.close()
+        httpClient.close()
         pluginManager.closeAllPlugins()
     }
 

--- a/src/commonMain/kotlin/io/github/jan/supabase/network/KtorSupabaseHttpClient.kt
+++ b/src/commonMain/kotlin/io/github/jan/supabase/network/KtorSupabaseHttpClient.kt
@@ -6,25 +6,33 @@ import io.ktor.client.HttpClientConfig
 import io.ktor.client.engine.HttpClientEngine
 import io.ktor.client.plugins.DefaultRequest
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.websocket.webSocketSession
 import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.client.request.headers
 import io.ktor.client.request.request
 import io.ktor.client.statement.HttpResponse
 import io.ktor.serialization.kotlinx.json.json
 
+/**
+ * A [SupabaseHttpClient] that uses ktor to send requests
+ */
 class KtorSupabaseHttpClient(
-    val supabaseKey: String,
+    private val supabaseKey: String,
     modifiers: List<HttpClientConfig<*>.() -> Unit> = listOf(),
     engine: HttpClientEngine? = null,
 ): SupabaseHttpClient() {
 
-    val httpClient =
+    private val httpClient =
         if(engine != null) HttpClient(engine) { applyDefaultConfiguration(modifiers) }
         else HttpClient { applyDefaultConfiguration(modifiers) }
 
     override suspend fun request(url: String, builder: HttpRequestBuilder.() -> Unit): HttpResponse {
         return httpClient.request(url, builder)
     }
+
+    suspend fun webSocketSession(url: String, block: HttpRequestBuilder.() -> Unit = {}) = httpClient.webSocketSession(url, block)
+
+    fun close() = httpClient.close()
 
     private fun HttpClientConfig<*>.applyDefaultConfiguration(modifiers: List<HttpClientConfig<*>.() -> Unit>) {
         install(DefaultRequest) {

--- a/src/commonMain/kotlin/io/github/jan/supabase/network/KtorSupabaseHttpClient.kt
+++ b/src/commonMain/kotlin/io/github/jan/supabase/network/KtorSupabaseHttpClient.kt
@@ -1,0 +1,44 @@
+package io.github.jan.supabase.network
+
+import io.github.jan.supabase.supabaseJson
+import io.ktor.client.HttpClient
+import io.ktor.client.HttpClientConfig
+import io.ktor.client.engine.HttpClientEngine
+import io.ktor.client.plugins.DefaultRequest
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.client.request.headers
+import io.ktor.client.request.request
+import io.ktor.client.statement.HttpResponse
+import io.ktor.serialization.kotlinx.json.json
+
+class KtorSupabaseHttpClient(
+    val supabaseKey: String,
+    modifiers: List<HttpClientConfig<*>.() -> Unit> = listOf(),
+    engine: HttpClientEngine? = null,
+): SupabaseHttpClient() {
+
+    val httpClient =
+        if(engine != null) HttpClient(engine) { applyDefaultConfiguration(modifiers) }
+        else HttpClient { applyDefaultConfiguration(modifiers) }
+
+    override suspend fun request(url: String, builder: HttpRequestBuilder.() -> Unit): HttpResponse {
+        return httpClient.request(url, builder)
+    }
+
+    private fun HttpClientConfig<*>.applyDefaultConfiguration(modifiers: List<HttpClientConfig<*>.() -> Unit>) {
+        install(DefaultRequest) {
+            headers {
+                if(supabaseKey.isNotBlank()) {
+                    append("apikey", supabaseKey)
+                }
+            }
+            port = 443
+        }
+        install(ContentNegotiation) {
+            json(supabaseJson)
+        }
+        modifiers.forEach { it.invoke(this) }
+    }
+
+}

--- a/src/commonMain/kotlin/io/github/jan/supabase/network/SupabaseApi.kt
+++ b/src/commonMain/kotlin/io/github/jan/supabase/network/SupabaseApi.kt
@@ -1,0 +1,21 @@
+package io.github.jan.supabase.network
+
+import io.github.jan.supabase.SupabaseClient
+import io.github.jan.supabase.plugins.MainPlugin
+import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.client.statement.HttpResponse
+
+open class SupabaseApi(
+    private val resolveUrl: (String) -> String,
+    private val supabaseClient: SupabaseClient
+) : SupabaseHttpClient() {
+
+    override suspend fun request(url: String, builder: HttpRequestBuilder.() -> Unit): HttpResponse {
+        return supabaseClient.httpClient.request(resolveUrl(url), builder)
+    }
+
+}
+
+fun SupabaseClient.supabaseApi(baseUrl: String) = SupabaseApi({ baseUrl + it }, this)
+
+fun SupabaseClient.supabaseApi(plugin: MainPlugin<*>) = SupabaseApi(plugin::resolveUrl, this)

--- a/src/commonMain/kotlin/io/github/jan/supabase/network/SupabaseApi.kt
+++ b/src/commonMain/kotlin/io/github/jan/supabase/network/SupabaseApi.kt
@@ -7,7 +7,7 @@ import io.ktor.client.statement.HttpResponse
 
 open class SupabaseApi(
     private val resolveUrl: (String) -> String,
-    private val supabaseClient: SupabaseClient
+    val supabaseClient: SupabaseClient
 ) : SupabaseHttpClient() {
 
     override suspend fun request(url: String, builder: HttpRequestBuilder.() -> Unit): HttpResponse {

--- a/src/commonMain/kotlin/io/github/jan/supabase/network/SupabaseApi.kt
+++ b/src/commonMain/kotlin/io/github/jan/supabase/network/SupabaseApi.kt
@@ -6,7 +6,7 @@ import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.client.statement.HttpResponse
 
 open class SupabaseApi(
-    private val resolveUrl: (String) -> String,
+    private val resolveUrl: (path: String) -> String,
     val supabaseClient: SupabaseClient
 ) : SupabaseHttpClient() {
 
@@ -16,6 +16,20 @@ open class SupabaseApi(
 
 }
 
-fun SupabaseClient.supabaseApi(baseUrl: String) = SupabaseApi({ baseUrl + it }, this)
+/**
+ * Creates a [SupabaseApi] with the given [baseUrl]
+ * All requests will be resolved relative to this url
+ */
+fun SupabaseClient.supabaseApi(baseUrl: String) = supabaseApi { baseUrl + it }
 
-fun SupabaseClient.supabaseApi(plugin: MainPlugin<*>) = SupabaseApi(plugin::resolveUrl, this)
+/**
+ * Creates a [SupabaseApi] for the given [plugin]
+ * All requests will be resolved using the [MainPlugin.resolveUrl] function
+ */
+fun SupabaseClient.supabaseApi(plugin: MainPlugin<*>) = supabaseApi(plugin::resolveUrl)
+
+/**
+ * Creates a [SupabaseApi] with the given [resolveUrl] function
+ * All requests will be resolved using this function
+ */
+fun SupabaseClient.supabaseApi(resolveUrl: (path: String) -> String) = SupabaseApi(resolveUrl, this)

--- a/src/commonMain/kotlin/io/github/jan/supabase/network/SupabaseHttpClient.kt
+++ b/src/commonMain/kotlin/io/github/jan/supabase/network/SupabaseHttpClient.kt
@@ -1,0 +1,75 @@
+package io.github.jan.supabase.network
+
+import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.HttpResponse
+import io.ktor.http.ContentType
+import io.ktor.http.HttpMethod
+import io.ktor.http.contentType
+
+abstract class SupabaseHttpClient {
+
+    abstract suspend fun request(url: String, builder: HttpRequestBuilder.() -> Unit): HttpResponse
+
+    suspend inline fun get(url: String, crossinline builder: HttpRequestBuilder.() -> Unit = {}) = request(url) {
+        method = HttpMethod.Get
+        builder()
+    }
+
+    suspend inline fun post(url: String, crossinline builder: HttpRequestBuilder.() -> Unit = {}) = request(url) {
+        method = HttpMethod.Post
+        builder()
+    }
+
+    suspend inline fun <reified T> post(url: String, body: T, contentType: ContentType = ContentType.Any, crossinline builder: HttpRequestBuilder.() -> Unit = {}) = request(url) {
+        method = HttpMethod.Post
+        builder()
+        contentType(contentType)
+        setBody(body)
+    }
+
+    suspend inline fun <reified T> postJson(url: String, body: T, crossinline builder: HttpRequestBuilder.() -> Unit = {}) = post(url, body, ContentType.Application.Json, builder)
+
+    suspend inline fun delete(url: String, crossinline builder: HttpRequestBuilder.() -> Unit = {}) = request(url) {
+        method = HttpMethod.Delete
+        builder()
+    }
+
+    suspend inline fun <reified T> delete(url: String, body: T, contentType: ContentType = ContentType.Any, crossinline builder: HttpRequestBuilder.() -> Unit = {}) = request(url) {
+        method = HttpMethod.Delete
+        builder()
+        contentType(contentType)
+        setBody(body)
+    }
+
+    suspend inline fun <reified T> deleteJson(url: String, body: T, crossinline builder: HttpRequestBuilder.() -> Unit = {}) = delete(url, body, ContentType.Application.Json, builder)
+
+    suspend inline fun patch(url: String, crossinline builder: HttpRequestBuilder.() -> Unit = {}) = request(url) {
+        method = HttpMethod.Patch
+        builder()
+    }
+
+    suspend inline fun <reified T> patch(url: String, body: T, contentType: ContentType = ContentType.Any, crossinline builder: HttpRequestBuilder.() -> Unit = {}) = request(url) {
+        method = HttpMethod.Patch
+        builder()
+        contentType(contentType)
+        setBody(body)
+    }
+
+    suspend inline fun <reified T> patchJson(url: String, body: T, crossinline builder: HttpRequestBuilder.() -> Unit = {}) = patch(url, body, ContentType.Application.Json, builder)
+
+    suspend inline fun put(url: String, crossinline builder: HttpRequestBuilder.() -> Unit = {}) = request(url) {
+        method = HttpMethod.Put
+        builder()
+    }
+
+    suspend inline fun <reified T> put(url: String, body: T, contentType: ContentType = ContentType.Any, crossinline builder: HttpRequestBuilder.() -> Unit = {}) = request(url) {
+        method = HttpMethod.Put
+        builder()
+        contentType(contentType)
+        setBody(body)
+    }
+
+    suspend inline fun <reified T> putJson(url: String, body: T, crossinline builder: HttpRequestBuilder.() -> Unit = {}) = put(url, body, ContentType.Application.Json, builder)
+
+}

--- a/src/commonMain/kotlin/io/github/jan/supabase/network/SupabaseHttpClient.kt
+++ b/src/commonMain/kotlin/io/github/jan/supabase/network/SupabaseHttpClient.kt
@@ -7,6 +7,9 @@ import io.ktor.http.ContentType
 import io.ktor.http.HttpMethod
 import io.ktor.http.contentType
 
+/**
+ * The base HttpClients used by all main plugins
+ */
 abstract class SupabaseHttpClient {
 
     abstract suspend fun request(url: String, builder: HttpRequestBuilder.() -> Unit): HttpResponse


### PR DESCRIPTION
## What kind of change does this PR introduce?

Backend rework

## What is the current behavior?

The main plugins call their apis using the central HttpClient. There are two problems with this:
- The authorization header must be added manually on each request 
- You always have to put in the whole url, when making a request (which got better as all MainPlugin have a **resolveUrl(path)** method)

## What is the new behavior?

- All API calls run via the new **SupabaseHttpClient**
- You can easily create an API Client via SupabaseClient#supabaseApi(baseUrl) or SupabaseClient#supabaseApi(mainPlugin) which automatically appends the endpoints to the baseUrl when calling **SupabaseApi#get** etc.
- GoTrue adds SupabaseClient#authenticatedSupabaseApi which does the same thing except all requests are authenticated
