### PR TITLE
Properly support OTPs

### DIFF
--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/GoTrue.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/GoTrue.kt
@@ -155,7 +155,7 @@ sealed interface GoTrue : MainPlugin<GoTrue.Config> {
      * @throws HttpRequestTimeoutException if the request timed out
      * @throws HttpRequestException on network related issues
      */
-    suspend fun verifyEmailOtp(type: VerifyType.Email, email: String, token: String, captchaToken: String? = null)
+    suspend fun verifyEmailOtp(type: OtpType.Email, email: String, token: String, captchaToken: String? = null)
 
     /**
      * Verifies a phone/sms otp
@@ -166,7 +166,7 @@ sealed interface GoTrue : MainPlugin<GoTrue.Config> {
      * @throws HttpRequestTimeoutException if the request timed out
      * @throws HttpRequestException on network related issues
      */
-    suspend fun verifyPhoneOtp(type: VerifyType.Phone, phoneNumber: String, token: String, captchaToken: String? = null)
+    suspend fun verifyPhoneOtp(type: OtpType.Phone, phoneNumber: String, token: String, captchaToken: String? = null)
 
     /**
      * Retrieves the current user with the session

--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/GoTrue.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/GoTrue.kt
@@ -155,7 +155,7 @@ sealed interface GoTrue : MainPlugin<GoTrue.Config> {
      * @throws HttpRequestTimeoutException if the request timed out
      * @throws HttpRequestException on network related issues
      */
-    suspend fun verifyEmail(type: VerifyType.Email, email: String, token: String, captchaToken: String? = null)
+    suspend fun verifyEmailOtp(type: VerifyType.Email, email: String, token: String, captchaToken: String? = null)
 
     /**
      * Verifies a phone/sms otp
@@ -166,7 +166,7 @@ sealed interface GoTrue : MainPlugin<GoTrue.Config> {
      * @throws HttpRequestTimeoutException if the request timed out
      * @throws HttpRequestException on network related issues
      */
-    suspend fun verifyPhone(type: VerifyType.Phone, phoneNumber: String, token: String, captchaToken: String? = null)
+    suspend fun verifyPhoneOtp(type: VerifyType.Phone, phoneNumber: String, token: String, captchaToken: String? = null)
 
     /**
      * Retrieves the current user with the session

--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/GoTrue.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/GoTrue.kt
@@ -147,24 +147,26 @@ sealed interface GoTrue : MainPlugin<GoTrue.Config> {
     suspend fun invalidateAllRefreshTokens()
 
     /**
-     * Verifies a registration, invite or password recovery
+     * Verifies a email otp
      * @param type The type of the verification
+     * @param email The email to verify
      * @param token The token used to verify
      * @throws RestException or one of its subclasses if receiving an error response
      * @throws HttpRequestTimeoutException if the request timed out
      * @throws HttpRequestException on network related issues
      */
-    suspend fun verify(type: VerifyType, token: String, captchaToken: String? = null)
+    suspend fun verifyEmail(type: VerifyType.Email, email: String, token: String, captchaToken: String? = null)
 
     /**
      * Verifies a phone/sms otp
+     * @param type The type of the verification
      * @param token The otp to verify
      * @param phoneNumber The phone number the token was sent to
      * @throws RestException or one of its subclasses if receiving an error response
      * @throws HttpRequestTimeoutException if the request timed out
      * @throws HttpRequestException on network related issues
      */
-    suspend fun verifyPhone(token: String, phoneNumber: String, captchaToken: String? = null)
+    suspend fun verifyPhone(type: VerifyType.Phone, phoneNumber: String, token: String, captchaToken: String? = null)
 
     /**
      * Retrieves the current user with the session
@@ -286,12 +288,6 @@ suspend inline fun <C, R, reified D, Provider : DefaultAuthProvider<C, R>> GoTru
     extraData: D? = null,
     noinline config: C.() -> Unit = { }
 ): UserInfo = modifyUser(provider, extraData?.let { Json.encodeToJsonElement(extraData) }?.jsonObject, config)
-
-enum class VerifyType {
-    SIGNUP,
-    RECOVERY,
-    INVITE
-}
 
 /**
  * The Auth plugin handles everything related to supabase's authentication system

--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/GoTrueImpl.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/GoTrueImpl.kt
@@ -171,7 +171,7 @@ internal class GoTrueImpl(override val supabaseClient: SupabaseClient, override 
     }
 
     override suspend fun verifyEmail(
-        type: VerifyType.Email,
+        type: OtpType.Email,
         email: String,
         token: String,
         captchaToken: String?
@@ -180,7 +180,7 @@ internal class GoTrueImpl(override val supabaseClient: SupabaseClient, override 
     }
 
     override suspend fun verifyPhone(
-        type: VerifyType.Phone,
+        type: OtpType.Phone,
         phoneNumber: String,
         token: String,
         captchaToken: String?

--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/GoTrueImpl.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/GoTrueImpl.kt
@@ -170,21 +170,21 @@ internal class GoTrueImpl(override val supabaseClient: SupabaseClient, override 
         startAutoRefresh(session)
     }
 
-    override suspend fun verifyEmail(
+    override suspend fun verifyEmailOtp(
         type: OtpType.Email,
         email: String,
         token: String,
         captchaToken: String?
-    ) = verify(type.value, token, captchaToken) {
+    ) = verify(type.type, token, captchaToken) {
         put("email", email)
     }
 
-    override suspend fun verifyPhone(
+    override suspend fun verifyPhoneOtp(
         type: OtpType.Phone,
         phoneNumber: String,
         token: String,
         captchaToken: String?
-    ) = verify(type.value, token, captchaToken) {
+    ) = verify(type.type, token, captchaToken) {
         put("phone", phoneNumber)
     }
 

--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/OtpType.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/OtpType.kt
@@ -1,6 +1,6 @@
 package io.github.jan.supabase.gotrue
 
-object VerifyType {
+object OtpType {
 
     enum class Email(val value: String) {
         MAGIC_LINK("magiclink"),
@@ -14,6 +14,5 @@ object VerifyType {
         SMS("sms"),
         PHONE_CHANGE("phone_change")
     }
-
 
 }

--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/OtpType.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/OtpType.kt
@@ -1,8 +1,10 @@
 package io.github.jan.supabase.gotrue
 
-object OtpType {
+sealed interface OtpType {
 
-    enum class Email(val value: String) {
+    val type: String
+
+    enum class Email(override val type: String): OtpType {
         MAGIC_LINK("magiclink"),
         SIGNUP("signup"),
         INVITE("invite"),
@@ -10,7 +12,7 @@ object OtpType {
         EMAIL_CHANGE("email_change")
     }
 
-    enum class Phone(val value: String) {
+    enum class Phone(override val type: String): OtpType {
         SMS("sms"),
         PHONE_CHANGE("phone_change")
     }

--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/VerifyType.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/VerifyType.kt
@@ -1,0 +1,19 @@
+package io.github.jan.supabase.gotrue
+
+object VerifyType {
+
+    enum class Email(val value: String) {
+        MAGIC_LINK("magiclink"),
+        SIGNUP("signup"),
+        INVITE("invite"),
+        RECOVERY("recovery"),
+        EMAIL_CHANGE("email_change")
+    }
+
+    enum class Phone(val value: String) {
+        SMS("sms"),
+        PHONE_CHANGE("phone_change")
+    }
+
+
+}

--- a/GoTrue/src/commonTest/kotlin/GoTrueTest.kt
+++ b/GoTrue/src/commonTest/kotlin/GoTrueTest.kt
@@ -164,7 +164,7 @@ class GoTrueTest {
         val client = createSupabaseClient()
         runTest(dispatcher) {
             assertFailsWith<BadRequestRestException>("verifying with a wrong token should fail") {
-                client.gotrue.verify(OtpType.INVITE, "wrong_token")
+                client.gotrue.verifyEmailOtp(OtpType.Email.INVITE, "example@email.com", "wrong_token")
             }
             client.close()
         }
@@ -175,7 +175,7 @@ class GoTrueTest {
     fun test_verifying_with_valid_token() {
         val client = createSupabaseClient()
         runTest(dispatcher) {
-            client.gotrue.verify(OtpType.INVITE, GoTrueMock.VALID_VERIFY_TOKEN)
+            client.gotrue.verifyEmailOtp(OtpType.Email.INVITE, "example@gmail.com", GoTrueMock.VALID_VERIFY_TOKEN)
             assertEquals(GoTrueMock.NEW_ACCESS_TOKEN, client.gotrue.currentAccessTokenOrNull(), "verify with valid token should update the user session")
         }
     }

--- a/GoTrue/src/commonTest/kotlin/GoTrueTest.kt
+++ b/GoTrue/src/commonTest/kotlin/GoTrueTest.kt
@@ -6,8 +6,8 @@ import io.github.jan.supabase.createSupabaseClient
 import io.github.jan.supabase.exceptions.BadRequestRestException
 import io.github.jan.supabase.exceptions.UnauthorizedRestException
 import io.github.jan.supabase.gotrue.GoTrue
+import io.github.jan.supabase.gotrue.OtpType
 import io.github.jan.supabase.gotrue.SettingsSessionManager
-import io.github.jan.supabase.gotrue.VerifyType
 import io.github.jan.supabase.gotrue.gotrue
 import io.github.jan.supabase.gotrue.providers.builtin.Email
 import io.github.jan.supabase.gotrue.providers.builtin.Phone
@@ -164,7 +164,7 @@ class GoTrueTest {
         val client = createSupabaseClient()
         runTest(dispatcher) {
             assertFailsWith<BadRequestRestException>("verifying with a wrong token should fail") {
-                client.gotrue.verify(VerifyType.INVITE, "wrong_token")
+                client.gotrue.verify(OtpType.INVITE, "wrong_token")
             }
             client.close()
         }
@@ -175,7 +175,7 @@ class GoTrueTest {
     fun test_verifying_with_valid_token() {
         val client = createSupabaseClient()
         runTest(dispatcher) {
-            client.gotrue.verify(VerifyType.INVITE, GoTrueMock.VALID_VERIFY_TOKEN)
+            client.gotrue.verify(OtpType.INVITE, GoTrueMock.VALID_VERIFY_TOKEN)
             assertEquals(GoTrueMock.NEW_ACCESS_TOKEN, client.gotrue.currentAccessTokenOrNull(), "verify with valid token should update the user session")
         }
     }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature (closes #38)

## What is the current behavior?

supabase-kt only supports a few OTP verifying methods

## What is the new behavior?

Full support for verifying OTPs
Syntax:
```kotlin
gotrue.verifyEmailOtp(OtpType.Email.INVITE, email = "example@email.com", token = "1234")
gotrue.verifyPhoneOtp(OtpType.Phone.SMS, phoneNumber = "123456789", token = "1234")
```

GoTrue#verify is getting removed as it's not working anyway.
and GoTrue#verifyPhone is renamed to verifyPhoneOtp
