### PR TITLE
Add support for Image Transformations

### DIFF
--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/BucketApi.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/BucketApi.kt
@@ -274,12 +274,12 @@ internal class BucketApiImpl(override val bucketId: String, val storage: Storage
 
     override fun authenticatedRenderUrl(path: String, transform: ImageTransformation.() -> Unit): String {
         val transformation = ImageTransformation().apply(transform).queryString()
-        return storage.resolveUrl("render/image/authenticated/$bucketId/$path$transformation")
+        return storage.resolveUrl("render/image/authenticated/$bucketId/$path${if(transformation.isNotBlank()) "?$transformation" else ""}")
     }
 
     override fun publicRenderUrl(path: String, transform: ImageTransformation.() -> Unit): String {
         val transformation = ImageTransformation().apply(transform).queryString()
-        return storage.resolveUrl("render/image/public/$bucketId/$path$transformation")
+        return storage.resolveUrl("render/image/public/$bucketId/$path${if(transformation.isNotBlank()) "?$transformation" else ""}")
     }
 
 }

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/BucketApi.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/BucketApi.kt
@@ -109,22 +109,24 @@ sealed interface BucketApi {
     /**
      * Downloads a file from [bucketId] under [path]
      * @param path The path to download
+     * @param transform The transformation to apply to the image
      * @return The file as a byte array
      * @throws RestException or one of its subclasses if receiving an error response
      * @throws HttpRequestTimeoutException if the request timed out
      * @throws HttpRequestException on network related issues
      */
-    suspend fun downloadAuthenticated(path: String): ByteArray
+    suspend fun downloadAuthenticated(path: String, transform: ImageTransformation.() -> Unit = {}): ByteArray
 
     /**
      * Downloads a file from [bucketId] under [path] using the public url
      * @param path The path to download
+     * @param transform The transformation to apply to the image
      * @return The file as a byte array
      * @throws RestException or one of its subclasses if receiving an error response
      * @throws HttpRequestTimeoutException if the request timed out
      * @throws HttpRequestException on network related issues
      */
-    suspend fun downloadPublic(path: String): ByteArray
+    suspend fun downloadPublic(path: String, transform: ImageTransformation.() -> Unit = {}): ByteArray
 
     /**
      * Searches for buckets with the given [prefix] and [filter]
@@ -158,6 +160,22 @@ sealed interface BucketApi {
      * @throws HttpRequestException on network related issues
      */
     fun authenticatedUrl(path: String): String
+
+    /**
+     * Returns the authenticated render url of [path] with the given [transform]
+     * @throws RestException or one of its subclasses if receiving an error response
+     * @throws HttpRequestTimeoutException if the request timed out
+     * @throws HttpRequestException on network related issues
+     */
+    fun authenticatedRenderUrl(path: String, transform: ImageTransformation.() -> Unit = {}): String
+
+    /**
+     * Returns the public render url of [path] with the given [transform]
+     * @throws RestException or one of its subclasses if receiving an error response
+     * @throws HttpRequestTimeoutException if the request timed out
+     * @throws HttpRequestException on network related issues
+     */
+    fun publicRenderUrl(path: String, transform: ImageTransformation.() -> Unit = {}): String
     
 }
 
@@ -213,12 +231,16 @@ internal class BucketApiImpl(override val bucketId: String, val storage: Storage
         return body
     }
 
-    override suspend fun downloadAuthenticated(path: String): ByteArray {
-        return storage.api.get("object/authenticated/$bucketId/$path").body()
+    override suspend fun downloadAuthenticated(path: String, transform: ImageTransformation.() -> Unit): ByteArray {
+        val transformation = ImageTransformation().apply(transform).queryString()
+        val url = if(transformation.isBlank()) authenticatedUrl(path) else authenticatedRenderUrl(path, transform)
+        return storage.api.get(url).body()
     }
 
-    override suspend fun downloadPublic(path: String): ByteArray {
-        return storage.api.get(publicUrl(path)).body()
+    override suspend fun downloadPublic(path: String, transform: ImageTransformation.() -> Unit): ByteArray {
+        val transformation = ImageTransformation().apply(transform).queryString()
+        val url = if(transformation.isBlank()) publicUrl(path) else publicRenderUrl(path, transform)
+        return storage.api.get(url).body()
     }
 
     override suspend fun list(prefix: String, filter: BucketListFilter.() -> Unit): List<BucketItem> {
@@ -237,9 +259,19 @@ internal class BucketApiImpl(override val bucketId: String, val storage: Storage
 
     override suspend fun changePublicStatusTo(public: Boolean) = storage.changePublicStatus(bucketId, public)
 
-    override fun authenticatedUrl(path: String) = storage.resolveUrl("object/authenticated/$bucketId/$path")
+    override fun authenticatedUrl(path: String): String = storage.resolveUrl("object/authenticated/$bucketId/$path")
 
-    override fun publicUrl(path: String) = storage.resolveUrl("object/public/$bucketId/$path")
+    override fun publicUrl(path: String): String = storage.resolveUrl("object/public/$bucketId/$path")
+
+    override fun authenticatedRenderUrl(path: String, transform: ImageTransformation.() -> Unit): String {
+        val transformation = ImageTransformation().apply(transform).queryString()
+        return storage.resolveUrl("render/image/authenticated/$bucketId/$path$transformation")
+    }
+
+    override fun publicRenderUrl(path: String, transform: ImageTransformation.() -> Unit): String {
+        val transformation = ImageTransformation().apply(transform).queryString()
+        return storage.resolveUrl("render/image/public/$bucketId/$path$transformation")
+    }
 
 }
 

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/ImageTransformation.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/ImageTransformation.kt
@@ -1,0 +1,35 @@
+package io.github.jan.supabase.storage
+
+import io.github.jan.supabase.storage.ImageTransformation.Resize
+
+/**
+ * Represents a transformation for an image. Used for [Storage] objects-
+ * @property width The width of the image
+ * @property height The height of the image
+ * @property resize The resize mode
+ * @see Resize
+ */
+data class ImageTransformation(
+    var width: Int? = null,
+    var height: Int? = null,
+    var resize: Resize? = null,
+) {
+
+    enum class Resize {
+        /**
+         * Resizes the image while keeping the aspect ratio to fill a given size and crops projecting parts
+         */
+        COVER,
+
+        /**
+         * Resizes the image while keeping the aspect ratio to fit a given size.
+         */
+        CONTAIN,
+
+        /**
+         * Resizes the image without keeping the aspect ratio.
+         */
+        FILL
+    }
+
+}

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/ImageTransformation.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/ImageTransformation.kt
@@ -21,7 +21,7 @@ data class ImageTransformation(
         val builder = ParametersBuilder()
         width?.let { builder.append("width", it.toString()) }
         height?.let { builder.append("height", it.toString()) }
-        resize?.let { builder.append("resize", it.name) }
+        resize?.let { builder.append("resize", it.name.lowercase()) }
         return builder.build().formUrlEncode()
     }
 

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/ImageTransformation.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/ImageTransformation.kt
@@ -1,6 +1,8 @@
 package io.github.jan.supabase.storage
 
 import io.github.jan.supabase.storage.ImageTransformation.Resize
+import io.ktor.http.ParametersBuilder
+import io.ktor.http.formUrlEncode
 
 /**
  * Represents a transformation for an image. Used for [Storage] objects-
@@ -14,6 +16,14 @@ data class ImageTransformation(
     var height: Int? = null,
     var resize: Resize? = null,
 ) {
+
+    fun queryString(): String {
+        val builder = ParametersBuilder()
+        width?.let { builder.append("width", it.toString()) }
+        height?.let { builder.append("height", it.toString()) }
+        resize?.let { builder.append("resize", it.name) }
+        return builder.build().formUrlEncode()
+    }
 
     enum class Resize {
         /**


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## Context

Supabase announced a new feature for the storage api: Image Transformations, which adds the ability to transform images dynamically with url parameters when downloading an image 
See [blog post](https://supabase.com/blog/storage-image-resizing-smart-cdn) for more information

*Note:* Only available for pro-tier and above

## What is the new behavior?

To proposed syntax for supabase-kt looks like this:

```kotlin
val bytes = client.storage["avatars"].downloadAuthenticated("user.png") {
     width = 500
     height = 500
     resize = ImageTransformation.Resize.FILL
}
//or generate an url
val url = client.storage["avatars"].publicRenderUrl("user.png") {
     width = 500
     height = 500
     resize = ImageTransformation.Resize.FILL
}
```
