### PR TITLE
[enhancement][postgrest]: add match/imatch filters to FilterBuilder

### DIFF
--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/PostgrestFilterBuilder.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/PostgrestFilterBuilder.kt
@@ -117,6 +117,16 @@ class PostgrestFilterBuilder(@PublishedApi internal val propertyConversionMethod
     fun ilike(column: String, pattern: String) = filter(column, FilterOperator.ILIKE, pattern)
 
     /**
+     * Finds all rows where the value of the [column] matches the specified [pattern] using pattern matching
+     */
+    fun match(column: String, pattern: String) = filter(column, FilterOperator.MATCH, pattern)
+
+    /**
+     * Finds all rows where the value of the [column] matches the specified [pattern] using pattern matching (case-insensitive)
+     */
+    fun imatch(column: String, pattern: String) = filter(column, FilterOperator.IMATCH, pattern)
+
+    /**
      * Finds all rows where the value of the [column] equals to one of these values: null,true,false,unknown
      */
     fun exact(column: String, value: Boolean?) = filter(column, FilterOperator.IS, value)
@@ -319,9 +329,21 @@ class PostgrestFilterBuilder(@PublishedApi internal val propertyConversionMethod
     infix fun <T, V> KProperty1<T, V>.like(pattern: String) = filter(FilterOperation(propertyConversionMethod(this), FilterOperator.LIKE, pattern))
 
     /**
+     * Finds all rows where the value of the column with the name of the [KProperty1] converted using [propertyConversionMethod] matches the specified [pattern]
+     * using pattern matching
+     */
+    infix fun <T, V> KProperty1<T, V>.matches(pattern: String) = filter(FilterOperation(propertyConversionMethod(this), FilterOperator.MATCH, pattern))
+
+    /**
      * Finds all rows where the value of the column with the name of the [KProperty1] converted using [propertyConversionMethod] matches the specified [pattern] (case-insensitive)
      */
     infix fun <T, V> KProperty1<T, V>.ilike(pattern: String) = filter(FilterOperation(propertyConversionMethod(this), FilterOperator.ILIKE, pattern))
+
+    /**
+     * Finds all rows where the value of the column with the name of the [KProperty1] converted using [propertyConversionMethod] matches the specified [pattern]
+     * using pattern matching
+     */
+    infix fun <T, V> KProperty1<T, V>.imatch(pattern: String) = filter(FilterOperation(propertyConversionMethod(this), FilterOperator.IMATCH, pattern))
 
     /**
      * Finds all rows where the value of the column with the name of the [KProperty1] converted using [propertyConversionMethod] equals to one of these values: null,true,false,unknown
@@ -398,7 +420,9 @@ enum class FilterOperator(val identifier: String) {
     LT("lt"),
     LTE("lte"),
     LIKE("like"),
+    MATCH("match"),
     ILIKE("ilike"),
+    IMATCH("imatch"),
     IS("is"),
     IN("in"),
     CS("cs"),

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/PostgrestFilterBuilder.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/PostgrestFilterBuilder.kt
@@ -332,7 +332,7 @@ class PostgrestFilterBuilder(@PublishedApi internal val propertyConversionMethod
      * Finds all rows where the value of the column with the name of the [KProperty1] converted using [propertyConversionMethod] matches the specified [pattern]
      * using pattern matching
      */
-    infix fun <T, V> KProperty1<T, V>.matches(pattern: String) = filter(FilterOperation(propertyConversionMethod(this), FilterOperator.MATCH, pattern))
+    infix fun <T, V> KProperty1<T, V>.match(pattern: String) = filter(FilterOperation(propertyConversionMethod(this), FilterOperator.MATCH, pattern))
 
     /**
      * Finds all rows where the value of the column with the name of the [KProperty1] converted using [propertyConversionMethod] matches the specified [pattern] (case-insensitive)

--- a/Postgrest/src/commonTest/kotlin/PostgrestFilterBuilderTest.kt
+++ b/Postgrest/src/commonTest/kotlin/PostgrestFilterBuilderTest.kt
@@ -73,6 +73,22 @@ class PostgrestFilterBuilderTest {
     }
 
     @Test
+    fun match() {
+        val filter = filterToString {
+            match("name", "person")
+        }
+        assertEquals("name=match.person", filter)
+    }
+
+    @Test
+    fun imatch() {
+        val filter = filterToString {
+            imatch("name", "person")
+        }
+        assertEquals("name=imatch.person", filter)
+    }
+
+    @Test
     fun ilike() {
         val filter = filterToString {
             ilike("name", "_n_")


### PR DESCRIPTION
match and imatch operations were missing from the filters. They are added and tested.

## What kind of change does this PR introduce?

This PR adds the `match`/`imatch` filters to the postgrest. These go along with `like`/`ilike` to facilitate pattern matching. See [the relevant docs](https://postgrest.org/en/stable/references/api/tables_views.html#horizontal-filtering-rows).

## What is the current behavior?

These filters are currently unsupported/featured in this codebase. They behave differently than `like`/`ilike`, so they seem like a worthwhile addition.

## What is the new behavior?

Pattern matching is now a valid filter for postgrest.

## Additional context
I'm using this package for a project right now and wish it had match support! This project is awesome by the way :)
