### PR TITLE
Improve error handling for all APIs

### DIFF
--- a/Functions/src/commonMain/kotlin/io/github/jan/supabase/functions/EdgeFunction.kt
+++ b/Functions/src/commonMain/kotlin/io/github/jan/supabase/functions/EdgeFunction.kt
@@ -2,8 +2,8 @@ package io.github.jan.supabase.functions
 
 import io.github.jan.supabase.SupabaseClient
 import io.github.jan.supabase.annotiations.SupabaseInternal
+import io.github.jan.supabase.exceptions.RestException
 import io.ktor.http.Headers
-import io.ktor.http.HeadersBuilder
 import io.ktor.http.HttpHeaders
 
 /**
@@ -21,11 +21,13 @@ class EdgeFunction @SupabaseInternal constructor(
     /**
      * Invokes the edge function
      * Note, if you want to serialize [body] to json, you need to add the [HttpHeaders.ContentType] header yourself.
+     * @throws RestException or one of its subclasses if the request failed
      */
     suspend inline operator fun <reified T> invoke(body: T) = supabaseClient.functions.invoke(functionName, body, headers)
 
     /**
      * Invokes the edge function
+     * @throws RestException or one of its subclasses if the request failed
      */
     suspend inline operator fun invoke() = supabaseClient.functions.invoke(function = functionName, headers = headers)
 

--- a/Functions/src/commonMain/kotlin/io/github/jan/supabase/functions/Functions.kt
+++ b/Functions/src/commonMain/kotlin/io/github/jan/supabase/functions/Functions.kt
@@ -3,6 +3,10 @@ package io.github.jan.supabase.functions
 import io.github.jan.supabase.SupabaseClient
 import io.github.jan.supabase.annotiations.SupabaseInternal
 import io.github.jan.supabase.buildUrl
+import io.github.jan.supabase.exceptions.BadRequestRestException
+import io.github.jan.supabase.exceptions.NotFoundRestException
+import io.github.jan.supabase.exceptions.RestException
+import io.github.jan.supabase.exceptions.UnauthorizedRestException
 import io.github.jan.supabase.gotrue.GoTrue
 import io.github.jan.supabase.gotrue.authenticatedSupabaseApi
 import io.github.jan.supabase.gotrue.checkErrors
@@ -12,8 +16,10 @@ import io.github.jan.supabase.plugins.SupabasePluginProvider
 import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsText
 import io.ktor.http.Headers
 import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
 import io.ktor.http.appendEncodedPathSegments
 
 /**
@@ -36,6 +42,7 @@ class Functions(override val config: Config, override val supabaseClient: Supaba
      * Invokes a remote edge function. The authorization token is automatically added to the request.
      * @param function The function to invoke
      * @param builder The request builder to configure the request
+     * @throws RestException or one of its subclasses if the request failed
      */
     suspend inline operator fun invoke(function: String, crossinline builder: HttpRequestBuilder.() -> Unit): HttpResponse {
         return api.post(function) {
@@ -53,6 +60,7 @@ class Functions(override val config: Config, override val supabaseClient: Supaba
      * @param function The function to invoke
      * @param body The body of the request
      * @param headers Headers to add to the request
+     * @throws RestException or one of its subclasses if the request failed
      */
     suspend inline operator fun <reified T> invoke(function: String, body: T, headers: Headers = Headers.Empty): HttpResponse = invoke(function) {
         this.headers.appendAll(headers)
@@ -65,6 +73,7 @@ class Functions(override val config: Config, override val supabaseClient: Supaba
      * Invokes a remote edge function. The authorization token is automatically added to the request.
      * @param function The function to invoke
      * @param headers Headers to add to the request
+     * @throws RestException or one of its subclasses if the request failed
      */
     suspend inline operator fun invoke(function: String, headers: Headers = Headers.Empty): HttpResponse = invoke(function) {
         this.headers.appendAll(headers)
@@ -81,6 +90,16 @@ class Functions(override val config: Config, override val supabaseClient: Supaba
     override fun resolveUrl(path: String): String {
         return buildUrl(config.customUrl ?: baseUrl) {
             appendEncodedPathSegments(path)
+        }
+    }
+
+    override suspend fun parseErrorResponse(response: HttpResponse): RestException {
+        val error = response.bodyAsText()
+        return when(response.status) {
+            HttpStatusCode.Unauthorized -> UnauthorizedRestException(error, response)
+            HttpStatusCode.NotFound -> NotFoundRestException(error, response)
+            HttpStatusCode.BadRequest -> BadRequestRestException(error, response)
+            else -> UnauthorizedRestException(error, response)
         }
     }
 

--- a/Functions/src/commonMain/kotlin/io/github/jan/supabase/functions/Functions.kt
+++ b/Functions/src/commonMain/kotlin/io/github/jan/supabase/functions/Functions.kt
@@ -9,7 +9,6 @@ import io.github.jan.supabase.exceptions.RestException
 import io.github.jan.supabase.exceptions.UnauthorizedRestException
 import io.github.jan.supabase.gotrue.GoTrue
 import io.github.jan.supabase.gotrue.authenticatedSupabaseApi
-import io.github.jan.supabase.gotrue.checkErrors
 import io.github.jan.supabase.plugins.MainConfig
 import io.github.jan.supabase.plugins.MainPlugin
 import io.github.jan.supabase.plugins.SupabasePluginProvider

--- a/Functions/src/commonMain/kotlin/io/github/jan/supabase/functions/Functions.kt
+++ b/Functions/src/commonMain/kotlin/io/github/jan/supabase/functions/Functions.kt
@@ -50,7 +50,7 @@ class Functions(override val config: Config, override val supabaseClient: Supaba
                 this.headers[HttpHeaders.Authorization] = "Bearer $it"
             }
             builder()
-        }.checkErrors("Couldn't invoke function $function")
+        }
     }
 
     /**

--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/AuthenticatedSupabaseApi.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/AuthenticatedSupabaseApi.kt
@@ -15,7 +15,7 @@ class AuthenticatedSupabaseApi(
 ): SupabaseApi(resolveUrl, parseErrorResponse, supabaseClient) {
 
     override suspend fun request(url: String, builder: HttpRequestBuilder.() -> Unit): HttpResponse = super.request(url) {
-        supabaseClient.gotrue.currentSessionOrNull()?.let {
+        supabaseClient.pluginManager.getPluginOrNull(GoTrue)?.currentSessionOrNull()?.let {
             headers {
                 append("Authorization", "Bearer ${it.accessToken}")
             }

--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/AuthenticatedSupabaseApi.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/AuthenticatedSupabaseApi.kt
@@ -1,6 +1,7 @@
 package io.github.jan.supabase.gotrue
 
 import io.github.jan.supabase.SupabaseClient
+import io.github.jan.supabase.exceptions.RestException
 import io.github.jan.supabase.network.SupabaseApi
 import io.github.jan.supabase.plugins.MainPlugin
 import io.ktor.client.request.HttpRequestBuilder
@@ -9,8 +10,9 @@ import io.ktor.client.statement.HttpResponse
 
 class AuthenticatedSupabaseApi(
     resolveUrl: (path: String) -> String,
+    parseErrorResponse: (suspend (response: HttpResponse) -> RestException)? = null,
     supabaseClient: SupabaseClient,
-): SupabaseApi(resolveUrl, supabaseClient) {
+): SupabaseApi(resolveUrl, parseErrorResponse, supabaseClient) {
 
     override suspend fun request(url: String, builder: HttpRequestBuilder.() -> Unit): HttpResponse = super.request(url) {
         supabaseClient.gotrue.currentSessionOrNull()?.let {
@@ -27,16 +29,16 @@ class AuthenticatedSupabaseApi(
  * Creates a [AuthenticatedSupabaseApi] with the given [baseUrl]. Requires [GoTrue] to authenticate requests
  * All requests will be resolved relative to this url
  */
-fun SupabaseClient.authenticatedSupabaseApi(baseUrl: String) = authenticatedSupabaseApi { baseUrl + it }
+fun SupabaseClient.authenticatedSupabaseApi(baseUrl: String, parseErrorResponse: (suspend (response: HttpResponse) -> RestException)? = null) = authenticatedSupabaseApi({ baseUrl + it }, parseErrorResponse)
 
 /**
  * Creates a [AuthenticatedSupabaseApi] for the given [plugin]. Requires [GoTrue] to authenticate requests
  * All requests will be resolved using the [MainPlugin.resolveUrl] function
  */
-fun SupabaseClient.authenticatedSupabaseApi(plugin: MainPlugin<*>) = authenticatedSupabaseApi(plugin::resolveUrl)
+fun SupabaseClient.authenticatedSupabaseApi(plugin: MainPlugin<*>) = authenticatedSupabaseApi(plugin::resolveUrl, plugin::parseErrorResponse)
 
 /**
  * Creates a [AuthenticatedSupabaseApi] with the given [resolveUrl] function. Requires [GoTrue] to authenticate requests
  * All requests will be resolved using this function
  */
-fun SupabaseClient.authenticatedSupabaseApi(resolveUrl: (path: String) -> String) = AuthenticatedSupabaseApi(resolveUrl, this)
+fun SupabaseClient.authenticatedSupabaseApi(resolveUrl: (path: String) -> String, parseErrorResponse: (suspend (response: HttpResponse) -> RestException)? = null) = AuthenticatedSupabaseApi(resolveUrl, parseErrorResponse, this)

--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/GoTrue.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/GoTrue.kt
@@ -10,7 +10,6 @@ import io.github.jan.supabase.gotrue.providers.builtin.Email
 import io.github.jan.supabase.gotrue.providers.builtin.Phone
 import io.github.jan.supabase.gotrue.user.UserInfo
 import io.github.jan.supabase.gotrue.user.UserSession
-import io.github.jan.supabase.exceptions.RestException
 import io.github.jan.supabase.plugins.MainConfig
 import io.github.jan.supabase.plugins.MainPlugin
 import io.github.jan.supabase.plugins.SupabasePluginProvider

--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/GoTrue.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/GoTrue.kt
@@ -2,6 +2,7 @@ package io.github.jan.supabase.gotrue
 
 import io.github.aakira.napier.Napier
 import io.github.jan.supabase.SupabaseClient
+import io.github.jan.supabase.exceptions.RestException
 import io.github.jan.supabase.gotrue.admin.AdminApi
 import io.github.jan.supabase.gotrue.providers.AuthProvider
 import io.github.jan.supabase.gotrue.providers.Google
@@ -53,7 +54,7 @@ sealed interface GoTrue : MainPlugin<GoTrue.Config> {
      * @param provider the provider to use for signing up. E.g. [Email], [Phone] or [Google]
      * @param redirectUrl The redirect url to use. If you don't specify this, the platform specific will be use, like deeplinks on android.
      * @param config The configuration to use for the sign-up.
-     * @throws RestException If the credentials are invalid
+     * @throws RestException or one of its subclasses if the request failed
      */
     suspend fun <C, R, Provider : AuthProvider<C, R>> signUpWith(
         provider: Provider,
@@ -66,7 +67,7 @@ sealed interface GoTrue : MainPlugin<GoTrue.Config> {
      * @param provider the provider to use for signing up. E.g. [Email], [Phone] or [Google]
      * @param redirectUrl The redirect url to use. If you don't specify this, the platform specific will be use, like deeplinks on android.
      * @param config The configuration to use for the sign-up.
-     * @throws RestException If the credentials are invalid
+     * @throws RestException or one of its subclasses if the request failed
      */
     suspend fun <C, R, Provider : AuthProvider<C, R>> loginWith(
         provider: Provider,
@@ -79,7 +80,7 @@ sealed interface GoTrue : MainPlugin<GoTrue.Config> {
      * @param provider The provider to use. Either [Email] or [Phone]
      * @param extraData Extra data to store
      * @param config The configuration to use
-     * @throws RestException If the current session is invalid
+     * @throws RestException or one of its subclasses if the request failed
      */
     suspend fun <C, R, Provider : DefaultAuthProvider<C, R>> modifyUser(
         provider: Provider,
@@ -92,6 +93,7 @@ sealed interface GoTrue : MainPlugin<GoTrue.Config> {
      * @param provider The provider to use. Either [Email] or [Phone]
      * @param createUser Whether to create a user when a user with the given credentials doesn't exist
      * @param redirectUrl The redirect url to use. If you don't specify this, the platform specific will be use, like deeplinks on android.
+     * @throws RestException or one of its subclasses if the request failed
      */
     suspend fun <C, R, Provider : DefaultAuthProvider<C, R>> sendOtpTo(
         provider: Provider,
@@ -104,16 +106,19 @@ sealed interface GoTrue : MainPlugin<GoTrue.Config> {
      * Sends a password reset email to the user with the specified [email]
      * @param email The email to send the password reset email to
      * @param redirectUrl The redirect url to use. If you don't specify this, the platform specific will be use, like deeplinks on android.
+     * @throws RestException or one of its subclasses if the request failed
      */
     suspend fun sendRecoveryEmail(email: String, redirectUrl: String? = null, captchaToken: String? = null)
 
     /**
      * Sends a nonce to the user's email (preferred) or phone
+     * @throws RestException or one of its subclasses if the request failed
      */
     suspend fun reauthenticate()
 
     /**
      * Revokes all refresh tokens for the user, and invalidates the session
+     * @throws RestException or one of its subclasses if the request failed
      */
     suspend fun invalidateAllRefreshTokens()
 
@@ -121,6 +126,7 @@ sealed interface GoTrue : MainPlugin<GoTrue.Config> {
      * Verifies a registration, invite or password recovery
      * @param type The type of the verification
      * @param token The token used to verify
+     * @throws RestException or one of its subclasses if the request failed
      */
     suspend fun verify(type: VerifyType, token: String, captchaToken: String? = null)
 
@@ -128,16 +134,19 @@ sealed interface GoTrue : MainPlugin<GoTrue.Config> {
      * Verifies a phone/sms otp
      * @param token The otp to verify
      * @param phoneNumber The phone number the token was sent to
+     * @throws RestException or one of its subclasses if the request failed
      */
     suspend fun verifyPhone(token: String, phoneNumber: String, captchaToken: String? = null)
 
     /**
      * Retrieves the current user with the session
+     * @throws RestException or one of its subclasses if the request failed
      */
     suspend fun getUser(jwt: String): UserInfo
 
     /**
-     * Invalidates the current session, which means [currentSession] will be null
+     * Invalidates the current session, which means [sessionStatus] will be [SessionStatus.NotAuthenticated]
+     * @throws RestException or one of its subclasses if the request failed
      */
     suspend fun invalidateSession()
 
@@ -162,11 +171,13 @@ sealed interface GoTrue : MainPlugin<GoTrue.Config> {
      * Refreshes a session using the refresh token
      * @param refreshToken The refresh token to use
      * @return A new session
+     * @throws RestException or one of its subclasses if the request failed
      */
     suspend fun refreshSession(refreshToken: String): UserSession
 
     /**
      * Refreshes the current session
+     * @throws RestException or one of its subclasses if the request failed
      */
     suspend fun refreshCurrentSession()
 

--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/GoTrueErrorResponse.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/GoTrueErrorResponse.kt
@@ -1,0 +1,37 @@
+package io.github.jan.supabase.gotrue
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.descriptors.buildClassSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+@Serializable(with = GoTrueErrorResponse.Companion::class)
+internal data class GoTrueErrorResponse(
+    val error: String
+) {
+
+    companion object : KSerializer<GoTrueErrorResponse> {
+
+        override val descriptor = buildClassSerialDescriptor("GoTrueErrorResponse") {
+            element("error", String.serializer().descriptor)
+        }
+
+        override fun deserialize(decoder: Decoder): GoTrueErrorResponse {
+            decoder as JsonDecoder
+            val json = decoder.decodeJsonElement()
+            val error = json.jsonObject["error"]?.jsonPrimitive?.content ?: json.jsonObject["msg"]?.jsonPrimitive?.content ?: json.toString()
+            return GoTrueErrorResponse(error)
+        }
+
+        override fun serialize(encoder: Encoder, value: GoTrueErrorResponse) {
+            throw UnsupportedOperationException()
+        }
+
+    }
+
+}

--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/GoTrueImpl.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/GoTrueImpl.kt
@@ -2,9 +2,9 @@ package io.github.jan.supabase.gotrue
 
  import io.github.aakira.napier.Napier
  import io.github.jan.supabase.SupabaseClient
- import io.github.jan.supabase.exceptions.BadRequestException
+ import io.github.jan.supabase.exceptions.BadRequestRestException
  import io.github.jan.supabase.exceptions.RestException
- import io.github.jan.supabase.exceptions.UnauthorizedException
+ import io.github.jan.supabase.exceptions.UnauthorizedRestException
  import io.github.jan.supabase.exceptions.UnknownRestException
  import io.github.jan.supabase.gotrue.admin.AdminApi
  import io.github.jan.supabase.gotrue.admin.AdminApiImpl
@@ -290,9 +290,9 @@ internal class GoTrueImpl(override val supabaseClient: SupabaseClient, override 
         val errorCode = response.status.value
         val errorBody = response.body<GoTrueErrorResponse>()
         return when(errorCode) {
-            401 -> UnauthorizedException(errorBody.error, response)
-            400 -> BadRequestException(errorBody.error, response)
-            422 -> BadRequestException(errorBody.error, response)
+            401 -> UnauthorizedRestException(errorBody.error, response)
+            400 -> BadRequestRestException(errorBody.error, response)
+            422 -> BadRequestRestException(errorBody.error, response)
             else -> UnknownRestException(errorBody.error, response)
         }
     }

--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/GoTrueImpl.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/GoTrueImpl.kt
@@ -126,7 +126,7 @@ internal class GoTrueImpl(override val supabaseClient: SupabaseClient, override 
         }.toString()
         api.postJson("otp", body) {
             finalRedirectUrl?.let { url.parameters.append("redirect_to", it) }
-        }.checkErrors()
+        }
     }
 
     override suspend fun sendRecoveryEmail(email: String, redirectUrl: String?, captchaToken: String?) {
@@ -141,11 +141,11 @@ internal class GoTrueImpl(override val supabaseClient: SupabaseClient, override 
         }.toString()
         api.postJson("recover", body) {
             finalRedirectUrl?.let { url.encodedParameters.append("redirect_to", it) }
-        }.checkErrors()
+        }
     }
 
     override suspend fun reauthenticate() {
-        api.get("reauthenticate").checkErrors()
+        api.get("reauthenticate")
     }
 
     override suspend fun verify(type: VerifyType, token: String, captchaToken: String?) {
@@ -159,7 +159,7 @@ internal class GoTrueImpl(override val supabaseClient: SupabaseClient, override 
             }
         }
         val response = api.postJson("verify", body)
-        val session =  response.checkErrors().body<UserSession>()
+        val session =  response.body<UserSession>()
         startAutoRefresh(session)
     }
 
@@ -175,7 +175,7 @@ internal class GoTrueImpl(override val supabaseClient: SupabaseClient, override 
             }
         }
         val response = api.postJson("verify", body)
-        val session = response.checkErrors().body<UserSession>()
+        val session = response.body<UserSession>()
         startAutoRefresh(session)
     }
 

--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/GoTrueImpl.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/GoTrueImpl.kt
@@ -17,6 +17,7 @@ package io.github.jan.supabase.gotrue
  import io.github.jan.supabase.toJsonObject
  import io.ktor.client.call.body
  import io.ktor.client.request.header
+ import io.ktor.client.statement.HttpResponse
  import io.ktor.client.statement.bodyAsText
  import kotlinx.coroutines.CoroutineScope
  import kotlinx.coroutines.Job

--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/Utils.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/Utils.kt
@@ -3,18 +3,9 @@ package io.github.jan.supabase.gotrue
 import io.github.aakira.napier.Napier
 import io.github.jan.supabase.SupabaseClient
 import io.github.jan.supabase.gotrue.user.UserSession
-import io.ktor.client.statement.HttpResponse
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-
-suspend fun HttpResponse.checkErrors(error: String = "Error while performing request"): HttpResponse {
-    if(status.value !in 200..299) {
-        throw Exception("da")
-      //  throw RestException(status.value, error, bodyAsText(), headers.entries().flatMap { (key, value) -> listOf(key) + value })
-    }
-    return this
-}
 
 internal fun SupabaseClient.parseFragment(fragment: String, onSessionSuccess: (UserSession) -> Unit = {}) {
     val authPlugin = gotrue

--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/Utils.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/Utils.kt
@@ -2,17 +2,16 @@ package io.github.jan.supabase.gotrue
 
 import io.github.aakira.napier.Napier
 import io.github.jan.supabase.SupabaseClient
-import io.github.jan.supabase.exceptions.RestException
 import io.github.jan.supabase.gotrue.user.UserSession
 import io.ktor.client.statement.HttpResponse
-import io.ktor.client.statement.bodyAsText
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
 suspend fun HttpResponse.checkErrors(error: String = "Error while performing request"): HttpResponse {
     if(status.value !in 200..299) {
-        throw RestException(status.value, error, bodyAsText(), headers.entries().flatMap { (key, value) -> listOf(key) + value })
+        throw Exception("da")
+      //  throw RestException(status.value, error, bodyAsText(), headers.entries().flatMap { (key, value) -> listOf(key) + value })
     }
     return this
 }

--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/admin/AdminApi.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/admin/AdminApi.kt
@@ -2,7 +2,6 @@ package io.github.jan.supabase.gotrue.admin
 
 import io.github.jan.supabase.gotrue.GoTrue
 import io.github.jan.supabase.gotrue.GoTrueImpl
-import io.github.jan.supabase.gotrue.checkErrors
 import io.github.jan.supabase.gotrue.user.UserInfo
 import io.github.jan.supabase.putJsonObject
 import io.github.jan.supabase.supabaseJson
@@ -72,24 +71,24 @@ internal class AdminApiImpl(val gotrue: GoTrue) : AdminApi {
 
     override suspend fun createUserWithEmail(builder: UserBuilder.Email.() -> Unit): UserInfo {
         val userBuilder = UserBuilder.Email().apply(builder) as UserBuilder
-        return api.postJson("admin/users", userBuilder).checkErrors().body()
+        return api.postJson("admin/users", userBuilder).body()
     }
 
     override suspend fun createUserWithPhone(builder: UserBuilder.Phone.() -> Unit): UserInfo {
         val userBuilder = UserBuilder.Phone().apply(builder) as UserBuilder
-        return api.postJson("admin/users", userBuilder).checkErrors().body()
+        return api.postJson("admin/users", userBuilder).body()
     }
 
     override suspend fun retrieveUsers(): List<UserInfo> {
-        return api.get("admin/users").checkErrors().body<JsonObject>().let { supabaseJson.decodeFromJsonElement(it["users"] ?: throw IllegalStateException("Didn't get users json field on method retrieveUsers. Full body: $it")) }
+        return api.get("admin/users").body<JsonObject>().let { supabaseJson.decodeFromJsonElement(it["users"] ?: throw IllegalStateException("Didn't get users json field on method retrieveUsers. Full body: $it")) }
     }
 
     override suspend fun retrieveUserById(uid: String): UserInfo {
-        return api.get("admin/users/$uid").checkErrors().body()
+        return api.get("admin/users/$uid").body()
     }
 
     override suspend fun deleteUser(uid: String) {
-        api.delete("admin/users/$uid").checkErrors()
+        api.delete("admin/users/$uid")
     }
 
     override suspend fun inviteUserByEmail(email: String, redirectTo: String?, data: JsonObject?) {
@@ -97,12 +96,12 @@ internal class AdminApiImpl(val gotrue: GoTrue) : AdminApi {
             put("email", email)
             data?.let { put("data", it) }
         }
-        api.postJson("invite", body) { redirectTo?.let { url.parameters.append("redirect_to", it) }}.checkErrors()
+        api.postJson("invite", body) { redirectTo?.let { url.parameters.append("redirect_to", it) }}
     }
 
     override suspend fun updateUserById(uid: String, builder: UserUpdateBuilder.() -> Unit): UserInfo {
         val updateBuilder = UserUpdateBuilder().apply(builder)
-        return api.putJson("admin/users/$uid", updateBuilder).checkErrors().body()
+        return api.putJson("admin/users/$uid", updateBuilder).body()
     }
 
     private fun tokenException(): Nothing = throw IllegalStateException("You need the service role access token to use admin methods. Use GoTrue#importAuthToken to import it. Never share it publicly")
@@ -133,6 +132,6 @@ suspend inline fun <reified C : LinkType.Config> AdminApi.generateLinkFor(
         put("type", linkType.type)
         putJsonObject(Json.encodeToJsonElement(generatedConfig).jsonObject)
     }
-    val user = api.postJson("admin/generate_link", body) { redirectTo?.let { url.parameters.append("redirect_to", it) }}.checkErrors().body<UserInfo>()
+    val user = api.postJson("admin/generate_link", body) { redirectTo?.let { url.parameters.append("redirect_to", it) }}.body<UserInfo>()
     return user.actionLink!! to user
 }

--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/providers/builtin/DefaultAuthProvider.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/providers/builtin/DefaultAuthProvider.kt
@@ -1,18 +1,15 @@
 package io.github.jan.supabase.gotrue.providers.builtin
 
 import io.github.jan.supabase.SupabaseClient
-import io.github.jan.supabase.gotrue.gotrue
-import io.github.jan.supabase.gotrue.checkErrors
 import io.github.jan.supabase.gotrue.generateRedirectUrl
+import io.github.jan.supabase.gotrue.gotrue
 import io.github.jan.supabase.gotrue.providers.AuthProvider
 import io.github.jan.supabase.gotrue.user.UserSession
 import io.ktor.client.call.body
-import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.builtins.serializer
-import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.descriptors.buildClassSerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
@@ -73,7 +70,6 @@ sealed interface DefaultAuthProvider<C, R> : AuthProvider<C, R> {
         val response = supabaseClient.httpClient.post(supabaseClient.gotrue.resolveUrl("token?grant_type=password")) {
             setBody(encodedCredentials)
         }
-        response.checkErrors()
         response.body<UserSession>().also {
             onSuccess(it)
         }
@@ -94,7 +90,6 @@ sealed interface DefaultAuthProvider<C, R> : AuthProvider<C, R> {
         val response = supabaseClient.httpClient.post(supabaseClient.gotrue.resolveUrl("signup$redirect")) {
             setBody(body)
         }
-        response.checkErrors()
         val json = response.body<JsonObject>()
         return decodeResult(json)
     }

--- a/GoTrue/src/commonTest/kotlin/GoTrueTest.kt
+++ b/GoTrue/src/commonTest/kotlin/GoTrueTest.kt
@@ -3,6 +3,8 @@
 import com.russhwolf.settings.MapSettings
 import io.github.jan.supabase.SupabaseClient
 import io.github.jan.supabase.createSupabaseClient
+import io.github.jan.supabase.exceptions.BadRequestRestException
+import io.github.jan.supabase.exceptions.UnauthorizedRestException
 import io.github.jan.supabase.gotrue.GoTrue
 import io.github.jan.supabase.gotrue.SettingsSessionManager
 import io.github.jan.supabase.gotrue.VerifyType
@@ -32,7 +34,7 @@ class GoTrueTest {
     fun test_login_with_email_with_wrong_credentials() {
         val client = createSupabaseClient()
         runTest(dispatcher) {
-            assertFailsWith<RestException>("Login with email and wrong password should fail") {
+            assertFailsWith<BadRequestRestException>("Login with email and wrong password should fail") {
                 client.gotrue.loginWith(Email, "https://website.com") {
                     email = "email@example.com"
                     password = "wrong_password"
@@ -138,7 +140,7 @@ class GoTrueTest {
     fun test_requesting_user_with_invalid_token() {
         val client = createSupabaseClient()
         runTest(dispatcher) {
-            assertFailsWith<UnauthorizedException>("Requesting user with invalid token should fail") {
+            assertFailsWith<UnauthorizedRestException>("Requesting user with invalid token should fail") {
                 client.gotrue.getUser("invalid_token")
             }
             client.close()
@@ -161,7 +163,7 @@ class GoTrueTest {
     fun test_verifying_with_wrong_token() {
         val client = createSupabaseClient()
         runTest(dispatcher) {
-            assertFailsWith<RestException>("verifying with a wrong token should fail") {
+            assertFailsWith<BadRequestRestException>("verifying with a wrong token should fail") {
                 client.gotrue.verify(VerifyType.INVITE, "wrong_token")
             }
             client.close()

--- a/GoTrue/src/commonTest/kotlin/GoTrueTest.kt
+++ b/GoTrue/src/commonTest/kotlin/GoTrueTest.kt
@@ -3,8 +3,6 @@
 import com.russhwolf.settings.MapSettings
 import io.github.jan.supabase.SupabaseClient
 import io.github.jan.supabase.createSupabaseClient
-import io.github.jan.supabase.exceptions.RestException
-import io.github.jan.supabase.exceptions.UnauthorizedException
 import io.github.jan.supabase.gotrue.GoTrue
 import io.github.jan.supabase.gotrue.SettingsSessionManager
 import io.github.jan.supabase.gotrue.VerifyType

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/PostgrestErrorResponse.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/PostgrestErrorResponse.kt
@@ -1,0 +1,11 @@
+package io.github.jan.supabase.postgrest
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+internal data class PostgrestErrorResponse(
+    val message: String,
+    val hint: String? = null,
+    val details: String? = null,
+    val code: String? = null,
+)

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/PostgrestBuilder.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/PostgrestBuilder.kt
@@ -1,5 +1,6 @@
 package io.github.jan.supabase.postgrest.query
 
+import io.github.jan.supabase.exceptions.RestException
 import io.github.jan.supabase.postgrest.Postgrest
 import io.github.jan.supabase.postgrest.request.PostgrestRequest
 import io.github.jan.supabase.supabaseJson
@@ -20,6 +21,7 @@ class PostgrestBuilder(val postgrest: Postgrest, val table: String) {
      * @param count Count algorithm to use to count rows in a table.
      * @param filter Additional filtering to apply to the query
      * @return PostgrestResult which is either an error, an empty JsonArray or the data you requested as an JsonArray
+     * @throws RestException or one of its subclasses if the request failed
      */
     @OptIn(ExperimentalTypeInference::class)
     suspend inline fun select(
@@ -36,6 +38,7 @@ class PostgrestBuilder(val postgrest: Postgrest, val table: String) {
      * @param upsert Performs an upsert if true.
      * @param onConflict When specifying onConflict, you can make upsert work on a columns that has a unique constraint.
      * @param returning By default, the new record is returned. You can set this to 'minimal' if you don't need this value
+     * @throws RestException or one of its subclasses if the request failed
      */
     suspend inline fun <reified T : Any> insert(
         values: List<T>,
@@ -56,6 +59,7 @@ class PostgrestBuilder(val postgrest: Postgrest, val table: String) {
      * @param upsert Performs an upsert if true.
      * @param onConflict When specifying onConflict, you can make upsert work on a columns that has a unique constraint.
      * @param returning By default, the new record is returned. You can set this to 'minimal' if you don't need this value
+     * @throws RestException or one of its subclasses if the request failed
      */
     suspend inline fun <reified T : Any> insert(
         value: T,
@@ -71,6 +75,7 @@ class PostgrestBuilder(val postgrest: Postgrest, val table: String) {
      *
      * @param update Specifies the fields to update via a DSL
      * @param returning By default, the new record is returned. You can set this to 'minimal' if you don't need this value
+     * @throws RestException or one of its subclasses if the request failed
      */
     @OptIn(ExperimentalTypeInference::class)
     suspend inline fun update(
@@ -84,6 +89,7 @@ class PostgrestBuilder(val postgrest: Postgrest, val table: String) {
      * Executes a delete operation on the [table].
      *
      * @param returning If set to true, you get the deleted rows as the response
+     * @throws RestException or one of its subclasses if the request failed
      */
     @OptIn(ExperimentalTypeInference::class)
     suspend inline fun delete(

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/request/PostgrestRequest.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/request/PostgrestRequest.kt
@@ -1,6 +1,5 @@
 package io.github.jan.supabase.postgrest.request
 
-import io.github.jan.supabase.exceptions.RestException
 import io.github.jan.supabase.gotrue.GoTrue
 import io.github.jan.supabase.postgrest.Postgrest
 import io.github.jan.supabase.postgrest.PostgrestImpl

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/request/PostgrestRequest.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/request/PostgrestRequest.kt
@@ -37,16 +37,10 @@ sealed interface PostgrestRequest {
             headers[PostgrestBuilder.HEADER_PREFER] = prefer.joinToString(",")
             setBody(this@PostgrestRequest.body)
             url.parameters.appendAll(parametersOf(filter.mapValues { (_, value) -> listOf(value) }))
-        }.checkForErrorCodes()
+        }.asPostgrestResult()
     }
 
-    private suspend fun HttpResponse.checkForErrorCodes(): PostgrestResult {
-        if(status.value !in 200..299) {
-            val error = body<JsonElement>()
-            throw RestException(status.value, "Unknown error", error.toString(), headers = headers.entries().flatMap { (key, value) -> listOf(key) + value })
-        }
-        return PostgrestResult(body())
-    }
+    private suspend fun HttpResponse.asPostgrestResult(): PostgrestResult = PostgrestResult(body())
 
     data class RPC(
         private val head: Boolean = false,

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/Realtime.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/Realtime.kt
@@ -4,6 +4,7 @@ import io.github.aakira.napier.Napier
 import io.github.jan.supabase.SupabaseClient
 import io.github.jan.supabase.SupabaseClientBuilder
 import io.github.jan.supabase.annotiations.SupabaseInternal
+import io.github.jan.supabase.exceptions.RestException
 import io.github.jan.supabase.gotrue.GoTrue
 import io.github.jan.supabase.gotrue.SessionStatus
 import io.github.jan.supabase.plugins.MainConfig
@@ -13,6 +14,7 @@ import io.github.jan.supabase.supabaseJson
 import io.ktor.client.plugins.websocket.DefaultClientWebSocketSession
 import io.ktor.client.plugins.websocket.WebSockets
 import io.ktor.client.plugins.websocket.sendSerialized
+import io.ktor.client.statement.HttpResponse
 import io.ktor.serialization.kotlinx.KotlinxWebsocketSerializationConverter
 import io.ktor.websocket.Frame
 import io.ktor.websocket.readText
@@ -267,6 +269,10 @@ internal class RealtimeImpl(override val supabaseClient: SupabaseClient, overrid
 
     override suspend fun block() {
         ws?.coroutineContext?.job?.join() ?: throw IllegalStateException("No connection available")
+    }
+
+    override suspend fun parseErrorResponse(response: HttpResponse): RestException {
+        throw UnsupportedOperationException("Realtime does not support REST requests")
     }
 
 }

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/Realtime.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/Realtime.kt
@@ -5,6 +5,7 @@ import io.github.jan.supabase.SupabaseClient
 import io.github.jan.supabase.SupabaseClientBuilder
 import io.github.jan.supabase.annotiations.SupabaseInternal
 import io.github.jan.supabase.exceptions.RestException
+import io.github.jan.supabase.exceptions.UnknownRestException
 import io.github.jan.supabase.gotrue.GoTrue
 import io.github.jan.supabase.gotrue.SessionStatus
 import io.github.jan.supabase.plugins.MainConfig
@@ -272,7 +273,7 @@ internal class RealtimeImpl(override val supabaseClient: SupabaseClient, overrid
     }
 
     override suspend fun parseErrorResponse(response: HttpResponse): RestException {
-        throw UnsupportedOperationException("Realtime does not support REST requests")
+        return UnknownRestException("Unknown error in realtime plugin", response)
     }
 
 }

--- a/Storage/build.gradle.kts
+++ b/Storage/build.gradle.kts
@@ -50,9 +50,6 @@ kotlin {
             }
         }
         val jvmMain by getting {
-            dependencies {
-                implementation("io.ktor:ktor-client-cio:2.0.3")
-            }
         }
         val androidMain by getting {
         }

--- a/Storage/build.gradle.kts
+++ b/Storage/build.gradle.kts
@@ -50,6 +50,9 @@ kotlin {
             }
         }
         val jvmMain by getting {
+            dependencies {
+                implementation("io.ktor:ktor-client-cio:2.0.3")
+            }
         }
         val androidMain by getting {
         }

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/BucketApi.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/BucketApi.kt
@@ -1,6 +1,7 @@
 package io.github.jan.supabase.storage
 
 import io.github.jan.supabase.SupabaseClient
+import io.github.jan.supabase.exceptions.RestException
 import io.github.jan.supabase.gotrue.GoTrue
 import io.github.jan.supabase.putJsonObject
 import io.ktor.client.call.body
@@ -23,32 +24,38 @@ sealed interface BucketApi {
      * Uploads a file in [bucketId] under [path]
      * @param path The path to upload the file to
      * @return the key to the uploaded file
+     * @throws RestException or one of its subclasses if the request failed
      */
     suspend fun upload(path: String, data: ByteArray): String
 
     /**
      * Updates a file in [bucketId] under [path]
      * @return the key to the updated file
+     * @throws RestException or one of its subclasses if the request failed
      */
     suspend fun update(path: String, data: ByteArray): String
 
     /**
      * Deletes all files in [bucketId] with in [paths]
+     * @throws RestException or one of its subclasses if the request failed
      */
     suspend fun delete(paths: Collection<String>)
 
     /**
      * Deletes all files in [bucketId] with in [paths]
+     * @throws RestException or one of its subclasses if the request failed
      */
     suspend fun delete(vararg paths: String) = delete(paths.toList())
 
     /**
      * Moves a file under [from] to [to]
+     * @throws RestException or one of its subclasses if the request failed
      */
     suspend fun move(from: String, to: String)
 
     /**
      * Copies a file under [from] to [to]
+     * @throws RestException or one of its subclasses if the request failed
      */
     suspend fun copy(from: String, to: String)
 
@@ -57,6 +64,7 @@ sealed interface BucketApi {
      * @param path The path to create an url for
      * @param expiresIn The duration the url is valid
      * @return The url to download the file
+     * @throws RestException or one of its subclasses if the request failed
      */
     suspend fun createSignedUrl(path: String, expiresIn: Duration): String
 
@@ -65,6 +73,7 @@ sealed interface BucketApi {
      * @param expiresIn The duration the urls are valid
      * @param paths The paths to create urls for
      * @return A list of [SignedUrl]s
+     * @throws RestException or one of its subclasses if the request failed
      */
     suspend fun createSignedUrls(expiresIn: Duration, paths: Collection<String>): List<SignedUrl>
 
@@ -73,6 +82,7 @@ sealed interface BucketApi {
      * @param expiresIn The duration the urls are valid
      * @param paths The paths to create urls for
      * @return A list of [SignedUrl]s
+     * @throws RestException or one of its subclasses if the request failed
      */
     suspend fun createSignedUrls(expiresIn: Duration, vararg paths: String) = createSignedUrls(expiresIn, paths.toList())
 
@@ -80,6 +90,7 @@ sealed interface BucketApi {
      * Downloads a file from [bucketId] under [path]
      * @param path The path to download
      * @return The file as a byte array
+     * @throws RestException or one of its subclasses if the request failed
      */
     suspend fun downloadAuthenticated(path: String): ByteArray
 
@@ -87,27 +98,32 @@ sealed interface BucketApi {
      * Downloads a file from [bucketId] under [path] using the public url
      * @param path The path to download
      * @return The file as a byte array
+     * @throws RestException or one of its subclasses if the request failed
      */
     suspend fun downloadPublic(path: String): ByteArray
 
     /**
      * Searches for buckets with the given [prefix] and [filter]
      * @return The filtered buckets
+     * @throws RestException or one of its subclasses if the request failed
      */
     suspend fun list(prefix: String, filter: BucketListFilter.() -> Unit = {}): List<BucketItem>
 
     /**
      * Changes the bucket's public status to [public]
+     * @throws RestException or one of its subclasses if the request failed
      */
     suspend fun changePublicStatusTo(public: Boolean)
 
     /**
      * Returns the public url of [path]
+     * @throws RestException or one of its subclasses if the request failed
      */
     fun publicUrl(path: String): String
 
     /**
      * Returns the authenticated url of [path]. Requires bearer token authentication using the user's access token
+     * @throws RestException or one of its subclasses if the request failed
      */
     fun authenticatedUrl(path: String): String
     

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/Storage.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/Storage.kt
@@ -1,10 +1,10 @@
 package io.github.jan.supabase.storage
 
 import io.github.jan.supabase.SupabaseClient
-import io.github.jan.supabase.exceptions.BadRequestException
-import io.github.jan.supabase.exceptions.NotFoundException
+import io.github.jan.supabase.exceptions.BadRequestRestException
+import io.github.jan.supabase.exceptions.NotFoundRestException
 import io.github.jan.supabase.exceptions.RestException
-import io.github.jan.supabase.exceptions.UnauthorizedException
+import io.github.jan.supabase.exceptions.UnauthorizedRestException
 import io.github.jan.supabase.exceptions.UnknownRestException
 import io.github.jan.supabase.gotrue.GoTrue
 import io.github.jan.supabase.gotrue.authenticatedSupabaseApi
@@ -119,9 +119,9 @@ internal class StorageImpl(override val supabaseClient: SupabaseClient, override
         val error = response.body<StorageErrorResponse>()
         if(statusCode != 400) return UnknownRestException("Unknown error response", response)
         when(error.statusCode) {
-            401 -> throw UnauthorizedException(error.error, response, error.message)
-            400 -> throw BadRequestException(error.error, response, error.message)
-            404 -> throw NotFoundException(error.error, response, error.message)
+            401 -> throw UnauthorizedRestException(error.error, response, error.message)
+            400 -> throw BadRequestRestException(error.error, response, error.message)
+            404 -> throw NotFoundRestException(error.error, response, error.message)
             else -> throw UnknownRestException("Unknown error response", response)
         }
     }

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/Storage.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/Storage.kt
@@ -6,12 +6,12 @@ import io.github.jan.supabase.exceptions.NotFoundRestException
 import io.github.jan.supabase.exceptions.RestException
 import io.github.jan.supabase.exceptions.UnauthorizedRestException
 import io.github.jan.supabase.exceptions.UnknownRestException
-import io.github.jan.supabase.gotrue.GoTrue
 import io.github.jan.supabase.gotrue.authenticatedSupabaseApi
 import io.github.jan.supabase.plugins.MainConfig
 import io.github.jan.supabase.plugins.MainPlugin
 import io.github.jan.supabase.plugins.SupabasePluginProvider
 import io.ktor.client.call.body
+import io.ktor.client.statement.HttpResponse
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/StorageErrorResponse.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/StorageErrorResponse.kt
@@ -1,0 +1,10 @@
+package io.github.jan.supabase.storage
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+internal data class StorageErrorResponse(
+    val statusCode: Int,
+    val error: String,
+    val message: String
+)

--- a/src/commonMain/kotlin/io/github/jan/supabase/SupabaseClient.kt
+++ b/src/commonMain/kotlin/io/github/jan/supabase/SupabaseClient.kt
@@ -53,6 +53,7 @@ internal class SupabaseClientImpl(
     httpConfigOverrides: MutableList<HttpClientConfig<*>.() -> Unit>,
     useHTTPS: Boolean,
     logNetworkTraffic: Boolean,
+    requestTimeout: Long,
     httpEngine: HttpClientEngine?,
 ) : SupabaseClient {
 
@@ -74,7 +75,7 @@ internal class SupabaseClientImpl(
         key to value(this)
     })
 
-    override val httpClient = KtorSupabaseHttpClient(supabaseKey, httpConfigOverrides, logNetworkTraffic, httpEngine)
+    override val httpClient = KtorSupabaseHttpClient(supabaseKey, httpConfigOverrides, logNetworkTraffic, requestTimeout, httpEngine)
 
     override suspend fun close() {
         httpClient.close()

--- a/src/commonMain/kotlin/io/github/jan/supabase/SupabaseClientBuilder.kt
+++ b/src/commonMain/kotlin/io/github/jan/supabase/SupabaseClientBuilder.kt
@@ -6,6 +6,7 @@ import io.github.jan.supabase.plugins.SupabasePlugin
 import io.github.jan.supabase.plugins.SupabasePluginProvider
 import io.ktor.client.HttpClientConfig
 import io.ktor.client.engine.HttpClientEngine
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * Creates a new [SupabaseClient] with the given options.
@@ -18,6 +19,7 @@ class SupabaseClientBuilder @PublishedApi internal constructor(private val supab
     var httpEngine: HttpClientEngine? = null
     var ignoreModulesInUrl = false
     var logNetworkTraffic = false
+    var requestTimeout = 10.seconds
     private val httpConfigOverrides = mutableListOf<HttpClientConfig<*>.() -> Unit>()
     private val plugins = mutableMapOf<String, ((SupabaseClient) -> SupabasePlugin)>()
 
@@ -36,7 +38,7 @@ class SupabaseClientBuilder @PublishedApi internal constructor(private val supab
 
     @PublishedApi
     internal fun build(): SupabaseClient {
-        return SupabaseClientImpl(supabaseUrl.split("//").last(), supabaseKey, plugins, httpConfigOverrides, useHTTPS, logNetworkTraffic, httpEngine)
+        return SupabaseClientImpl(supabaseUrl.split("//").last(), supabaseKey, plugins, httpConfigOverrides, useHTTPS, logNetworkTraffic, requestTimeout.inWholeMilliseconds, httpEngine)
     }
 
     /**

--- a/src/commonMain/kotlin/io/github/jan/supabase/Utils.kt
+++ b/src/commonMain/kotlin/io/github/jan/supabase/Utils.kt
@@ -1,5 +1,7 @@
 package io.github.jan.supabase
 
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsText
 import io.ktor.http.URLBuilder
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
@@ -31,5 +33,14 @@ inline fun <reified T> JsonObject.decodeIfNotEmptyOrDefault(default: T): T {
         default
     } else {
         supabaseJson.decodeFromJsonElement<T>(this)
+    }
+}
+
+suspend inline fun <reified T> HttpResponse.bodyOrNull(): T? {
+    val text = bodyAsText()
+    return try {
+        Json.decodeFromString<T>(text)
+    } catch(e: Exception) {
+        null
     }
 }

--- a/src/commonMain/kotlin/io/github/jan/supabase/Utils.kt
+++ b/src/commonMain/kotlin/io/github/jan/supabase/Utils.kt
@@ -37,8 +37,8 @@ inline fun <reified T> JsonObject.decodeIfNotEmptyOrDefault(default: T): T {
 }
 
 suspend inline fun <reified T> HttpResponse.bodyOrNull(): T? {
-    val text = bodyAsText()
     return try {
+        val text = bodyAsText()
         Json.decodeFromString<T>(text)
     } catch(e: Exception) {
         null

--- a/src/commonMain/kotlin/io/github/jan/supabase/exceptions/HttpRequestException.kt
+++ b/src/commonMain/kotlin/io/github/jan/supabase/exceptions/HttpRequestException.kt
@@ -1,0 +1,8 @@
+package io.github.jan.supabase.exceptions
+
+import io.ktor.client.request.HttpRequestBuilder
+
+/**
+ * An exception that is thrown when a request fails due to network issues
+ */
+class HttpRequestException(message: String, request: HttpRequestBuilder): Exception("HTTP request to ${request.url.buildString()} (${request.method.value}) failed with message: $message")

--- a/src/commonMain/kotlin/io/github/jan/supabase/exceptions/RestException.kt
+++ b/src/commonMain/kotlin/io/github/jan/supabase/exceptions/RestException.kt
@@ -6,7 +6,7 @@ import io.ktor.client.statement.request
 sealed class RestException(message: String): Exception(message) {
 
     constructor(error: String, response: HttpResponse, message: String? = null): this("""
-        $error: ${message?.let { "($it)" }}
+        $error ${message?.let { ":($it)" } ?: ""}
         URL: ${response.request.url}
         Headers: ${response.request.headers.entries()}
         Http Method: ${response.request.method.value}

--- a/src/commonMain/kotlin/io/github/jan/supabase/exceptions/RestException.kt
+++ b/src/commonMain/kotlin/io/github/jan/supabase/exceptions/RestException.kt
@@ -1,3 +1,23 @@
 package io.github.jan.supabase.exceptions
 
-class RestException(val status: Int, val error: String, description: String, headers: List<String> = emptyList()) : Exception("$error: $description (HTTP status $status) \nHeaders: $headers")
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.request
+
+sealed class RestException(message: String): Exception(message) {
+
+    constructor(error: String, response: HttpResponse, message: String? = null): this("""
+        $error: ${message?.let { "($it)" }}
+        URL: ${response.request.url}
+        Headers: ${response.request.headers.entries()}
+        Http Method: ${response.request.method.value}
+    """.trimIndent())
+
+}
+
+class UnauthorizedException(error: String, response: HttpResponse, message: String? = null): RestException(error, response, message)
+
+class BadRequestException(error: String, response: HttpResponse, message: String? = null): RestException(error, response, message)
+
+class UnknownRestException(error: String, response: HttpResponse, message: String? = null): RestException(error, response, message)
+
+class NotFoundException(error: String, response: HttpResponse, message: String? = null): RestException(error, response, message)

--- a/src/commonMain/kotlin/io/github/jan/supabase/exceptions/RestException.kt
+++ b/src/commonMain/kotlin/io/github/jan/supabase/exceptions/RestException.kt
@@ -14,10 +14,10 @@ sealed class RestException(message: String): Exception(message) {
 
 }
 
-class UnauthorizedException(error: String, response: HttpResponse, message: String? = null): RestException(error, response, message)
+class UnauthorizedRestException(error: String, response: HttpResponse, message: String? = null): RestException(error, response, message)
 
-class BadRequestException(error: String, response: HttpResponse, message: String? = null): RestException(error, response, message)
+class BadRequestRestException(error: String, response: HttpResponse, message: String? = null): RestException(error, response, message)
 
 class UnknownRestException(error: String, response: HttpResponse, message: String? = null): RestException(error, response, message)
 
-class NotFoundException(error: String, response: HttpResponse, message: String? = null): RestException(error, response, message)
+class NotFoundRestException(error: String, response: HttpResponse, message: String? = null): RestException(error, response, message)

--- a/src/commonMain/kotlin/io/github/jan/supabase/exceptions/RestException.kt
+++ b/src/commonMain/kotlin/io/github/jan/supabase/exceptions/RestException.kt
@@ -3,6 +3,9 @@ package io.github.jan.supabase.exceptions
 import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.request
 
+/**
+ * Base class for all response-related exceptions
+ */
 sealed class RestException(message: String): Exception(message) {
 
     constructor(error: String, response: HttpResponse, message: String? = null): this("""
@@ -14,10 +17,22 @@ sealed class RestException(message: String): Exception(message) {
 
 }
 
+/**
+ * Thrown when supabase-kt receives a response indicating an authentication error
+ */
 class UnauthorizedRestException(error: String, response: HttpResponse, message: String? = null): RestException(error, response, message)
 
+/**
+ * Thrown when supabase-kt receives a response indicating that the request was invalid due to missing or wrong fields
+ */
 class BadRequestRestException(error: String, response: HttpResponse, message: String? = null): RestException(error, response, message)
 
-class UnknownRestException(error: String, response: HttpResponse, message: String? = null): RestException(error, response, message)
-
+/**
+ * Thrown when supabase-kt receives a response indicating that the wanted resource was not found
+ */
 class NotFoundRestException(error: String, response: HttpResponse, message: String? = null): RestException(error, response, message)
+
+/**
+ * Thrown for all other response codes
+ */
+class UnknownRestException(error: String, response: HttpResponse, message: String? = null): RestException(error, response, message)

--- a/src/commonMain/kotlin/io/github/jan/supabase/exceptions/UnauthorizedException.kt
+++ b/src/commonMain/kotlin/io/github/jan/supabase/exceptions/UnauthorizedException.kt
@@ -1,3 +1,0 @@
-package io.github.jan.supabase.exceptions
-
-class UnauthorizedException(message: String): Exception(message)

--- a/src/commonMain/kotlin/io/github/jan/supabase/network/KtorSupabaseHttpClient.kt
+++ b/src/commonMain/kotlin/io/github/jan/supabase/network/KtorSupabaseHttpClient.kt
@@ -1,6 +1,7 @@
 package io.github.jan.supabase.network
 
 import io.github.aakira.napier.Napier
+import io.github.jan.supabase.exceptions.HttpRequestException
 import io.github.jan.supabase.supabaseJson
 import io.ktor.client.HttpClient
 import io.ktor.client.HttpClientConfig
@@ -13,6 +14,7 @@ import io.ktor.client.plugins.websocket.webSocketSession
 import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.client.request.headers
 import io.ktor.client.request.request
+import io.ktor.client.request.url
 import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.request
 import io.ktor.http.content.TextContent
@@ -34,32 +36,46 @@ class KtorSupabaseHttpClient(
         else HttpClient { applyDefaultConfiguration(modifiers) }
 
     override suspend fun request(url: String, builder: HttpRequestBuilder.() -> Unit): HttpResponse {
+        val request = HttpRequestBuilder().apply {
+            url(url)
+            builder()
+        }
+
         val response = try {
-            httpClient.request(url, builder)
+            httpClient.request(builder)
         } catch(e: HttpRequestTimeoutException) {
             Napier.d { "Request timed out after $requestTimeout ms" }
             throw e
+        } catch(e: Exception) {
+            Napier.d { "Request failed with ${e.message}" }
+            throw HttpRequestException(e.message ?: "", request)
         }
+
         if(logNetworkTraffic) {
-            Napier.d {
-                """
-                        
-                        --------------------
-                        Making a request to $url with method ${response.request.method.value}
-                        Request headers: ${response.request.headers}
-                        Request body: ${(response.request.content as? TextContent)?.text}
-                        Response status: ${response.status}
-                        Response headers: ${response.headers}
-                        --------------------
-                    """.trimIndent()
-            }
+            response.logResponse(url)
         }
+
         return response
     }
 
     suspend fun webSocketSession(url: String, block: HttpRequestBuilder.() -> Unit = {}) = httpClient.webSocketSession(url, block)
 
     fun close() = httpClient.close()
+
+    private fun HttpResponse.logResponse(url: String) {
+        Napier.d {
+            """
+                        
+                        --------------------
+                        Making a request to $url with method ${request.method.value}
+                        Request headers: ${request.headers}
+                        Request body: ${(request.content as? TextContent)?.text}
+                        Response status: $status
+                        Response headers: $headers
+                        --------------------
+                    """.trimIndent()
+        }
+    }
 
     private fun HttpClientConfig<*>.applyDefaultConfiguration(modifiers: List<HttpClientConfig<*>.() -> Unit>) {
         install(DefaultRequest) {

--- a/src/commonMain/kotlin/io/github/jan/supabase/network/SupabaseApi.kt
+++ b/src/commonMain/kotlin/io/github/jan/supabase/network/SupabaseApi.kt
@@ -1,17 +1,21 @@
 package io.github.jan.supabase.network
 
 import io.github.jan.supabase.SupabaseClient
+import io.github.jan.supabase.exceptions.RestException
 import io.github.jan.supabase.plugins.MainPlugin
 import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.client.statement.HttpResponse
 
 open class SupabaseApi(
     private val resolveUrl: (path: String) -> String,
+    private val parseErrorResponse: (suspend (response: HttpResponse) -> RestException)? = null,
     val supabaseClient: SupabaseClient
 ) : SupabaseHttpClient() {
 
     override suspend fun request(url: String, builder: HttpRequestBuilder.() -> Unit): HttpResponse {
-        return supabaseClient.httpClient.request(resolveUrl(url), builder)
+        return supabaseClient.httpClient.request(resolveUrl(url), builder).also {
+            if(it.status.value in 400..499 && parseErrorResponse != null) throw parseErrorResponse.invoke(it)
+        }
     }
 
 }
@@ -20,16 +24,16 @@ open class SupabaseApi(
  * Creates a [SupabaseApi] with the given [baseUrl]
  * All requests will be resolved relative to this url
  */
-fun SupabaseClient.supabaseApi(baseUrl: String) = supabaseApi { baseUrl + it }
+fun SupabaseClient.supabaseApi(baseUrl: String, parseErrorResponse: (suspend (response: HttpResponse) -> RestException)? = null) = supabaseApi({ baseUrl + it }, parseErrorResponse)
 
 /**
  * Creates a [SupabaseApi] for the given [plugin]
  * All requests will be resolved using the [MainPlugin.resolveUrl] function
  */
-fun SupabaseClient.supabaseApi(plugin: MainPlugin<*>) = supabaseApi(plugin::resolveUrl)
+fun SupabaseClient.supabaseApi(plugin: MainPlugin<*>) = supabaseApi(plugin::resolveUrl, plugin::parseErrorResponse)
 
 /**
  * Creates a [SupabaseApi] with the given [resolveUrl] function
  * All requests will be resolved using this function
  */
-fun SupabaseClient.supabaseApi(resolveUrl: (path: String) -> String) = SupabaseApi(resolveUrl, this)
+fun SupabaseClient.supabaseApi(resolveUrl: (path: String) -> String, parseErrorResponse: (suspend (response: HttpResponse) -> RestException)? = null) = SupabaseApi(resolveUrl, parseErrorResponse, this)

--- a/src/commonMain/kotlin/io/github/jan/supabase/plugins/MainPlugin.kt
+++ b/src/commonMain/kotlin/io/github/jan/supabase/plugins/MainPlugin.kt
@@ -3,7 +3,8 @@ package io.github.jan.supabase.plugins
 import io.github.jan.supabase.SupabaseClient
 import io.github.jan.supabase.buildUrl
 import io.github.jan.supabase.createSupabaseClient
-import io.ktor.client.request.HttpRequestBuilder
+import io.github.jan.supabase.exceptions.RestException
+import io.ktor.client.statement.HttpResponse
 import io.ktor.http.appendEncodedPathSegments
 
 /**
@@ -60,6 +61,11 @@ interface MainPlugin <Config : MainConfig> : SupabasePlugin {
             appendEncodedPathSegments(path)
         }
     }
+
+    /**
+     * Parses the response from the server and builds a [RestException]
+     */
+    suspend fun parseErrorResponse(response: HttpResponse): RestException
 
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

All apis throw a RestException (mostly) including the response payload

## What is the new behavior?

All main plugins have to implement a new method: **parseErrorResponse** which is called when the library receives a response with the status code **400..499**.
This method returns a **RestException** which is now a sealed class, which currently can be of type:
- UnauthorizedException (for auth-related issues)
- BadRequestException (for things like missing or wrong fields etc.)
- NotFoundException (should be self-explanatory)
- UnknownRestException (for the rest)

The plugins parse the corresponding response payload and status code and return a matching exception which is thrown by the core library

On top of that supabase-kt throws two exceptions when having network problems:
- HttpRequestTimeoutException from Ktor (can be configured in the supabase client builder)
- HttpRequestException for all other network related problems
