### PR TITLE
Add support for changing database schemas in the Postgrest plugin

### DIFF
--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/Postgrest.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/Postgrest.kt
@@ -28,9 +28,17 @@ sealed interface Postgrest : MainPlugin<Postgrest.Config> {
 
     fun from(table: String): PostgrestBuilder
 
+    fun from(schema: String, table: String): PostgrestBuilder
+
+    operator fun get(schema: String, table: String): PostgrestBuilder = from(schema, table)
+
     operator fun get(table: String): PostgrestBuilder = from(table)
 
-    data class Config(override var customUrl: String? = null, override var jwtToken: String? = null): MainConfig
+    /**
+     * Config for the Postgrest plugin
+     * @param defaultSchema The default schema to use for the requests. Defaults to "public"
+     */
+    data class Config(override var customUrl: String? = null, override var jwtToken: String? = null, var defaultSchema: String = "public"): MainConfig
 
     companion object : SupabasePluginProvider<Config, Postgrest> {
 
@@ -58,6 +66,10 @@ internal class PostgrestImpl(override val supabaseClient: SupabaseClient, overri
 
     override fun from(table: String): PostgrestBuilder {
         return PostgrestBuilder(this, table)
+    }
+
+    override fun from(schema: String, table: String): PostgrestBuilder {
+        return PostgrestBuilder(this, table, schema)
     }
 
     override suspend fun parseErrorResponse(response: HttpResponse): RestException {

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/PostgrestBuilder.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/PostgrestBuilder.kt
@@ -12,7 +12,7 @@ import kotlinx.serialization.json.jsonArray
 /**
  * The main class to build a postgrest request
  */
-class PostgrestBuilder(val postgrest: Postgrest, val table: String) {
+class PostgrestBuilder(val postgrest: Postgrest, val table: String, val schema: String = postgrest.config.defaultSchema) {
 
     /**
      * Executes vertical filtering with select on [table]
@@ -33,7 +33,7 @@ class PostgrestBuilder(val postgrest: Postgrest, val table: String) {
         count: Count? = null,
         single: Boolean = false,
         filter: PostgrestFilterBuilder.() -> Unit = {}
-    ): PostgrestResult = PostgrestRequest.Select(head, count, single, buildPostgrestFilter { filter(); _params["select"] = columns }).execute(table, postgrest)
+    ): PostgrestResult = PostgrestRequest.Select(head, count, single, buildPostgrestFilter { filter(); _params["select"] = columns }, schema).execute(table, postgrest)
 
     /**
      * Executes an insert operation on the [table]
@@ -56,7 +56,7 @@ class PostgrestBuilder(val postgrest: Postgrest, val table: String) {
     ): PostgrestResult = PostgrestRequest.Insert(supabaseJson.encodeToJsonElement(values).jsonArray, upsert, onConflict, returning, count, buildPostgrestFilter {
         filter()
         if (upsert && onConflict != null) _params["on_conflict"] = onConflict
-    }).execute(table, postgrest)
+    }, schema).execute(table, postgrest)
 
     /**
      * Executes an insert operation on the [table]
@@ -92,7 +92,7 @@ class PostgrestBuilder(val postgrest: Postgrest, val table: String) {
         returning: Returning = Returning.REPRESENTATION,
         count: Count? = null,
         filter: PostgrestFilterBuilder.() -> Unit = {}
-    ): PostgrestResult = PostgrestRequest.Update(returning, count, buildPostgrestFilter(filter), buildPostgrestUpdate(update)).execute(table, postgrest)
+    ): PostgrestResult = PostgrestRequest.Update(returning, count, buildPostgrestFilter(filter), buildPostgrestUpdate(update), schema).execute(table, postgrest)
 
     /**
      * Executes a delete operation on the [table].
@@ -106,7 +106,7 @@ class PostgrestBuilder(val postgrest: Postgrest, val table: String) {
         returning: Returning = Returning.REPRESENTATION,
         count: Count? = null,
         filter: PostgrestFilterBuilder.() -> Unit = {}
-    ): PostgrestResult = PostgrestRequest.Delete(returning, count, buildPostgrestFilter(filter)).execute(table, postgrest)
+    ): PostgrestResult = PostgrestRequest.Delete(returning, count, buildPostgrestFilter(filter), schema).execute(table, postgrest)
 
     companion object {
         const val HEADER_PREFER = "Prefer"

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/request/PostgrestRequest.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/request/PostgrestRequest.kt
@@ -8,6 +8,7 @@ import io.github.jan.supabase.postgrest.query.PostgrestBuilder
 import io.github.jan.supabase.postgrest.query.PostgrestResult
 import io.github.jan.supabase.postgrest.query.Returning
 import io.ktor.client.call.body
+import io.ktor.client.request.header
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.HttpResponse
 import io.ktor.http.ContentType
@@ -26,6 +27,7 @@ sealed interface PostgrestRequest {
     val prefer: List<String>
     val single: Boolean get() = false
     val urlParams: Map<String, String> get() = mapOf()
+    val schema: String
 
     suspend fun execute(path: String, postgrest: Postgrest): PostgrestResult {
         postgrest as PostgrestImpl
@@ -43,6 +45,14 @@ sealed interface PostgrestRequest {
             this@PostgrestRequest.body?.let { setBody(it) }
             url.parameters.appendAll(parametersOf(urlParams.mapValues { (_, value) -> listOf(value) }))
             url.parameters.appendAll(parametersOf(filter.mapValues { (_, value) -> listOf(value) }))
+
+            if(schema.isNotBlank()) {
+                if(method in listOf(HttpMethod.Get, HttpMethod.Head)) {
+                    header("Accept-Profile", schema)
+                } else {
+                    header("Content-Profile", schema)
+                }
+            }
         }.asPostgrestResult()
     }
 
@@ -55,6 +65,8 @@ sealed interface PostgrestRequest {
         override val body: JsonElement? = null,
         ): PostgrestRequest {
 
+        override val schema: String = ""
+
         override val method = if(head) HttpMethod.Head else HttpMethod.Post
         override val prefer = if (count != null) listOf("count=${count.identifier}") else listOf()
 
@@ -64,7 +76,8 @@ sealed interface PostgrestRequest {
         head: Boolean = false,
         count: Count? = null,
         override val single: Boolean = false,
-        override val filter: Map<String, String>
+        override val filter: Map<String, String>,
+        override val schema: String
     ): PostgrestRequest {
 
         override val method = if(head) HttpMethod.Head else HttpMethod.Get
@@ -79,6 +92,7 @@ sealed interface PostgrestRequest {
         private val returning: Returning = Returning.REPRESENTATION,
         private val count: Count? = null,
         override val filter: Map<String, String>,
+        override val schema: String
     ): PostgrestRequest {
 
         override val method = HttpMethod.Post
@@ -95,7 +109,8 @@ sealed interface PostgrestRequest {
         private val returning: Returning = Returning.REPRESENTATION,
         private val count: Count? = null,
         override val filter: Map<String, String>,
-        override val body: JsonElement
+        override val body: JsonElement,
+        override val schema: String
     ) : PostgrestRequest {
 
         override val method = HttpMethod.Patch
@@ -109,7 +124,8 @@ sealed interface PostgrestRequest {
     class Delete(
         private val returning: Returning = Returning.REPRESENTATION,
         private val count: Count? = null,
-        override val filter: Map<String, String>
+        override val filter: Map<String, String>,
+        override val schema: String
     ): PostgrestRequest {
 
         override val method = HttpMethod.Delete


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature (closes #50)

## What is the current behavior?

There is no way to change the schema for postgrest table requests. It always defaults to `public`

## What is the new behavior?

You can now change the default request schema and override it per request:
```kotlin
install(Postgrest) {
    defaultSchema = "storage"
}
```

```kotlin
client.postgrest["public", "users"]
    .select()
```
