### PR TITLE
Add new storage LW7 features

### DIFF
--- a/Storage/build.gradle.kts
+++ b/Storage/build.gradle.kts
@@ -42,7 +42,9 @@ kotlin {
                 api(project(":gotrue-kt"))
             }
         }
-        val nonJsMain by creating {}
+        val nonJsMain by creating {
+            dependsOn(commonMain)
+        }
         val jvmMain by getting {
             dependsOn(nonJsMain)
         }

--- a/Storage/build.gradle.kts
+++ b/Storage/build.gradle.kts
@@ -49,6 +49,11 @@ kotlin {
         val androidMain by getting {
             dependsOn(nonJsMain)
         }
+        val commonTest by getting {
+            dependencies {
+                implementation(kotlin("test"))
+            }
+        }
         val jsMain by getting
         val iosMain by getting
         val iosSimulatorArm64Main by getting {

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/Bucket.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/Bucket.kt
@@ -5,6 +5,19 @@ import kotlinx.datetime.Instant
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
+/**
+ * Represents a storage bucket
+ * @param createdAt The creation date of the bucket
+ * @param id The id of the bucket
+ * @param name The name of the bucket
+ * @param owner The owner of the bucket
+ * @param updatedAt The last update date of the bucket
+ * @param public Whether the bucket is public
+ * @param allowedMimeTypes The allowed mime types for the bucket
+ * @param fileSizeLimit The file size limit for the bucket
+ * @see BucketBuilder
+ * @see Storage.createBucket
+ */
 @Serializable
 data class Bucket(
     @SerialName("created_at")

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/Bucket.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/Bucket.kt
@@ -16,5 +16,10 @@ data class Bucket(
     @SerialName("owner")
     val owner: String,
     @SerialName("updated_at")
-    val updatedAt: Instant
+    val updatedAt: Instant,
+    val public: Boolean,
+    @SerialName("allowed_mime_types")
+    val allowedMimeTypes: List<String>? = null,
+    @SerialName("file_size_limit")
+    val fileSizeLimit: Long? = null
 )

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/BucketApi.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/BucketApi.kt
@@ -209,7 +209,7 @@ internal class BucketApiImpl(override val bucketId: String, val storage: Storage
         val url = Url(storage.resolveUrl(urlPath))
         return UploadSignedUrl(
             url = url.toString(),
-            path = urlPath,
+            path = path,
             token = url.parameters["token"] ?: throw IllegalStateException("Expected a token in create upload signed url response")
         )
     }

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/BucketApi.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/BucketApi.kt
@@ -9,7 +9,6 @@ import io.github.jan.supabase.safeBody
 import io.ktor.client.call.*
 import io.ktor.client.plugins.*
 import io.ktor.client.request.*
-import io.ktor.client.statement.*
 import io.ktor.http.*
 import kotlinx.serialization.json.*
 import kotlin.time.Duration
@@ -206,10 +205,11 @@ internal class BucketApiImpl(override val bucketId: String, val storage: Storage
 
     override suspend fun createUploadSignedUrl(path: String): UploadSignedUrl {
         val result = storage.api.post("object/upload/sign/$bucketId/$path")
-        val url = result.request.url
+        val urlPath = result.body<JsonObject>()["url"]?.jsonPrimitive?.content ?: throw IllegalStateException("Expected a url in create upload signed url response")
+        val url = Url(storage.resolveUrl(urlPath))
         return UploadSignedUrl(
-            url = storage.resolveUrl(url.encodedPath),
-            path = url.encodedPath,
+            url = url.toString(),
+            path = urlPath,
             token = url.parameters["token"] ?: throw IllegalStateException("Expected a token in create upload signed url response")
         )
     }

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/BucketApi.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/BucketApi.kt
@@ -6,20 +6,12 @@ import io.github.jan.supabase.exceptions.RestException
 import io.github.jan.supabase.gotrue.GoTrue
 import io.github.jan.supabase.putJsonObject
 import io.github.jan.supabase.safeBody
-import io.ktor.client.call.body
-import io.ktor.client.plugins.HttpRequestTimeoutException
-import io.ktor.client.request.header
-import io.ktor.client.request.setBody
-import io.ktor.http.ContentType
-import io.ktor.http.HttpHeaders
-import io.ktor.http.HttpMethod
-import io.ktor.http.defaultForFilePath
-import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.add
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.jsonPrimitive
-import kotlinx.serialization.json.put
-import kotlinx.serialization.json.putJsonArray
+import io.ktor.client.call.*
+import io.ktor.client.plugins.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import kotlinx.serialization.json.*
 import kotlin.time.Duration
 
 sealed interface BucketApi {
@@ -36,6 +28,15 @@ sealed interface BucketApi {
      * @throws HttpRequestException on network related issues
      */
     suspend fun upload(path: String, data: ByteArray): String
+
+    /**
+     * Uploads a file in [bucketId] under [path] using a presigned url
+     * @param path The path to upload the file to
+     * @param token The presigned url token
+     * @param data The data to upload
+     * @return the key of the uploaded file
+     */
+    suspend fun uploadToSignedUrl(path: String, token: String, data: ByteArray): String
 
     /**
      * Updates a file in [bucketId] under [path]
@@ -77,6 +78,12 @@ sealed interface BucketApi {
      * @throws HttpRequestException on network related issues
      */
     suspend fun copy(from: String, to: String)
+
+    /**
+     * Creates a signed url to upload without authentication.
+     * @param path The path to create an url for
+     */
+    suspend fun createUploadSignedUrl(path: String): UploadSignedUrl
 
     /**
      * Creates a signed url to download without authentication. The url will expire after [expiresIn]
@@ -190,6 +197,22 @@ internal class BucketApiImpl(override val bucketId: String, val storage: Storage
     override val supabaseClient = storage.supabaseClient
 
     override suspend fun update(path: String, data: ByteArray): String = uploadOrUpdate(HttpMethod.Put, bucketId, path, data)
+
+    override suspend fun uploadToSignedUrl(path: String, token: String, data: ByteArray): String {
+        return storage.api.put("object/upload/sign/$bucketId/$path") {
+            parameter("token", token)
+        }.body<JsonObject>()["Key"]?.jsonPrimitive?.content ?: throw IllegalStateException("Expected a key in a upload response")
+    }
+
+    override suspend fun createUploadSignedUrl(path: String): UploadSignedUrl {
+        val result = storage.api.post("object/upload/sign/$bucketId/$path")
+        val url = result.request.url
+        return UploadSignedUrl(
+            url = storage.resolveUrl(url.encodedPath),
+            path = url.encodedPath,
+            token = url.parameters["token"] ?: throw IllegalStateException("Expected a token in create upload signed url response")
+        )
+    }
 
     override suspend fun upload(path: String, data: ByteArray): String = uploadOrUpdate(HttpMethod.Post, bucketId, path, data)
 

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/BucketBuilder.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/BucketBuilder.kt
@@ -1,15 +1,36 @@
 package io.github.jan.supabase.storage
 
+/**
+ * A builder for [Bucket]s
+ */
 class BucketBuilder {
 
+    /**
+     * Whether the bucket should be public
+     */
     var public = false
+
+    /**
+     * The file size limit for the bucket. E.g. **10.megabytes**
+     */
     var fileSizeLimit: FileSizeLimit? = null
+
+    /**
+     * The allowed mime types for the bucket
+     */
     internal var allowedMimeTypes: List<String>? = null
 
+
+    /**
+     * Sets the file size limit for the bucket
+     */
     fun allowedMimeTypes(vararg mimeTypes: String) {
         allowedMimeTypes = mimeTypes.toList()
     }
 
+    /**
+     * Sets the file size limit for the bucket
+     */
     fun allowedMimeTypes(mimeTypes: List<String>) {
         allowedMimeTypes = mimeTypes
     }

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/BucketBuilder.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/BucketBuilder.kt
@@ -1,0 +1,27 @@
+package io.github.jan.supabase.storage
+
+class BucketBuilder {
+
+    var public = false
+    var fileSizeLimit: FileSizeLimit? = null
+    internal var allowedMimeTypes: List<String>? = null
+
+    fun allowedMimeTypes(vararg mimeTypes: String) {
+        allowedMimeTypes = mimeTypes.toList()
+    }
+
+    fun allowedMimeTypes(mimeTypes: List<String>) {
+        allowedMimeTypes = mimeTypes
+    }
+
+    val Long.bytes get() = FileSizeLimit("${this}b")
+    val Long.kilobytes get() = FileSizeLimit("${this}kb")
+    val Long.megabytes get() = FileSizeLimit("${this}mb")
+    val Long.gigabytes get() = FileSizeLimit("${this}gb")
+
+    val Int.bytes get() = FileSizeLimit("${this}b")
+    val Int.kilobytes get() = FileSizeLimit("${this}kb")
+    val Int.megabytes get() = FileSizeLimit("${this}mb")
+    val Int.gigabytes get() = FileSizeLimit("${this}gb")
+
+}

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/BucketItem.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/BucketItem.kt
@@ -7,6 +7,12 @@ import kotlinx.serialization.json.JsonObject
 
 /**
  * Represents a file or a folder in a bucket. If the item is a folder, everything except [name] is null.
+ * @param name The name of the item
+ * @param id The id of the item
+ * @param updatedAt The last update date of the item
+ * @param createdAt The creation date of the item
+ * @param lastAccessedAt The last access date of the item
+ * @param metadata The metadata of the item
  */
 @Serializable
 data class BucketItem(

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/BucketListFilter.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/BucketListFilter.kt
@@ -4,10 +4,24 @@ import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonObject
 
+/**
+ * A filter builder for [BucketApi.list]
+ */
 class BucketListFilter {
 
+    /**
+     * The limit of items to return
+     */
     var limit: Int? = null
+
+    /**
+     * The starting position
+     */
     var offset: Int? = null
+
+    /**
+     * The search string to filter files by.
+     */
     var search: String? = null
     private var column: String? = null
     private var order: String? = null

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/FileSizeLimit.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/FileSizeLimit.kt
@@ -1,0 +1,6 @@
+package io.github.jan.supabase.storage
+
+import kotlin.jvm.JvmInline
+
+@JvmInline
+value class FileSizeLimit internal constructor(val value: String)

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/FileSizeLimit.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/FileSizeLimit.kt
@@ -2,5 +2,9 @@ package io.github.jan.supabase.storage
 
 import kotlin.jvm.JvmInline
 
+/**
+ * A file size limit for buckets
+ * @param value The value of the limit (e.g. 10mb)
+ */
 @JvmInline
 value class FileSizeLimit internal constructor(val value: String)

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/ImageTransformation.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/ImageTransformation.kt
@@ -26,12 +26,13 @@ class ImageTransformation {
         }
     var format: String? = null
 
-    fun queryString(): String {
+    internal fun queryString(): String {
         val builder = ParametersBuilder()
         width?.let { builder.append("width", it.toString()) }
         height?.let { builder.append("height", it.toString()) }
         resize?.let { builder.append("resize", it.name.lowercase()) }
         quality?.let { builder.append("quality", it.toString()) }
+        format?.let { builder.append("format", it) }
         return builder.build().formUrlEncode()
     }
 

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/ImageTransformation.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/ImageTransformation.kt
@@ -1,20 +1,23 @@
 package io.github.jan.supabase.storage
 
 import io.github.jan.supabase.storage.ImageTransformation.Resize
-import io.ktor.http.ParametersBuilder
-import io.ktor.http.formUrlEncode
+import io.ktor.http.*
 
 /**
  * Represents a transformation for an image. Used for [Storage] objects-
  * @property width The width of the image
  * @property height The height of the image
  * @property resize The resize mode
+ * @property quality The quality of the image. (Percentage 1-100, defaults to 80)
+ * @property format Specify in which format you want the image to receive. (Defaults to 'origin', which means the original format
  * @see Resize
  */
 data class ImageTransformation(
     var width: Int? = null,
     var height: Int? = null,
     var resize: Resize? = null,
+    var quality: Int? = null,
+    var format: String? = null
 ) {
 
     fun queryString(): String {
@@ -22,6 +25,7 @@ data class ImageTransformation(
         width?.let { builder.append("width", it.toString()) }
         height?.let { builder.append("height", it.toString()) }
         resize?.let { builder.append("resize", it.name.lowercase()) }
+        quality?.let { builder.append("quality", it.toString()) }
         return builder.build().formUrlEncode()
     }
 

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/ImageTransformation.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/ImageTransformation.kt
@@ -11,14 +11,20 @@ import io.ktor.http.*
  * @property quality The quality of the image. (Percentage 1-100, defaults to 80)
  * @property format Specify in which format you want the image to receive. (Defaults to 'origin', which means the original format
  * @see Resize
+ * @see BucketApi.downloadAuthenticated
+ * @see BucketApi.downloadPublic
  */
-data class ImageTransformation(
-    var width: Int? = null,
-    var height: Int? = null,
-    var resize: Resize? = null,
-    var quality: Int? = null,
+class ImageTransformation {
+
+    var width: Int? = null
+    var height: Int? = null
+    var resize: Resize? = null
+    var quality: Int? = null
+        set(value) {
+            if(value !in 1..100) throw IllegalArgumentException("Quality must be between 1 and 100")
+            field = value
+        }
     var format: String? = null
-) {
 
     fun queryString(): String {
         val builder = ParametersBuilder()

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/SignedUrl.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/SignedUrl.kt
@@ -2,5 +2,11 @@ package io.github.jan.supabase.storage
 
 import kotlinx.serialization.Serializable
 
+/**
+ * Represents a signed url
+ * @param error An optional error message
+ * @param signedURL The signed url
+ * @param path The path of the file
+ */
 @Serializable
 data class SignedUrl(val error: String?, val signedURL: String, val path: String)

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/UploadSignedUrl.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/UploadSignedUrl.kt
@@ -1,0 +1,7 @@
+package io.github.jan.supabase.storage
+
+data class UploadSignedUrl(
+    val url: String,
+    val path: String,
+    val token: String
+)

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/UploadSignedUrl.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/UploadSignedUrl.kt
@@ -1,5 +1,11 @@
 package io.github.jan.supabase.storage
 
+/**
+ * A signed url to upload a file
+ * @param url The signed url
+ * @param path The path of the file
+ * @param token The token to use for the upload
+ */
 data class UploadSignedUrl(
     val url: String,
     val path: String,

--- a/Storage/src/commonTest/kotlin/BucketListFilterTest.kt
+++ b/Storage/src/commonTest/kotlin/BucketListFilterTest.kt
@@ -1,0 +1,25 @@
+import io.github.jan.supabase.storage.BucketListFilter
+import kotlinx.serialization.json.jsonObject
+import kotlin.test.Test
+import kotlin.test.assertContains
+
+class BucketListFilterTest {
+
+    @Test
+    fun testBucketListFilter() {
+        val filter = BucketListFilter().apply {
+            limit = 10
+            offset = 0
+            search = "string"
+            sortBy("name", "asc")
+        }
+        val filterJson = filter.build()
+        assertContains(filterJson, "limit")
+        assertContains(filterJson, "offset")
+        assertContains(filterJson, "search")
+        assertContains(filterJson, "sortBy")
+        assertContains(filterJson["sortBy"]!!.jsonObject, "column")
+        assertContains(filterJson["sortBy"]!!.jsonObject, "order")
+    }
+
+}

--- a/Storage/src/nonJsMain/kotlin/io/github/jan/supabase/storage/JvmUtils.kt
+++ b/Storage/src/nonJsMain/kotlin/io/github/jan/supabase/storage/JvmUtils.kt
@@ -22,6 +22,22 @@ suspend fun BucketApi.upload(path: String, file: File) = upload(path, file.readB
 suspend fun BucketApi.upload(path: String, file: Path) = upload(path, file.readBytes())
 
 /**
+ * Uploads a file in [BucketApi.bucketId] under [path] using a presigned url
+ * @param path The path to upload the file to
+ * @param file The presigned url token
+ * @param file The file to upload
+ */
+suspend fun BucketApi.uploadToSignedUrl(path: String, token: String, file: File) = uploadToSignedUrl(path, token, file.readBytes())
+
+/**
+ * Uploads a file in [BucketApi.bucketId] under [path] using a presigned url
+ * @param path The path to upload the file to
+ * @param file The presigned url token
+ * @param file The file to upload
+ */
+suspend fun BucketApi.uploadToSignedUrl(path: String, token: String, file: Path) = uploadToSignedUrl(path, token, file.readBytes())
+
+/**
  * Updates a file in [BucketApi.bucketId] under [path]
  * @param path The path to be updated
  * @param file The new file


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature (closes #88)

## What is the current behavior?

Only supports features from LW6

## What is the new behavior?

Supports new storage features:

More options when creating a bucket (& move public to builder):
```kotlin
client.storage.createBucket("test", "test")  {
   public = true
   fileSizeLimit = 1000000.kilobytes
   allowedMimeTypes("image/png", "image/jpeg")
}
```

Create presigned urls for upload images:
```kotlin
val signedUrl = client.storage["test"].createUploadSignedUrl("test.txt")
println(signedUrl.url)
client.storage["test"].uploadToSignedUrl(
    path = "test.txt",
    token = signedUrl.token,
    data = File("mydata.txt").readBytes()
)
```

New image transformation options:
```kotlin
client.storage["icons"].downloadPublic("icon.png") {
    width = 100
    height = 100
    format = "origin" //image format
    resize = ImageTransformation.Resize.FILL
    quality = 40 //image quality
}
```

# Additional context

These features are untested as I my supabase instance doesn't seem to be updated yet (or I oversaw something)