### PR TITLE
Improve select syntax

### DIFF
--- a/Postgrest/src/androidMain/kotlin/io/github/jan/supabase/postgrest/getColumnName.kt
+++ b/Postgrest/src/androidMain/kotlin/io/github/jan/supabase/postgrest/getColumnName.kt
@@ -1,17 +1,10 @@
 package io.github.jan.supabase.postgrest
 
-import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
-import kotlinx.serialization.descriptors.elementNames
-import kotlinx.serialization.serializerOrNull
 import kotlin.reflect.KProperty1
 import kotlin.reflect.full.findAnnotation
-import kotlin.reflect.typeOf
 
 actual fun <T, V> getSerialName(property: KProperty1<T, V>): String {
     val serialName = property.findAnnotation<SerialName>()
     return serialName?.value ?: property.name
 }
-
-@OptIn(ExperimentalSerializationApi::class)
-actual inline fun <reified T> classPropertyNames(): List<String> = serializerOrNull(typeOf<T>())?.descriptor?.elementNames?.toList() ?: throw IllegalArgumentException("Could not find serializer for ${T::class.simpleName}")

--- a/Postgrest/src/androidMain/kotlin/io/github/jan/supabase/postgrest/getColumnName.kt
+++ b/Postgrest/src/androidMain/kotlin/io/github/jan/supabase/postgrest/getColumnName.kt
@@ -1,10 +1,17 @@
 package io.github.jan.supabase.postgrest
 
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
+import kotlinx.serialization.descriptors.elementNames
+import kotlinx.serialization.serializerOrNull
 import kotlin.reflect.KProperty1
 import kotlin.reflect.full.findAnnotation
+import kotlin.reflect.typeOf
 
 actual fun <T, V> getSerialName(property: KProperty1<T, V>): String {
     val serialName = property.findAnnotation<SerialName>()
     return serialName?.value ?: property.name
 }
+
+@OptIn(ExperimentalSerializationApi::class)
+actual inline fun <reified T> classPropertyNames(): List<String> = serializerOrNull(typeOf<T>())?.descriptor?.elementNames?.toList() ?: throw IllegalArgumentException("Could not find serializer for ${T::class.simpleName}")

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/Utils.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/Utils.kt
@@ -21,3 +21,5 @@ expect fun <T, V> getSerialName(property: KProperty1<T, V>): String
 internal fun String.camelToSnakeCase(): String {
     return this.replace(SNAKE_CASE_REGEX, "_$0").lowercase()
 }
+
+expect inline fun <reified T> classPropertyNames(): List<String>

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/Utils.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/Utils.kt
@@ -2,7 +2,10 @@ package io.github.jan.supabase.postgrest
 
 import io.github.jan.supabase.postgrest.query.PostgrestFilterBuilder
 import io.github.jan.supabase.postgrest.query.buildPostgrestFilter
+import kotlinx.serialization.descriptors.elementNames
+import kotlinx.serialization.serializerOrNull
 import kotlin.reflect.KProperty1
+import kotlin.reflect.typeOf
 
 private val SNAKE_CASE_REGEX = "(?<=.)[A-Z]".toRegex()
 
@@ -22,4 +25,4 @@ internal fun String.camelToSnakeCase(): String {
     return this.replace(SNAKE_CASE_REGEX, "_$0").lowercase()
 }
 
-expect inline fun <reified T> classPropertyNames(): List<String>
+inline fun <reified T> classPropertyNames(): List<String> = serializerOrNull(typeOf<T>())?.descriptor?.elementNames?.toList() ?: throw IllegalArgumentException("Could not find serializer for ${T::class.simpleName}")

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/Columns.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/Columns.kt
@@ -1,0 +1,20 @@
+package io.github.jan.supabase.postgrest.query
+
+import kotlin.jvm.JvmInline
+
+@JvmInline
+value class Columns @PublishedApi internal constructor(val value: String) {
+
+    companion object {
+
+        val ALL = Columns("*")
+
+        fun raw(value: String) = Columns(value)
+
+        fun list(vararg columns: String) = Columns(columns.joinToString(","))
+
+        inline fun <reified T> type() = Columns(T::class.simpleName!!)
+
+    }
+
+}

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/Columns.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/Columns.kt
@@ -7,12 +7,33 @@ value class Columns @PublishedApi internal constructor(val value: String) {
 
     companion object {
 
+        /**
+         * Select all columns
+         */
         val ALL = Columns("*")
 
+        /**
+         * Select all columns given in the [value] parameter
+         * @param value The columns to select, separated by a comma
+         */
         fun raw(value: String) = Columns(value)
 
+        /**
+         * Select all columns given in the [columns] parameter
+         * @param columns The columns to select
+         */
         fun list(vararg columns: String) = Columns(columns.joinToString(","))
 
+        /**
+         * Select all columns given in the [columns] parameter
+         * @param columns The columns to select
+         */
+        fun list(columns: List<String>) = Columns(columns.joinToString(","))
+
+        /**
+         * Select all columns of type [T]'s class properties. Example: If you specify a class 'User' with the fields 'id' and 'name', this will select 'id,name'
+         * @param T The type of the columns to select
+         */
         inline fun <reified T> type() = Columns(T::class.simpleName!!)
 
     }

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/PostgrestBuilder.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/PostgrestBuilder.kt
@@ -4,7 +4,7 @@ import io.github.jan.supabase.exceptions.HttpRequestException
 import io.github.jan.supabase.exceptions.RestException
 import io.github.jan.supabase.postgrest.Postgrest
 import io.github.jan.supabase.postgrest.request.PostgrestRequest
-import io.ktor.client.plugins.HttpRequestTimeoutException
+import io.ktor.client.plugins.*
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.encodeToJsonElement
 import kotlinx.serialization.json.jsonArray
@@ -17,7 +17,7 @@ class PostgrestBuilder(val postgrest: Postgrest, val table: String, val schema: 
     /**
      * Executes vertical filtering with select on [table]
      *
-     * @param columns The columns to retrieve, separated by commas.
+     * @param columns The columns to retrieve, defaults to [Columns.ALL]. You can also use [Columns.list], [Columns.type] or [Columns.raw] to specify the columns
      * @param head If true, select will delete the selected data.
      * @param count Count algorithm to use to count rows in a table.
      * @param single If true, select will return a single row. Throws an error if the query returns more than one row.

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/PostgrestBuilder.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/PostgrestBuilder.kt
@@ -28,12 +28,12 @@ class PostgrestBuilder(val postgrest: Postgrest, val table: String, val schema: 
      * @throws HttpRequestException on network related issues
      */
     suspend inline fun select(
-        columns: String = "*",
+        columns: Columns = Columns.ALL,
         head: Boolean = false,
         count: Count? = null,
         single: Boolean = false,
         filter: PostgrestFilterBuilder.() -> Unit = {}
-    ): PostgrestResult = PostgrestRequest.Select(head, count, single, buildPostgrestFilter(postgrest.config.propertyConversionMethod) { filter(); _params["select"] = listOf(columns) }, schema).execute(table, postgrest)
+    ): PostgrestResult = PostgrestRequest.Select(head, count, single, buildPostgrestFilter(postgrest.config.propertyConversionMethod) { filter(); _params["select"] = listOf(columns.value) }, schema).execute(table, postgrest)
 
     /**
      * Executes an insert operation on the [table]

--- a/Postgrest/src/jsMain/kotlin/io/github/jan/supabase/postgrest/getColumnName.kt
+++ b/Postgrest/src/jsMain/kotlin/io/github/jan/supabase/postgrest/getColumnName.kt
@@ -1,12 +1,5 @@
 package io.github.jan.supabase.postgrest
 
-import kotlinx.serialization.ExperimentalSerializationApi
-import kotlinx.serialization.descriptors.elementNames
-import kotlinx.serialization.serializerOrNull
 import kotlin.reflect.KProperty1
-import kotlin.reflect.typeOf
 
 actual fun <T, V> getSerialName(property: KProperty1<T, V>) = property.name
-@OptIn(ExperimentalSerializationApi::class)
-actual inline fun <reified T> classPropertyNames(): List<String> = serializerOrNull(typeOf<T>())?.descriptor?.elementNames?.toList() ?: throw IllegalArgumentException("Could not find serializer for ${T::class.simpleName}")
-

--- a/Postgrest/src/jsMain/kotlin/io/github/jan/supabase/postgrest/getColumnName.kt
+++ b/Postgrest/src/jsMain/kotlin/io/github/jan/supabase/postgrest/getColumnName.kt
@@ -1,5 +1,12 @@
 package io.github.jan.supabase.postgrest
 
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.descriptors.elementNames
+import kotlinx.serialization.serializerOrNull
 import kotlin.reflect.KProperty1
+import kotlin.reflect.typeOf
 
 actual fun <T, V> getSerialName(property: KProperty1<T, V>) = property.name
+@OptIn(ExperimentalSerializationApi::class)
+actual inline fun <reified T> classPropertyNames(): List<String> = serializerOrNull(typeOf<T>())?.descriptor?.elementNames?.toList() ?: throw IllegalArgumentException("Could not find serializer for ${T::class.simpleName}")
+

--- a/Postgrest/src/jvmMain/kotlin/io/github/jan/supabase/postgrest/getColumnName.kt
+++ b/Postgrest/src/jvmMain/kotlin/io/github/jan/supabase/postgrest/getColumnName.kt
@@ -8,5 +8,3 @@ actual fun <T, V> getSerialName(property: KProperty1<T, V>): String {
     val serialName = property.findAnnotation<SerialName>()
     return serialName?.value ?: property.name
 }
-
-actual inline fun <reified T> classPropertyNames(): List<String> = T::class.members.filterIsInstance<KProperty1<T, *>>().map { it.name }

--- a/Postgrest/src/jvmMain/kotlin/io/github/jan/supabase/postgrest/getColumnName.kt
+++ b/Postgrest/src/jvmMain/kotlin/io/github/jan/supabase/postgrest/getColumnName.kt
@@ -8,3 +8,5 @@ actual fun <T, V> getSerialName(property: KProperty1<T, V>): String {
     val serialName = property.findAnnotation<SerialName>()
     return serialName?.value ?: property.name
 }
+
+actual inline fun <reified T> classPropertyNames(): List<String> = T::class.members.filterIsInstance<KProperty1<T, *>>().map { it.name }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,6 +12,7 @@ include("Storage")
 include("Realtime")
 include("Functions")
 include("bom")
+include("test")
 include(":plugins:ApolloGraphQL")
 project(":GoTrue").name = "gotrue-kt"
 project(":Postgrest").name = "postgrest-kt"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature (closes #82)

## What is the current behavior?

You can restrict columns you want to receive like this:
```kotlin
//user class
@Serializable
data class User(val id: String, val name: String)

client.postgrest["table"].select("id,name").decodeSingle<User>()
```

## What is the new behavior?

You restrict the columns you want to receive like this:
```kotlin
//user class
@Serializable
data class User(val id: String, val name: String)

client.postgrest["table"].select(Columns.list(columns)).decodeSingle<User>()
//or
client.postgrest["table"].select(Columns.list("id", "name")).decodeSingle<User>()
//or
client.postgrest["table"].select(Columns.type<User>()).decodeSingle<User>() //uses the class properties serial names as column restriction
//defaults to Columns.ALL
```

## Additional context

Columns is a value class
Syntax not final, feel free to comment.