### PR TITLE
Add missing SQL modifiers

### DIFF
--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/Order.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/Order.kt
@@ -1,0 +1,5 @@
+package io.github.jan.supabase.postgrest.query
+
+enum class Order(val value: String) {
+    ASCENDING("asc"), DESCENDING("desc");
+}

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/PostgrestBuilder.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/PostgrestBuilder.kt
@@ -20,6 +20,7 @@ class PostgrestBuilder(val postgrest: Postgrest, val table: String) {
      * @param columns The columns to retrieve, separated by commas.
      * @param head If true, select will delete the selected data.
      * @param count Count algorithm to use to count rows in a table.
+     * @param single If true, select will return a single row. Throws an error if the query returns more than one row.
      * @param filter Additional filtering to apply to the query
      * @return PostgrestResult which is either an error, an empty JsonArray or the data you requested as an JsonArray
      * @throws RestException or one of its subclasses if receiving an error response
@@ -30,8 +31,9 @@ class PostgrestBuilder(val postgrest: Postgrest, val table: String) {
         columns: String = "*",
         head: Boolean = false,
         count: Count? = null,
+        single: Boolean = false,
         filter: PostgrestFilterBuilder.() -> Unit = {}
-    ): PostgrestResult = PostgrestRequest.Select(head, count, buildPostgrestFilter { filter(); _params["select"] = columns }).execute(table, postgrest)
+    ): PostgrestResult = PostgrestRequest.Select(head, count, single, buildPostgrestFilter { filter(); _params["select"] = columns }).execute(table, postgrest)
 
     /**
      * Executes an insert operation on the [table]

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/PostgrestFilterBuilder.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/PostgrestFilterBuilder.kt
@@ -1,7 +1,6 @@
 package io.github.jan.supabase.postgrest.query
 
 import io.github.jan.supabase.postgrest.getColumnName
-import io.ktor.http.HeadersBuilder
 import kotlin.reflect.KProperty1
 
 /**
@@ -11,8 +10,6 @@ class PostgrestFilterBuilder {
 
     @PublishedApi
     internal val _params = mutableMapOf<String, String>()
-    @PublishedApi
-    internal val _headers = HeadersBuilder()
     val params: Map<String, String>
         get() = _params.toMap()
 
@@ -84,10 +81,6 @@ class PostgrestFilterBuilder {
 
         _params[keyOffset] = from.toString()
         _params[keyLimit] = (to - from + 1).toString()
-    }
-
-    fun single() {
-        _headers["Accept"] = "application/vnd.pgrst.object+json"
     }
 
     fun range(range: LongRange, foreignTable: String? = null) = range(range.first, range.last, foreignTable)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature (closes #35)

## Context

This PR adds four new SQL modifiers: **limit**, **order**, **range**, **single**

Syntax:

```kotlin
client.postgrest["test"].select(single = true) {
    order("id", Order.ASCENDING)
    limit(1)
    range(1L..5L)
}
```

