### PR TITLE
Use Kermit for logging

### DIFF
--- a/GoTrue/src/androidMain/kotlin/io/github/jan/supabase/gotrue/setupPlatform.kt
+++ b/GoTrue/src/androidMain/kotlin/io/github/jan/supabase/gotrue/setupPlatform.kt
@@ -5,7 +5,7 @@ import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
 import androidx.startup.Initializer
-import io.github.aakira.napier.Napier
+import co.touchlab.kermit.Logger
 import io.github.jan.supabase.annotiations.SupabaseInternal
 import kotlinx.coroutines.launch
 
@@ -35,14 +35,14 @@ private fun addLifecycleCallbacks(gotrue: GoTrue) {
 
             override fun onStart(owner: LifecycleOwner) {
                 if(!gotrue.isAutoRefreshRunning && gotrue.config.alwaysAutoRefresh) {
-                    Napier.d {
+                    Logger.d {
                         "Starting auto refresh"
                     }
                     scope.launch {
                         try {
                             gotrue.startAutoRefreshForCurrentSession()
                         } catch(e: IllegalStateException) {
-                            Napier.d {
+                            Logger.d {
                                 "No session found for auto refresh"
                             }
                         }
@@ -51,7 +51,7 @@ private fun addLifecycleCallbacks(gotrue: GoTrue) {
             }
             override fun onStop(owner: LifecycleOwner) {
                 if(gotrue.isAutoRefreshRunning) {
-                    Napier.d { "Cancelling auto refresh because app is switching to the background" }
+                    Logger.d { "Cancelling auto refresh because app is switching to the background" }
                     scope.launch {
                         gotrue.stopAutoRefreshForCurrentSession()
                     }

--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/GoTrue.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/GoTrue.kt
@@ -1,6 +1,6 @@
 package io.github.jan.supabase.gotrue
 
-import io.github.aakira.napier.Napier
+import co.touchlab.kermit.Logger
 import io.github.jan.supabase.SupabaseClient
 import io.github.jan.supabase.exceptions.HttpRequestException
 import io.github.jan.supabase.exceptions.RestException
@@ -424,6 +424,6 @@ val SupabaseClient.gotrue: GoTrue
 private suspend fun GoTrue.tryToGetUser(jwt: String) = try {
     retrieveUser(jwt)
 } catch (e: Exception) {
-    Napier.e(e) { "Couldn't retrieve user using your custom jwt token. If you use the project secret ignore this message" }
+    Logger.e(e) { "Couldn't retrieve user using your custom jwt token. If you use the project secret ignore this message" }
     null
 }

--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/SessionManager.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/SessionManager.kt
@@ -1,14 +1,13 @@
 @file:OptIn(ExperimentalSettingsApi::class)
 package io.github.jan.supabase.gotrue
 
+import co.touchlab.kermit.Logger
 import com.russhwolf.settings.ExperimentalSettingsApi
 import com.russhwolf.settings.Settings
 import com.russhwolf.settings.coroutines.toSuspendSettings
-import io.github.aakira.napier.Napier
 import io.github.jan.supabase.annotiations.SupabaseInternal
 import io.github.jan.supabase.gotrue.user.UserSession
 import io.github.jan.supabase.supabaseJson
-import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 
 /**
@@ -51,7 +50,7 @@ class SettingsSessionManager(settings: Settings = createDefaultSettings()): Sess
         return try {
             supabaseJson.decodeFromString(session)
         } catch(e: Exception) {
-            Napier.e(e) { "Failed to load session" }
+            Logger.e(e) { "Failed to load session" }
             null
         }
     }

--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/Utils.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/Utils.kt
@@ -1,6 +1,6 @@
 package io.github.jan.supabase.gotrue
 
-import io.github.aakira.napier.Napier
+import co.touchlab.kermit.Logger
 import io.github.jan.supabase.annotiations.SupabaseInternal
 import io.github.jan.supabase.gotrue.user.UserSession
 import io.ktor.client.request.HttpRequestBuilder
@@ -10,13 +10,13 @@ import kotlinx.coroutines.launch
 
 @SupabaseInternal
 fun GoTrue.parseFragmentAndImportSession(fragment: String, onSessionSuccess: (UserSession) -> Unit = {}) {
-    Napier.d { "Parsing deeplink fragment" }
+    Logger.d { "Parsing deeplink fragment" }
     val map = fragment.split("&").associate {
         it.split("=").let { pair ->
             pair[0] to pair[1]
         }
     }
-    Napier.d { "Fragment parts: $map" }
+    Logger.d { "Fragment parts: $map" }
 
     val accessToken = map["access_token"] ?: return
     val refreshToken = map["refresh_token"] ?: return
@@ -26,7 +26,7 @@ fun GoTrue.parseFragmentAndImportSession(fragment: String, onSessionSuccess: (Us
     val providerToken = map["provider_token"]
     val providerRefreshToken = map["provider_refresh_token"]
     val scope = CoroutineScope(Dispatchers.Default)
-    Napier.d {
+    Logger.d {
         "Received session deeplink"
     }
     scope.launch {

--- a/GoTrue/src/iosMain/kotlin/io/github/jan/supabase/gotrue/IOS.kt
+++ b/GoTrue/src/iosMain/kotlin/io/github/jan/supabase/gotrue/IOS.kt
@@ -1,6 +1,6 @@
 package io.github.jan.supabase.gotrue
 
-import io.github.aakira.napier.Napier
+import co.touchlab.kermit.Logger
 import io.github.jan.supabase.SupabaseClient
 import io.github.jan.supabase.annotiations.SupabaseExperimental
 import io.github.jan.supabase.gotrue.user.UserSession
@@ -20,14 +20,14 @@ import platform.Foundation.NSURLQueryItem
 @SupabaseExperimental
 fun SupabaseClient.handleDeeplinks(url: NSURL, onSessionSuccess: (UserSession) -> Unit = {}) {
     if (url.scheme != gotrue.config.scheme || url.host != gotrue.config.host) {
-        Napier.d { "Received deeplink with wrong scheme or host" }
+        Logger.d { "Received deeplink with wrong scheme or host" }
         return
     }
     when (gotrue.config.flowType) {
         FlowType.IMPLICIT -> {
             val fragment = url.fragment
             if (fragment == null) {
-                Napier.d { "No fragment for deeplink" }
+                Logger.d { "No fragment for deeplink" }
                 return
             }
             gotrue.parseFragmentAndImportSession(fragment, onSessionSuccess)

--- a/GoTrue/src/iosMain/kotlin/io/github/jan/supabase/gotrue/providers/OAuthProvider.kt
+++ b/GoTrue/src/iosMain/kotlin/io/github/jan/supabase/gotrue/providers/OAuthProvider.kt
@@ -1,6 +1,6 @@
 package io.github.jan.supabase.gotrue.providers
 
-import io.github.aakira.napier.Napier
+import co.touchlab.kermit.Logger
 import io.github.jan.supabase.SupabaseClient
 import io.github.jan.supabase.gotrue.gotrue
 import io.github.jan.supabase.gotrue.user.UserSession
@@ -49,7 +49,7 @@ actual abstract class OAuthProvider : AuthProvider<ExternalAuthConfig, Unit> {
             queryParams.putAll(externalConfig.queryParams)
         })
         UIApplication.sharedApplication.openURL(url, emptyMap<Any?, Any>()) {
-            if(it) Napier.d { "Successfully opened provider url in safari" } else Napier.e { "Failed to open provider url in safari" }
+            if(it) Logger.d { "Successfully opened provider url in safari" } else Logger.e { "Failed to open provider url in safari" }
         }
     }
 

--- a/GoTrue/src/iosMain/kotlin/io/github/jan/supabase/gotrue/providers/builtin/loginWithSSO.kt
+++ b/GoTrue/src/iosMain/kotlin/io/github/jan/supabase/gotrue/providers/builtin/loginWithSSO.kt
@@ -1,6 +1,6 @@
 package io.github.jan.supabase.gotrue.providers.builtin
 
-import io.github.aakira.napier.Napier
+import co.touchlab.kermit.Logger
 import io.github.jan.supabase.SupabaseClient
 import io.github.jan.supabase.gotrue.gotrue
 import io.github.jan.supabase.gotrue.user.UserSession
@@ -18,6 +18,6 @@ internal actual suspend fun <Config : SSO.Config> SSO<Config>.loginWithSSO(
     val result = supabaseClient.gotrue.retrieveSSOUrl(this@loginWithSSO, deepLink, config)
     val url = NSURL(string = result.url)
     UIApplication.sharedApplication.openURL(url, emptyMap<Any?, Any>()) {
-        if(it) Napier.d { "Successfully opened provider url in safari" } else Napier.e { "Failed to open provider url in safari" }
+        if(it) Logger.d { "Successfully opened provider url in safari" } else Logger.e { "Failed to open provider url in safari" }
     }
 }

--- a/GoTrue/src/iosMain/kotlin/io/github/jan/supabase/gotrue/setupPlatform.kt
+++ b/GoTrue/src/iosMain/kotlin/io/github/jan/supabase/gotrue/setupPlatform.kt
@@ -1,9 +1,9 @@
 package io.github.jan.supabase.gotrue
 
-import io.github.aakira.napier.Napier
+import co.touchlab.kermit.Logger
 import io.github.jan.supabase.annotiations.SupabaseInternal
 
 @SupabaseInternal
 actual fun GoTrue.setupPlatform() {
-    Napier.w { "IOS support is experimental, please report any bugs you find!" }
+    Logger.w { "IOS support is experimental, please report any bugs you find!" }
 }

--- a/GoTrue/src/jvmMain/kotlin/io/github/jan/supabase/gotrue/providers/HttpCallbackServer.kt
+++ b/GoTrue/src/jvmMain/kotlin/io/github/jan/supabase/gotrue/providers/HttpCallbackServer.kt
@@ -1,6 +1,6 @@
 package io.github.jan.supabase.gotrue.providers
 
-import io.github.aakira.napier.Napier
+import co.touchlab.kermit.Logger
 import io.github.jan.supabase.annotiations.SupabaseExperimental
 import io.github.jan.supabase.gotrue.GoTrue
 import io.github.jan.supabase.gotrue.GoTrueImpl
@@ -35,7 +35,7 @@ internal suspend fun createServer(
             }
         }
     server.get("/callback") { ctx ->
-        Napier.d {
+        Logger.d {
             "Received callback on oauth callback"
         }
         val accessToken = ctx.queryParam("access_token") ?: return@get
@@ -49,7 +49,7 @@ internal suspend fun createServer(
             val user = gotrue.retrieveUser(accessToken)
             onSuccess(UserSession(accessToken, refreshToken, providerRefreshToken, providerToken, expiresIn, tokenType, user, type))
         }
-        Napier.d {
+        Logger.d {
             "Successfully received http callback"
         }
         ctx.html(HTML.redirectPage(gotrue.config.htmlIconUrl, gotrue.config.htmlTitle, gotrue.config.htmlText))

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/Storage.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/Storage.kt
@@ -2,9 +2,9 @@
 
 package io.github.jan.supabase.storage
 
+import co.touchlab.kermit.Logger
 import co.touchlab.stately.collections.IsoMutableMap
 import com.russhwolf.settings.ExperimentalSettingsApi
-import io.github.aakira.napier.Napier
 import io.github.jan.supabase.SupabaseClient
 import io.github.jan.supabase.annotiations.SupabaseInternal
 import io.github.jan.supabase.bodyOrNull
@@ -146,7 +146,7 @@ sealed interface Storage : MainPlugin<Storage.Config> {
             var defaultChunkSize: Long = DEFAULT_CHUNK_SIZE
                 set(value) {
                     if(value != DEFAULT_CHUNK_SIZE) {
-                        Napier.w { "supabase currently only supports a chunk size of 6MB" }
+                        Logger.w { "supabase currently only supports a chunk size of 6MB" }
                     }
                     field = value
                 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -157,7 +157,7 @@ kotlin {
             dependencies {
                 api(libs.kotlinx.datetime)
                 api(libs.kotlinx.coroutines.core)
-                api(libs.napier)
+                api(libs.kermit)
                 api(libs.bundles.ktor.client)
                 api(libs.kotlinx.atomicfu)
                 api(libs.stately)

--- a/demos/android-login/android/src/main/java/io/github/jan/supabase/android/MainActivity.kt
+++ b/demos/android-login/android/src/main/java/io/github/jan/supabase/android/MainActivity.kt
@@ -18,7 +18,7 @@ import androidx.compose.ui.Modifier
 import com.stevdzasan.onetap.OneTapSignInWithGoogle
 import com.stevdzasan.onetap.rememberOneTapSignInState
 import io.github.aakira.napier.DebugAntilog
-import io.github.aakira.napier.Napier
+import co.touchlab.kermit.Logger
 import io.github.jan.supabase.common.AppViewModel
 import io.github.jan.supabase.common.di.SERVER_CLIENT_ID
 import io.github.jan.supabase.common.ui.screen.LoginScreen
@@ -36,7 +36,7 @@ class MainActivity : ComponentActivity() {
     private val viewModel: AppViewModel by inject()
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        Napier.base(DebugAntilog())
+        Logger.base(DebugAntilog())
         viewModel.supabaseClient.handleDeeplinks(intent)
         setContent {
             MaterialTheme {

--- a/demos/android-login/common/src/commonMain/kotlin/io/github/jan/supabase/common/AppViewModel.kt
+++ b/demos/android-login/common/src/commonMain/kotlin/io/github/jan/supabase/common/AppViewModel.kt
@@ -1,7 +1,7 @@
 package io.github.jan.supabase.common
 
 import io.github.aakira.napier.DebugAntilog
-import io.github.aakira.napier.Napier
+import co.touchlab.kermit.Logger
 import io.github.jan.supabase.SupabaseClient
 import io.github.jan.supabase.gotrue.gotrue
 import io.github.jan.supabase.gotrue.parseFragmentAndImportSession
@@ -23,7 +23,7 @@ class AppViewModel(
 ) : MPViewModel() {
 
     init {
-        Napier.base(DebugAntilog())
+        Logger.base(DebugAntilog())
     }
 
     val sessionStatus = supabaseClient.gotrue.sessionStatus

--- a/demos/chat-demo-mpp/android/src/main/java/io/github/jan/supabase/android/MainActivity.kt
+++ b/demos/chat-demo-mpp/android/src/main/java/io/github/jan/supabase/android/MainActivity.kt
@@ -5,7 +5,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import io.github.aakira.napier.DebugAntilog
-import io.github.aakira.napier.Napier
+import co.touchlab.kermit.Logger
 import io.github.jan.supabase.SupabaseClient
 import io.github.jan.supabase.common.App
 import io.github.jan.supabase.common.ChatViewModel
@@ -18,7 +18,7 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        Napier.base(DebugAntilog())
+        Logger.base(DebugAntilog())
         viewModel.supabaseClient.handleDeeplinks(intent)
         setContent {
             MaterialTheme {

--- a/demos/chat-demo-mpp/common/src/commonMain/kotlin/io/github/jan/supabase/common/ChatViewModel.kt
+++ b/demos/chat-demo-mpp/common/src/commonMain/kotlin/io/github/jan/supabase/common/ChatViewModel.kt
@@ -1,7 +1,7 @@
 package io.github.jan.supabase.common
 
 import io.github.aakira.napier.DebugAntilog
-import io.github.aakira.napier.Napier
+import co.touchlab.kermit.Logger
 import io.github.jan.supabase.SupabaseClient
 import io.github.jan.supabase.common.net.Message
 import io.github.jan.supabase.common.net.MessageApi
@@ -34,7 +34,7 @@ class ChatViewModel(
 ) : MPViewModel() {
 
     init {
-        Napier.base(DebugAntilog())
+        Logger.base(DebugAntilog())
     }
 
     val sessionStatus = supabaseClient.gotrue.sessionStatus
@@ -127,7 +127,7 @@ class ChatViewModel(
             kotlin.runCatching {
                 messageApi.createMessage(message)
             }.onFailure {
-                Napier.e(it) { "Error while creating message" }
+                Logger.e(it) { "Error while creating message" }
             }
         }
     }
@@ -137,7 +137,7 @@ class ChatViewModel(
             kotlin.runCatching {
                 messageApi.deleteMessage(id)
             }.onFailure {
-                Napier.e(it) { "Error while deleting message" }
+                Logger.e(it) { "Error while deleting message" }
             }
         }
     }
@@ -149,7 +149,7 @@ class ChatViewModel(
             }.onSuccess {
                 messages.value = it
             }.onFailure {
-                Napier.e(it) { "Error while retrieving messages" }
+                Logger.e(it) { "Error while retrieving messages" }
             }
         }
     }

--- a/demos/file-upload/android/src/main/java/io/github/jan/supabase/android/MainActivity.kt
+++ b/demos/file-upload/android/src/main/java/io/github/jan/supabase/android/MainActivity.kt
@@ -9,7 +9,7 @@ import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.PermissionStatus
 import com.google.accompanist.permissions.rememberPermissionState
 import io.github.aakira.napier.DebugAntilog
-import io.github.aakira.napier.Napier
+import co.touchlab.kermit.Logger
 import io.github.jan.supabase.common.App
 import io.github.jan.supabase.common.UploadViewModel
 import org.koin.android.ext.android.inject
@@ -21,7 +21,7 @@ class MainActivity : ComponentActivity() {
     @OptIn(ExperimentalPermissionsApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        Napier.base(DebugAntilog())
+        Logger.base(DebugAntilog())
         setContent {
             val permissions = rememberPermissionState(android.Manifest.permission.READ_EXTERNAL_STORAGE)
             when(permissions.status) {

--- a/demos/file-upload/common/src/commonMain/kotlin/io/github/jan/supabase/common/UploadViewModel.kt
+++ b/demos/file-upload/common/src/commonMain/kotlin/io/github/jan/supabase/common/UploadViewModel.kt
@@ -3,7 +3,7 @@ package io.github.jan.supabase.common
 import androidx.compose.ui.ExperimentalComposeUiApi
 import co.touchlab.stately.collections.IsoMutableMap
 import io.github.aakira.napier.DebugAntilog
-import io.github.aakira.napier.Napier
+import co.touchlab.kermit.Logger
 import io.github.jan.supabase.storage.UploadStatus
 import io.github.jan.supabase.storage.resumable.Fingerprint
 import io.github.jan.supabase.storage.resumable.ResumableClient
@@ -29,7 +29,7 @@ class UploadViewModel(
     private val uploads = IsoMutableMap<Fingerprint, ResumableUpload>()
 
     init {
-        Napier.base(DebugAntilog())
+        Logger.base(DebugAntilog())
     }
 
     fun queueUpload(file: MPFile, path: String) {

--- a/demos/multi-factor-authentication/android/src/main/java/io/github/jan/supabase/android/MainActivity.kt
+++ b/demos/multi-factor-authentication/android/src/main/java/io/github/jan/supabase/android/MainActivity.kt
@@ -5,7 +5,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import io.github.aakira.napier.DebugAntilog
-import io.github.aakira.napier.Napier
+import co.touchlab.kermit.Logger
 import io.github.jan.supabase.common.App
 import io.github.jan.supabase.common.AppViewModel
 import io.github.jan.supabase.gotrue.handleDeeplinks
@@ -17,7 +17,7 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        Napier.base(DebugAntilog())
+        Logger.base(DebugAntilog())
         viewModel.supabaseClient.handleDeeplinks(intent)
         setContent {
             MaterialTheme {

--- a/demos/multi-factor-authentication/common/src/commonMain/kotlin/io/github/jan/supabase/common/AppViewModel.kt
+++ b/demos/multi-factor-authentication/common/src/commonMain/kotlin/io/github/jan/supabase/common/AppViewModel.kt
@@ -1,7 +1,7 @@
 package io.github.jan.supabase.common
 
 import io.github.aakira.napier.DebugAntilog
-import io.github.aakira.napier.Napier
+import co.touchlab.kermit.Logger
 import io.github.jan.supabase.SupabaseClient
 import io.github.jan.supabase.exceptions.RestException
 import io.github.jan.supabase.gotrue.gotrue
@@ -24,7 +24,7 @@ class AppViewModel(
 ) : MPViewModel() {
 
     init {
-        Napier.base(DebugAntilog())
+        Logger.base(DebugAntilog())
     }
 
     val sessionStatus = supabaseClient.gotrue.sessionStatus

--- a/demos/multiplatform-deeplinks/android/src/main/java/io/github/jan/supabase/android/MainActivity.kt
+++ b/demos/multiplatform-deeplinks/android/src/main/java/io/github/jan/supabase/android/MainActivity.kt
@@ -5,7 +5,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import io.github.aakira.napier.DebugAntilog
-import io.github.aakira.napier.Napier
+import co.touchlab.kermit.Logger
 import io.github.jan.supabase.common.App
 import io.github.jan.supabase.common.AppViewModel
 import io.github.jan.supabase.gotrue.handleDeeplinks
@@ -17,7 +17,7 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        Napier.base(DebugAntilog())
+        Logger.base(DebugAntilog())
         viewModel.supabaseClient.handleDeeplinks(intent)
         setContent {
             MaterialTheme {

--- a/demos/multiplatform-deeplinks/common/src/commonMain/kotlin/io/github/jan/supabase/common/AppViewModel.kt
+++ b/demos/multiplatform-deeplinks/common/src/commonMain/kotlin/io/github/jan/supabase/common/AppViewModel.kt
@@ -1,7 +1,7 @@
 package io.github.jan.supabase.common
 
 import io.github.aakira.napier.DebugAntilog
-import io.github.aakira.napier.Napier
+import co.touchlab.kermit.Logger
 import io.github.jan.supabase.SupabaseClient
 import io.github.jan.supabase.gotrue.gotrue
 import io.github.jan.supabase.gotrue.parseFragmentAndImportSession
@@ -24,7 +24,7 @@ class AppViewModel(
 ) : MPViewModel() {
 
     init {
-        Napier.base(DebugAntilog())
+        Logger.base(DebugAntilog())
     }
 
     val sessionStatus = supabaseClient.gotrue.sessionStatus

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ kotlin = "1.8.22"
 dokka = "1.8.20"
 ktor = "2.3.1"
 kotlinx-datetime = "0.4.0"
-napir = "2.6.1"
+kermit = "2.0.0-RC4"
 atomicfu = "0.20.2"
 coroutines = "1.7.1"
 android-lifecycle = "2.6.1"
@@ -44,7 +44,7 @@ ktor-client-websockets = { module = "io.ktor:ktor-client-websockets", version.re
 ktor-client-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
 ktor-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 
-napier = { module = "io.github.aakira:napier", version.ref = "napir" }
+kermit = { module = "co.touchlab:kermit", version.ref = "kermit" }
 
 android-lifecycle-process = { module = "androidx.lifecycle:lifecycle-process", version.ref = "android-lifecycle" }
 androidx-startup-runtime = { module = "androidx.startup:startup-runtime", version.ref = "androidx-startup" }

--- a/src/commonMain/kotlin/io/github/jan/supabase/SupabaseClient.kt
+++ b/src/commonMain/kotlin/io/github/jan/supabase/SupabaseClient.kt
@@ -1,6 +1,6 @@
 package io.github.jan.supabase
 
-import io.github.aakira.napier.Napier
+import co.touchlab.kermit.Logger
 import io.github.jan.supabase.annotiations.SupabaseInternal
 import io.github.jan.supabase.network.KtorSupabaseHttpClient
 import io.github.jan.supabase.plugins.PluginManager
@@ -63,7 +63,7 @@ internal class SupabaseClientImpl(
 ) : SupabaseClient {
 
     init {
-        Napier.i {
+        Logger.i {
             "SupabaseClient created! Please report any bugs you find."
         }
     }

--- a/src/commonMain/kotlin/io/github/jan/supabase/SupabaseClientBuilder.kt
+++ b/src/commonMain/kotlin/io/github/jan/supabase/SupabaseClientBuilder.kt
@@ -1,6 +1,6 @@
 package io.github.jan.supabase
 
-import io.github.aakira.napier.Napier
+import co.touchlab.kermit.Logger
 import io.github.jan.supabase.annotiations.SupabaseDsl
 import io.github.jan.supabase.plugins.PluginManager
 import io.github.jan.supabase.plugins.SupabasePlugin
@@ -60,7 +60,7 @@ class SupabaseClientBuilder @PublishedApi internal constructor(private val supab
         }
         if(supabaseUrl.startsWith("http://")) {
             useHTTPS = false
-            Napier.w { "You are using a non https supabase url ($supabaseUrl)."}
+            Logger.w { "You are using a non https supabase url ($supabaseUrl)."}
         }
     }
 

--- a/src/commonMain/kotlin/io/github/jan/supabase/network/KtorSupabaseHttpClient.kt
+++ b/src/commonMain/kotlin/io/github/jan/supabase/network/KtorSupabaseHttpClient.kt
@@ -1,7 +1,7 @@
 @file:Suppress("UndocumentedPublicFunction")
 package io.github.jan.supabase.network
 
-import io.github.aakira.napier.Napier
+import co.touchlab.kermit.Logger
 import io.github.jan.supabase.annotiations.SupabaseInternal
 import io.github.jan.supabase.exceptions.HttpRequestException
 import io.github.jan.supabase.supabaseJson
@@ -47,10 +47,10 @@ class KtorSupabaseHttpClient @SupabaseInternal constructor(
         val response = try {
             httpClient.request(url, builder)
         } catch(e: HttpRequestTimeoutException) {
-            Napier.d { "Request timed out after $requestTimeout ms" }
+            Logger.d { "Request timed out after $requestTimeout ms" }
             throw e
         } catch(e: Exception) {
-            Napier.d { "Request failed with ${e.message}" }
+            Logger.d { "Request failed with ${e.message}" }
             throw HttpRequestException(e.message ?: "", request)
         }
         return response
@@ -67,10 +67,10 @@ class KtorSupabaseHttpClient @SupabaseInternal constructor(
         val response = try {
             httpClient.prepareRequest(url, builder)
         } catch(e: HttpRequestTimeoutException) {
-            Napier.d { "Request timed out after $requestTimeout ms" }
+            Logger.d { "Request timed out after $requestTimeout ms" }
             throw e
         } catch(e: Exception) {
-            Napier.d { "Request failed with ${e.message}" }
+            Logger.d { "Request failed with ${e.message}" }
             throw HttpRequestException(e.message ?: "", request)
         }
         return response


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

supabase-kt uses [Napier](https://github.com/AAkira/Napier/) for logging. However, Napier doesn't support kotlin targets like `mingwX64` and hasn't been updated for a while.

## What is the new behavior?

supabase-kt now uses [Kermit](https://kermit.touchlab.co/docs/) for logging. The changes are minimal as Napier and Kermit work the same, you just have to replace `Napier` occurences with `Logger`
