### PR TITLE
Update docs to reflect the real usage of Supabase URL when provide each service

### DIFF
--- a/GoTrue/README.md
+++ b/GoTrue/README.md
@@ -27,7 +27,7 @@ val client = createSupabaseClient {
 
 or create standalone module
 ```kotlin
-val gotrue = standaloneSupabaseModule(GoTrue, url = "https://your.gotrue.url.com", apiKey = "your-api-key")
+val gotrue = standaloneSupabaseModule(GoTrue, url = "https://your.gotrue.url.com/auth/v1", apiKey = "your-api-key")
 ```
 
 # Usage

--- a/Postgrest/README.md
+++ b/Postgrest/README.md
@@ -27,7 +27,7 @@ val client = createSupabaseClient {
 
 or create standalone module
 ```kotlin
-val postgrest = standaloneSupabaseModule(Postgrest, url = "https://your.postgrest.url.com", apiKey = "your-api-key")
+val postgrest = standaloneSupabaseModule(Postgrest, url = "https://your.postgrest.url.com/rest/v1", apiKey = "your-api-key")
 ```
 
 # Usage


### PR DESCRIPTION
## What kind of change does this PR introduce?

Update doc to avoid misunderstanding usage of Supabase URL

## What is the current behavior?
Currently, the docs for GoTrue and Postgrest are telling developer to set url when setup service instance as `"https://your.postgrest.url.com"`. However, according to the document in dashboard and it must have the endpoint for each service for example `/auth` or `/rest`

## What is the new behavior?
Update usage of Supabase url to be included endpoint of each service
## Additional context

Add any other context or screenshots.
