### PR TITLE
Introduce flow variants for uploading and downloading files in storage

### DIFF
--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/AuthenticatedSupabaseApi.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/AuthenticatedSupabaseApi.kt
@@ -4,10 +4,8 @@ import io.github.jan.supabase.SupabaseClient
 import io.github.jan.supabase.exceptions.RestException
 import io.github.jan.supabase.network.SupabaseApi
 import io.github.jan.supabase.plugins.MainPlugin
-import io.ktor.client.request.HttpRequestBuilder
-import io.ktor.client.request.bearerAuth
-import io.ktor.client.request.headers
-import io.ktor.client.statement.HttpResponse
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
 
 class AuthenticatedSupabaseApi(
     resolveUrl: (path: String) -> String,
@@ -25,6 +23,8 @@ class AuthenticatedSupabaseApi(
         }
         builder()
     }
+
+    suspend fun rawRequest(builder: HttpRequestBuilder.() -> Unit): HttpResponse = rawRequest("", builder)
 
 }
 

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/BucketApi.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/BucketApi.kt
@@ -263,10 +263,10 @@ internal class BucketApiImpl(override val bucketId: String, val storage: Storage
     override suspend fun updateAsFlow(path: String, data: ByteArray): Flow<UploadStatus> = callbackFlow {
         val key = uploadOrUpdate(HttpMethod.Put, bucketId, path, data) {
             onUpload { bytesSentTotal, contentLength ->
-                trySend(UploadStatus.UploadProgress(bytesSentTotal, contentLength))
+                trySend(UploadStatus.Progress(bytesSentTotal, contentLength))
             }
         }
-        trySend(UploadStatus.UploadSuccess(key))
+        trySend(UploadStatus.Success(key))
         close()
     }
 
@@ -279,10 +279,10 @@ internal class BucketApiImpl(override val bucketId: String, val storage: Storage
         return callbackFlow {
             val key = uploadToSignedUrl(path, token, data) {
                 onUpload { bytesSentTotal, contentLength ->
-                    trySend(UploadStatus.UploadProgress(bytesSentTotal, contentLength))
+                    trySend(UploadStatus.Progress(bytesSentTotal, contentLength))
                 }
             }
-            trySend(UploadStatus.UploadSuccess(key))
+            trySend(UploadStatus.Success(key))
             close()
         }
     }
@@ -305,10 +305,10 @@ internal class BucketApiImpl(override val bucketId: String, val storage: Storage
         return callbackFlow {
             val key = uploadOrUpdate(HttpMethod.Post, bucketId, path, data) {
                 onUpload { bytesSentTotal, contentLength ->
-                    trySend(UploadStatus.UploadProgress(bytesSentTotal, contentLength))
+                    trySend(UploadStatus.Progress(bytesSentTotal, contentLength))
                 }
             }
-            trySend(UploadStatus.UploadSuccess(key))
+            trySend(UploadStatus.Success(key))
             close()
         }
     }
@@ -380,10 +380,10 @@ internal class BucketApiImpl(override val bucketId: String, val storage: Storage
             val data = storage.api.rawRequest {
                 prepareDownloadRequest(path, false, transform)
                 onDownload { bytesSentTotal, contentLength ->
-                    trySend(DownloadStatus.DownloadProgress(bytesSentTotal, contentLength))
+                    trySend(DownloadStatus.Progress(bytesSentTotal, contentLength))
                 }
             }.body<ByteArray>()
-            trySend(DownloadStatus.DownloadSuccess(data))
+            trySend(DownloadStatus.Success(data))
             close()
         }
     }
@@ -400,10 +400,10 @@ internal class BucketApiImpl(override val bucketId: String, val storage: Storage
             val data = storage.api.rawRequest {
                 prepareDownloadRequest(path, true, transform)
                 onDownload { bytesSentTotal, contentLength ->
-                    trySend(DownloadStatus.DownloadProgress(bytesSentTotal, contentLength))
+                    trySend(DownloadStatus.Progress(bytesSentTotal, contentLength))
                 }
             }.body<ByteArray>()
-            trySend(DownloadStatus.DownloadSuccess(data))
+            trySend(DownloadStatus.Success(data))
             close()
         }
     }

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/BucketApi.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/BucketApi.kt
@@ -1,6 +1,7 @@
 package io.github.jan.supabase.storage
 
 import io.github.jan.supabase.SupabaseClient
+import io.github.jan.supabase.annotiations.SupabaseExperimental
 import io.github.jan.supabase.exceptions.HttpRequestException
 import io.github.jan.supabase.exceptions.RestException
 import io.github.jan.supabase.gotrue.GoTrue
@@ -38,6 +39,7 @@ sealed interface BucketApi {
      * @throws HttpRequestTimeoutException if the request timed out
      * @throws HttpRequestException on network related issues
      */
+    @SupabaseExperimental
     suspend fun uploadAsFlow(path: String, data: ByteArray): Flow<UploadStatus>
 
     /**
@@ -56,6 +58,7 @@ sealed interface BucketApi {
      * @param data The data to upload
      * @return A flow that emits the upload progress and at last the key to the uploaded file
      */
+    @SupabaseExperimental
     suspend fun uploadToSignedUrlAsFlow(path: String, token: String, data: ByteArray): Flow<UploadStatus>
 
     /**
@@ -78,6 +81,7 @@ sealed interface BucketApi {
      * @throws HttpRequestTimeoutException if the request timed out
      * @throws HttpRequestException on network related issues
      */
+    @SupabaseExperimental
     suspend fun updateAsFlow(path: String, data: ByteArray): Flow<UploadStatus>
 
     /**
@@ -172,6 +176,7 @@ sealed interface BucketApi {
      * @throws HttpRequestTimeoutException if the request timed out
      * @throws HttpRequestException on network related issues
      */
+    @SupabaseExperimental
     suspend fun downloadAuthenticatedAsFlow(path: String, transform: ImageTransformation.() -> Unit = {}): Flow<DownloadStatus>
 
     /**
@@ -194,6 +199,7 @@ sealed interface BucketApi {
      * @throws HttpRequestTimeoutException if the request timed out
      * @throws HttpRequestException on network related issues
      */
+    @SupabaseExperimental
     suspend fun downloadPublicAsFlow(path: String, transform: ImageTransformation.() -> Unit = {}): Flow<DownloadStatus>
 
     /**
@@ -253,6 +259,7 @@ internal class BucketApiImpl(override val bucketId: String, val storage: Storage
 
     override suspend fun update(path: String, data: ByteArray): String = uploadOrUpdate(HttpMethod.Put, bucketId, path, data)
 
+    @SupabaseExperimental
     override suspend fun updateAsFlow(path: String, data: ByteArray): Flow<UploadStatus> = callbackFlow {
         val key = uploadOrUpdate(HttpMethod.Put, bucketId, path, data) {
             onUpload { bytesSentTotal, contentLength ->
@@ -267,6 +274,7 @@ internal class BucketApiImpl(override val bucketId: String, val storage: Storage
         return uploadToSignedUrl(path, token, data)
     }
 
+    @SupabaseExperimental
     override suspend fun uploadToSignedUrlAsFlow(path: String, token: String, data: ByteArray): Flow<UploadStatus> {
         return callbackFlow {
             val key = uploadToSignedUrl(path, token, data) {
@@ -292,6 +300,7 @@ internal class BucketApiImpl(override val bucketId: String, val storage: Storage
 
     override suspend fun upload(path: String, data: ByteArray): String = uploadOrUpdate(HttpMethod.Post, bucketId, path, data)
 
+    @SupabaseExperimental
     override suspend fun uploadAsFlow(path: String, data: ByteArray): Flow<UploadStatus> {
         return callbackFlow {
             val key = uploadOrUpdate(HttpMethod.Post, bucketId, path, data) {
@@ -362,6 +371,7 @@ internal class BucketApiImpl(override val bucketId: String, val storage: Storage
         }.body()
     }
 
+    @SupabaseExperimental
     override suspend fun downloadAuthenticatedAsFlow(
         path: String,
         transform: ImageTransformation.() -> Unit
@@ -384,6 +394,7 @@ internal class BucketApiImpl(override val bucketId: String, val storage: Storage
         }.body()
     }
 
+    @SupabaseExperimental
     override suspend fun downloadPublicAsFlow(path: String, transform: ImageTransformation.() -> Unit): Flow<DownloadStatus> {
         return callbackFlow {
             val data = storage.api.rawRequest {

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/BucketApi.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/BucketApi.kt
@@ -30,6 +30,14 @@ sealed interface BucketApi {
      */
     suspend fun upload(path: String, data: ByteArray): String
 
+    /**
+     * Uploads a file in [bucketId] under [path]
+     * @param path The path to upload the file to
+     * @return A flow that emits the upload progress and at last the key to the uploaded file
+     * @throws RestException or one of its subclasses if receiving an error response
+     * @throws HttpRequestTimeoutException if the request timed out
+     * @throws HttpRequestException on network related issues
+     */
     suspend fun uploadAsFlow(path: String, data: ByteArray): Flow<UploadStatus>
 
     /**
@@ -41,10 +49,19 @@ sealed interface BucketApi {
      */
     suspend fun uploadToSignedUrl(path: String, token: String, data: ByteArray): String
 
+    /**
+     * Uploads a file in [bucketId] under [path] using a presigned url
+     * @param path The path to upload the file to
+     * @param token The presigned url token
+     * @param data The data to upload
+     * @return A flow that emits the upload progress and at last the key to the uploaded file
+     */
     suspend fun uploadToSignedUrlAsFlow(path: String, token: String, data: ByteArray): Flow<UploadStatus>
 
     /**
      * Updates a file in [bucketId] under [path]
+     * @param path The path to update the file to
+     * @param data The new data
      * @return the key to the updated file
      * @throws RestException or one of its subclasses if receiving an error response
      * @throws HttpRequestTimeoutException if the request timed out
@@ -52,6 +69,15 @@ sealed interface BucketApi {
      */
     suspend fun update(path: String, data: ByteArray): String
 
+    /**
+     * Updates a file in [bucketId] under [path]
+     * @param path The path to update the file to
+     * @param data The new data
+     * @return A flow that emits the upload progress and at last the key to the uploaded file
+     * @throws RestException or one of its subclasses if receiving an error response
+     * @throws HttpRequestTimeoutException if the request timed out
+     * @throws HttpRequestException on network related issues
+     */
     suspend fun updateAsFlow(path: String, data: ByteArray): Flow<UploadStatus>
 
     /**
@@ -137,6 +163,15 @@ sealed interface BucketApi {
      */
     suspend fun downloadAuthenticated(path: String, transform: ImageTransformation.() -> Unit = {}): ByteArray
 
+    /**
+     * Downloads a file from [bucketId] under [path]
+     * @param path The path to download
+     * @param transform The transformation to apply to the image
+     * @return A flow that emits the download progress and at last the data as a byte array
+     * @throws RestException or one of its subclasses if receiving an error response
+     * @throws HttpRequestTimeoutException if the request timed out
+     * @throws HttpRequestException on network related issues
+     */
     suspend fun downloadAuthenticatedAsFlow(path: String, transform: ImageTransformation.() -> Unit = {}): Flow<DownloadStatus>
 
     /**
@@ -150,6 +185,15 @@ sealed interface BucketApi {
      */
     suspend fun downloadPublic(path: String, transform: ImageTransformation.() -> Unit = {}): ByteArray
 
+    /**
+     * Downloads a file from [bucketId] under [path] using the public url
+     * @param path The path to download
+     * @param transform The transformation to apply to the image
+     * @return A flow that emits the download progress and at last the data as a byte array
+     * @throws RestException or one of its subclasses if receiving an error response
+     * @throws HttpRequestTimeoutException if the request timed out
+     * @throws HttpRequestException on network related issues
+     */
     suspend fun downloadPublicAsFlow(path: String, transform: ImageTransformation.() -> Unit = {}): Flow<DownloadStatus>
 
     /**

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/BucketBuilder.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/BucketBuilder.kt
@@ -1,5 +1,7 @@
 package io.github.jan.supabase.storage
 
+import io.ktor.http.*
+
 /**
  * A builder for [Bucket]s
  */
@@ -33,6 +35,14 @@ class BucketBuilder {
      */
     fun allowedMimeTypes(mimeTypes: List<String>) {
         allowedMimeTypes = mimeTypes
+    }
+
+    fun allowedMimeTypes(mimeTypes: List<ContentType>) {
+        allowedMimeTypes = mimeTypes.map { it.toString() }
+    }
+
+    fun allowedMimeTypes(vararg mimeTypes: ContentType) {
+        allowedMimeTypes = mimeTypes.map { it.toString() }
     }
 
     val Long.bytes get() = FileSizeLimit("${this}b")

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/NetworkStatus.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/NetworkStatus.kt
@@ -12,14 +12,14 @@ sealed interface DownloadStatus {
      * @param totalBytesReceived The total bytes received
      * @param contentLength The total bytes to receive
      */
-    data class DownloadProgress(val totalBytesReceived: Long, val contentLength: Long) : DownloadStatus
+    data class Progress(val totalBytesReceived: Long, val contentLength: Long) : DownloadStatus
 
     /**
      * Represents the success of a download
      * @param data The downloaded data
      */
     @JvmInline
-    value class DownloadSuccess(val data: ByteArray) : DownloadStatus
+    value class Success(val data: ByteArray) : DownloadStatus
 
 }
 
@@ -33,13 +33,13 @@ sealed interface UploadStatus {
      * @param totalBytesSend The total bytes sent
      * @param contentLength The total bytes to send
      */
-    data class UploadProgress(val totalBytesSend: Long, val contentLength: Long) : UploadStatus
+    data class Progress(val totalBytesSend: Long, val contentLength: Long) : UploadStatus
 
     /**
      * Represents the success of an upload
      * @param key The key of the uploaded file
      */
     @JvmInline
-    value class UploadSuccess(val key: String) : UploadStatus
+    value class Success(val key: String) : UploadStatus
 
 }

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/NetworkStatus.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/NetworkStatus.kt
@@ -1,0 +1,21 @@
+package io.github.jan.supabase.storage
+
+import kotlin.jvm.JvmInline
+
+sealed interface DownloadStatus {
+
+    data class DownloadProgress(val received: Long, val total: Long) : DownloadStatus
+
+    @JvmInline
+    value class DownloadSuccess(val data: ByteArray) : DownloadStatus
+
+}
+
+sealed interface UploadStatus {
+
+    data class UploadProgress(val sent: Long, val total: Long) : UploadStatus
+
+    @JvmInline
+    value class UploadSuccess(val key: String) : UploadStatus
+
+}

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/NetworkStatus.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/NetworkStatus.kt
@@ -2,19 +2,43 @@ package io.github.jan.supabase.storage
 
 import kotlin.jvm.JvmInline
 
+/**
+ * Represents the status of a download
+ */
 sealed interface DownloadStatus {
 
-    data class DownloadProgress(val received: Long, val total: Long) : DownloadStatus
+    /**
+     * Represents the progress of a download
+     * @param totalBytesReceived The total bytes received
+     * @param contentLength The total bytes to receive
+     */
+    data class DownloadProgress(val totalBytesReceived: Long, val contentLength: Long) : DownloadStatus
 
+    /**
+     * Represents the success of a download
+     * @param data The downloaded data
+     */
     @JvmInline
     value class DownloadSuccess(val data: ByteArray) : DownloadStatus
 
 }
 
+/**
+ * Represents the status of an upload
+ */
 sealed interface UploadStatus {
 
-    data class UploadProgress(val sent: Long, val total: Long) : UploadStatus
+    /**
+     * Represents the progress of an upload
+     * @param totalBytesSend The total bytes sent
+     * @param contentLength The total bytes to send
+     */
+    data class UploadProgress(val totalBytesSend: Long, val contentLength: Long) : UploadStatus
 
+    /**
+     * Represents the success of an upload
+     * @param key The key of the uploaded file
+     */
     @JvmInline
     value class UploadSuccess(val key: String) : UploadStatus
 

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/NetworkStatus.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/NetworkStatus.kt
@@ -12,6 +12,7 @@ sealed interface DownloadStatus {
      * @param totalBytesReceived The total bytes received
      * @param contentLength The total bytes to receive
      */
+    //TODO: Replace with multi-field value class
     data class Progress(val totalBytesReceived: Long, val contentLength: Long) : DownloadStatus
 
     /**
@@ -33,6 +34,7 @@ sealed interface UploadStatus {
      * @param totalBytesSend The total bytes sent
      * @param contentLength The total bytes to send
      */
+    //TODO: Replace with multi-field value class
     data class Progress(val totalBytesSend: Long, val contentLength: Long) : UploadStatus
 
     /**

--- a/Storage/src/nonJsMain/kotlin/io/github/jan/supabase/storage/JvmUtils.kt
+++ b/Storage/src/nonJsMain/kotlin/io/github/jan/supabase/storage/JvmUtils.kt
@@ -17,17 +17,43 @@ suspend fun BucketApi.upload(path: String, file: File) = upload(path, file.readB
  * Uploads a file in [BucketApi.bucketId] under [path]
  * @param path The path to upload the file to
  * @param file The file to upload
+ * @return A flow that emits the upload progress and at last the key to the uploaded file
+ */
+suspend fun BucketApi.uploadAsFlow(path: String, file: File) = uploadAsFlow(path, file.readBytes())
+
+/**
+ * Uploads a file in [BucketApi.bucketId] under [path]
+ * @param path The path to upload the file to
+ * @param file The file to upload
  * @return the key to the uploaded file
  */
 suspend fun BucketApi.upload(path: String, file: Path) = upload(path, file.readBytes())
 
 /**
+ * Uploads a file in [BucketApi.bucketId] under [path]
+ * @param path The path to upload the file to
+ * @param file The file to upload
+ * @return A flow that emits the upload progress and at last the key to the uploaded file
+ */
+suspend fun BucketApi.uploadAsFlow(path: String, file: Path) = uploadAsFlow(path, file.readBytes())
+
+/**
  * Uploads a file in [BucketApi.bucketId] under [path] using a presigned url
  * @param path The path to upload the file to
- * @param file The presigned url token
+ * @param token The presigned url token
  * @param file The file to upload
+ * @return the key to the uploaded file
  */
 suspend fun BucketApi.uploadToSignedUrl(path: String, token: String, file: File) = uploadToSignedUrl(path, token, file.readBytes())
+
+/**
+ * Uploads a file in [BucketApi.bucketId] under [path] using a presigned url
+ * @param path The path to upload the file to
+ * @param token The presigned url token
+ * @param file The file to upload
+ * @return A flow that emits the upload progress and at last the key to the uploaded file
+ */
+suspend fun BucketApi.uploadToSignedUrlAsFlow(path: String, token: String, file: File) = uploadToSignedUrlAsFlow(path, token, file.readBytes())
 
 /**
  * Uploads a file in [BucketApi.bucketId] under [path] using a presigned url
@@ -36,6 +62,15 @@ suspend fun BucketApi.uploadToSignedUrl(path: String, token: String, file: File)
  * @param file The file to upload
  */
 suspend fun BucketApi.uploadToSignedUrl(path: String, token: String, file: Path) = uploadToSignedUrl(path, token, file.readBytes())
+
+/**
+ * Uploads a file in [BucketApi.bucketId] under [path] using a presigned url
+ * @param path The path to upload the file to
+ * @param token The presigned url token
+ * @param file The file to upload
+ * @return A flow that emits the upload progress and at last the key to the uploaded file
+ */
+suspend fun BucketApi.uploadToSignedUrlAsFlow(path: String, token: String, file: Path) = uploadToSignedUrlAsFlow(path, token, file.readBytes())
 
 /**
  * Updates a file in [BucketApi.bucketId] under [path]
@@ -48,8 +83,24 @@ suspend fun BucketApi.update(path: String, file: Path) = update(path, file.readB
  * Updates a file in [BucketApi.bucketId] under [path]
  * @param path The path to be updated
  * @param file The new file
+ * @return A flow that emits the upload progress and at last the key to the uploaded file
+ */
+suspend fun BucketApi.updateAsFlow(path: String, file: Path) = updateAsFlow(path, file.readBytes())
+
+/**
+ * Updates a file in [BucketApi.bucketId] under [path]
+ * @param path The path to be updated
+ * @param file The new file
  */
 suspend fun BucketApi.update(path: String, file: File) = update(path, file.readBytes())
+
+/**
+ * Updates a file in [BucketApi.bucketId] under [path]
+ * @param path The path to be updated
+ * @param file The new file
+ * @return A flow that emits the upload progress and at last the key to the uploaded file
+ */
+suspend fun BucketApi.updateAsFlow(path: String, file: File) = updateAsFlow(path, file.readBytes())
 
 /**
  * Downloads a file from [BucketApi.bucketId] under [path] and saves it to [file]

--- a/Storage/src/nonJsMain/kotlin/io/github/jan/supabase/storage/JvmUtils.kt
+++ b/Storage/src/nonJsMain/kotlin/io/github/jan/supabase/storage/JvmUtils.kt
@@ -1,5 +1,6 @@
 package io.github.jan.supabase.storage
 
+import io.github.jan.supabase.annotiations.SupabaseExperimental
 import java.io.File
 import java.nio.file.Path
 import kotlin.io.path.readBytes
@@ -19,6 +20,7 @@ suspend fun BucketApi.upload(path: String, file: File) = upload(path, file.readB
  * @param file The file to upload
  * @return A flow that emits the upload progress and at last the key to the uploaded file
  */
+@SupabaseExperimental
 suspend fun BucketApi.uploadAsFlow(path: String, file: File) = uploadAsFlow(path, file.readBytes())
 
 /**
@@ -35,6 +37,7 @@ suspend fun BucketApi.upload(path: String, file: Path) = upload(path, file.readB
  * @param file The file to upload
  * @return A flow that emits the upload progress and at last the key to the uploaded file
  */
+@SupabaseExperimental
 suspend fun BucketApi.uploadAsFlow(path: String, file: Path) = uploadAsFlow(path, file.readBytes())
 
 /**
@@ -53,6 +56,7 @@ suspend fun BucketApi.uploadToSignedUrl(path: String, token: String, file: File)
  * @param file The file to upload
  * @return A flow that emits the upload progress and at last the key to the uploaded file
  */
+@SupabaseExperimental
 suspend fun BucketApi.uploadToSignedUrlAsFlow(path: String, token: String, file: File) = uploadToSignedUrlAsFlow(path, token, file.readBytes())
 
 /**
@@ -70,6 +74,7 @@ suspend fun BucketApi.uploadToSignedUrl(path: String, token: String, file: Path)
  * @param file The file to upload
  * @return A flow that emits the upload progress and at last the key to the uploaded file
  */
+@SupabaseExperimental
 suspend fun BucketApi.uploadToSignedUrlAsFlow(path: String, token: String, file: Path) = uploadToSignedUrlAsFlow(path, token, file.readBytes())
 
 /**
@@ -85,6 +90,7 @@ suspend fun BucketApi.update(path: String, file: Path) = update(path, file.readB
  * @param file The new file
  * @return A flow that emits the upload progress and at last the key to the uploaded file
  */
+@SupabaseExperimental
 suspend fun BucketApi.updateAsFlow(path: String, file: Path) = updateAsFlow(path, file.readBytes())
 
 /**
@@ -100,6 +106,7 @@ suspend fun BucketApi.update(path: String, file: File) = update(path, file.readB
  * @param file The new file
  * @return A flow that emits the upload progress and at last the key to the uploaded file
  */
+@SupabaseExperimental
 suspend fun BucketApi.updateAsFlow(path: String, file: File) = updateAsFlow(path, file.readBytes())
 
 /**


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

You can only download & upload files without having access to progress

## What is the new behavior?

Each download/upload method has a flow variant, emitting either progress updates or in the end the result:

**Uploading as a flow**
```kotlin
client.storage["icons"].uploadAsFlow("test.png", File("test.png").readBytes()).collect {
    when(it) {
        is UploadStatus.Progress -> println("Percent done: ${it.sent.toDouble() / it.total.toDouble() * 100}")
        is UploadStatus.Success -> println("Done: ${it.key}")
    }
}
```

**Downloading as a flow**
```kotlin
client.storage["icons"].downloadPublicAsFlow("1654898740006.jpg").collect { status ->
    when(status) {
        is DownloadStatus.Progress -> println("Percent done: ${status.received.toDouble() / status.total.toDouble() * 100}")
        is DownloadStatus.Success -> println("Done: ${status.data.size} bytes")
    }
}
```

-> This works for all different uploading/downloading methods including update. 

## Additional context

Feel free to comment on this syntax