### PR TITLE
Fix unused GraphQL config init block

### DIFF
--- a/plugins/ApolloGraphQL/src/commonMain/kotlin/io/github/jan/supabase/graphql/GraphQL.kt
+++ b/plugins/ApolloGraphQL/src/commonMain/kotlin/io/github/jan/supabase/graphql/GraphQL.kt
@@ -50,7 +50,7 @@ sealed interface GraphQL: MainPlugin<GraphQL.Config> {
         }
 
         override fun createConfig(init: Config.() -> Unit): Config {
-            return Config()
+            return Config().apply(init)
         }
 
     }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix

## What is the current behavior?

GraphQL config builder is being ignored

## What is the new behavior?

GraphQL config builder is no longer being ignored

## Additional context

Add any other context or screenshots.
