### PR TITLE
Add Windows (MingwX64) target

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,3 +75,25 @@ jobs:
         run: chmod +x gradlew
       - name: Test supabase-kt
         run: ./gradlew iosX64Test iosSimulatorArm64Test --stacktrace
+  testWindows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 17
+        uses: actions/setup-java@v2
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+            ~/.konan
+          key: ${{ runner.os }}-gradle-v3-${{ hashFiles('gradle.properties', 'gradle/libs.versions.toml', 'gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-v3-
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+      - name: Test supabase-kt
+        run: ./gradlew mingwX64Test --stacktrace

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@
 .idea
 local.properties
 /test/
+/test-w/

--- a/Functions/build.gradle.kts
+++ b/Functions/build.gradle.kts
@@ -33,6 +33,7 @@ kotlin {
     }
     ios()
     iosSimulatorArm64()
+    mingwX64()
     sourceSets {
         all {
             languageSettings.optIn("kotlin.RequiresOptIn")

--- a/GoTrue/build.gradle.kts
+++ b/GoTrue/build.gradle.kts
@@ -34,6 +34,7 @@ kotlin {
     }
     ios()
     iosSimulatorArm64()
+    mingwX64()
     sourceSets {
         all {
             languageSettings.optIn("kotlin.RequiresOptIn")

--- a/GoTrue/src/mingwX64Main/kotlin/io/github/jan/supabase/gotrue/GoTrueConfig.kt
+++ b/GoTrue/src/mingwX64Main/kotlin/io/github/jan/supabase/gotrue/GoTrueConfig.kt
@@ -1,0 +1,8 @@
+package io.github.jan.supabase.gotrue
+
+import io.github.jan.supabase.plugins.MainConfig
+
+/**
+ * The configuration for [GoTrue]
+ */
+actual class GoTrueConfig actual constructor() : MainConfig, GoTrueConfigDefaults()

--- a/GoTrue/src/mingwX64Main/kotlin/io/github/jan/supabase/gotrue/generateRedirectUrl.kt
+++ b/GoTrue/src/mingwX64Main/kotlin/io/github/jan/supabase/gotrue/generateRedirectUrl.kt
@@ -1,0 +1,6 @@
+package io.github.jan.supabase.gotrue
+
+import io.github.jan.supabase.annotiations.SupabaseInternal
+
+@SupabaseInternal
+actual fun GoTrue.generateRedirectUrl(fallbackUrl: String?): String? = fallbackUrl

--- a/GoTrue/src/mingwX64Main/kotlin/io/github/jan/supabase/gotrue/providers/ExternalAuthConfig.kt
+++ b/GoTrue/src/mingwX64Main/kotlin/io/github/jan/supabase/gotrue/providers/ExternalAuthConfig.kt
@@ -1,0 +1,7 @@
+package io.github.jan.supabase.gotrue.providers
+
+/**
+ * Configuration for external authentication providers like Google, Twitter, etc.
+ */
+actual class ExternalAuthConfig :
+    ExternalAuthConfigDefaults()

--- a/GoTrue/src/mingwX64Main/kotlin/io/github/jan/supabase/gotrue/providers/OAuthProvider.kt
+++ b/GoTrue/src/mingwX64Main/kotlin/io/github/jan/supabase/gotrue/providers/OAuthProvider.kt
@@ -1,0 +1,41 @@
+package io.github.jan.supabase.gotrue.providers
+
+import io.github.jan.supabase.SupabaseClient
+import io.github.jan.supabase.gotrue.gotrue
+import io.github.jan.supabase.gotrue.user.UserSession
+import platform.windows.SW_SHOWNORMAL
+import platform.windows.ShellExecuteW
+
+/**
+ * Represents an OAuth provider.
+ */
+actual abstract class OAuthProvider actual constructor() : AuthProvider<ExternalAuthConfig, Unit> {
+    /**
+     * The name of the provider.
+     */
+    actual abstract val name: String
+
+    actual override suspend fun login(
+        supabaseClient: SupabaseClient,
+        onSuccess: suspend (UserSession) -> Unit,
+        redirectUrl: String?,
+        config: (ExternalAuthConfig.() -> Unit)?
+    ) {
+        val externalConfig = ExternalAuthConfig().apply { config?.invoke(this) }
+        val url = supabaseClient.gotrue.oAuthUrl(this@OAuthProvider, redirectUrl) {
+            scopes.addAll(externalConfig.scopes)
+            queryParams.putAll(externalConfig.queryParams)
+        }
+        ShellExecuteW(null, "open", url, null, null, SW_SHOWNORMAL);
+    }
+
+    actual override suspend fun signUp(
+        supabaseClient: SupabaseClient,
+        onSuccess: suspend (UserSession) -> Unit,
+        redirectUrl: String?,
+        config: (ExternalAuthConfig.() -> Unit)?
+    ) = login(supabaseClient, onSuccess, redirectUrl, config = config)
+
+    actual companion object
+
+}

--- a/GoTrue/src/mingwX64Main/kotlin/io/github/jan/supabase/gotrue/providers/builtin/loginWithSSO.kt
+++ b/GoTrue/src/mingwX64Main/kotlin/io/github/jan/supabase/gotrue/providers/builtin/loginWithSSO.kt
@@ -1,0 +1,17 @@
+package io.github.jan.supabase.gotrue.providers.builtin
+
+import io.github.jan.supabase.SupabaseClient
+import io.github.jan.supabase.gotrue.gotrue
+import io.github.jan.supabase.gotrue.user.UserSession
+import platform.windows.SW_SHOWNORMAL
+import platform.windows.ShellExecuteW
+
+internal actual suspend fun <Config : SSO.Config> SSO<Config>.loginWithSSO(
+    supabaseClient: SupabaseClient,
+    onSuccess: suspend (UserSession) -> Unit,
+    redirectUrl: String?,
+    config: (Config.() -> Unit)?
+) {
+    val result = supabaseClient.gotrue.retrieveSSOUrl(this@loginWithSSO, redirectUrl, config)
+    ShellExecuteW(null, "open", result.url, null, null, SW_SHOWNORMAL);
+}

--- a/GoTrue/src/mingwX64Main/kotlin/io/github/jan/supabase/gotrue/setupPlatform.kt
+++ b/GoTrue/src/mingwX64Main/kotlin/io/github/jan/supabase/gotrue/setupPlatform.kt
@@ -1,0 +1,7 @@
+package io.github.jan.supabase.gotrue
+
+import io.github.jan.supabase.annotiations.SupabaseInternal
+
+@SupabaseInternal
+actual fun GoTrue.setupPlatform() {
+}

--- a/GoTrue/src/mingwX64Main/kotlin/io/github/jan/supabase/gotrue/setupPlatform.kt
+++ b/GoTrue/src/mingwX64Main/kotlin/io/github/jan/supabase/gotrue/setupPlatform.kt
@@ -3,5 +3,4 @@ package io.github.jan.supabase.gotrue
 import io.github.jan.supabase.annotiations.SupabaseInternal
 
 @SupabaseInternal
-actual fun GoTrue.setupPlatform() {
-}
+actual fun GoTrue.setupPlatform() = Unit

--- a/GoTrue/src/mingwX64Test/kotlin/platformSettings.kt
+++ b/GoTrue/src/mingwX64Test/kotlin/platformSettings.kt
@@ -1,4 +1,3 @@
 import io.github.jan.supabase.gotrue.GoTrueConfig
 
-actual fun GoTrueConfig.platformSettings() {
-}
+actual fun GoTrueConfig.platformSettings() = Unit

--- a/GoTrue/src/mingwX64Test/kotlin/platformSettings.kt
+++ b/GoTrue/src/mingwX64Test/kotlin/platformSettings.kt
@@ -1,0 +1,4 @@
+import io.github.jan.supabase.gotrue.GoTrueConfig
+
+actual fun GoTrueConfig.platformSettings() {
+}

--- a/Postgrest/build.gradle.kts
+++ b/Postgrest/build.gradle.kts
@@ -33,6 +33,7 @@ kotlin {
     }
     ios()
     iosSimulatorArm64()
+    mingwX64()
     sourceSets {
         all {
             languageSettings.optIn("kotlin.RequiresOptIn")

--- a/Postgrest/src/mingwX64Main/kotlin/io/github/jan/supabase/postgrest/getSerialName.kt
+++ b/Postgrest/src/mingwX64Main/kotlin/io/github/jan/supabase/postgrest/getSerialName.kt
@@ -1,0 +1,7 @@
+package io.github.jan.supabase.postgrest
+
+import io.github.jan.supabase.annotiations.SupabaseInternal
+import kotlin.reflect.KProperty1
+
+@SupabaseInternal
+actual fun <T, V> getSerialName(property: KProperty1<T, V>): String = property.name

--- a/Realtime/build.gradle.kts
+++ b/Realtime/build.gradle.kts
@@ -37,6 +37,7 @@ kotlin {
     }
     ios()
     iosSimulatorArm64()
+    mingwX64()
     sourceSets {
         all {
             languageSettings.optIn("kotlin.RequiresOptIn")

--- a/Storage/build.gradle.kts
+++ b/Storage/build.gradle.kts
@@ -33,6 +33,7 @@ kotlin {
     }
     ios()
     iosSimulatorArm64()
+    mingwX64()
     sourceSets {
         all {
             languageSettings.optIn("kotlin.RequiresOptIn")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -148,6 +148,7 @@ kotlin {
     }
     ios()
     iosSimulatorArm64()
+    mingwX64()
     sourceSets {
         all {
             languageSettings.optIn("kotlin.RequiresOptIn")

--- a/detekt.yml
+++ b/detekt.yml
@@ -67,7 +67,7 @@ comments:
     endOfSentenceFormat: '([.?!][ \t\n\r\f<])|([.?!:]$)'
   KDocReferencesNonPublicProperty:
     active: false
-    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**', '**/mingwX64Test/**']
   OutdatedDocumentation:
     active: false
     matchTypeParameters: true
@@ -75,7 +75,7 @@ comments:
     allowParamOnConstructorProperties: false
   UndocumentedPublicClass:
     active: true
-    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**', '**/mingwX64Test/**']
     searchInNestedClass: true
     searchInInnerClass: true
     searchInInnerObject: true
@@ -86,14 +86,14 @@ comments:
       - 'SupabaseExperimental'
   UndocumentedPublicFunction:
     active: true
-    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**', '**/mingwX64Test/**']
     searchProtectedFunction: false
     ignoreAnnotated:
       - 'SupabaseInternal'
       - 'SupabaseExperimental'
   UndocumentedPublicProperty:
     active: true
-    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**', '**/mingwX64Test/**']
     searchProtectedProperty: false
     ignoreAnnotated:
       - 'SupabaseInternal'
@@ -168,14 +168,14 @@ complexity:
     active: false
   StringLiteralDuplication:
     active: false
-    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**', '**/mingwX64Test/**']
     threshold: 3
     ignoreAnnotation: true
     excludeStringsWithLessThan5Characters: true
     ignoreStringsRegex: '$^'
   TooManyFunctions:
     active: false
-    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**', '**/mingwX64Test/**']
     thresholdInFiles: 11
     thresholdInClasses: 11
     thresholdInInterfaces: 11
@@ -252,7 +252,7 @@ exceptions:
       - 'toString'
   InstanceOfCheckForException:
     active: false
-    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**', '**/mingwX64Test/**']
   NotImplementedDeclaration:
     active: false
   ObjectExtendsThrowable:
@@ -278,7 +278,7 @@ exceptions:
     active: false
   ThrowingExceptionsWithoutMessageOrCause:
     active: true
-    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**', '**/mingwX64Test/**']
     exceptions:
       - 'ArrayIndexOutOfBoundsException'
       - 'Exception'
@@ -293,7 +293,7 @@ exceptions:
     active: true
   TooGenericExceptionCaught:
     active: false
-    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**', '**/mingwX64Test/**']
     exceptionNames:
       - 'ArrayIndexOutOfBoundsException'
       - 'Error'
@@ -339,7 +339,7 @@ naming:
     minimumFunctionNameLength: 3
   FunctionNaming:
     active: true
-    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**', '**/mingwX64Test/**']
     functionPattern: '[a-z][a-zA-Z0-9]*'
     excludeClassPattern: '$^'
   FunctionParameterNaming:
@@ -397,10 +397,10 @@ performance:
     threshold: 3
   ForEachOnRange:
     active: true
-    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**', '**/mingwX64Test/**']
   SpreadOperator:
     active: true
-    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**', '**/mingwX64Test/**']
   UnnecessaryPartOfBinaryExpression:
     active: false
   UnnecessaryTemporaryInstantiation:
@@ -473,7 +473,7 @@ potential-bugs:
     active: true
   LateinitUsage:
     active: false
-    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**', '**/mingwX64Test/**']
     ignoreOnClassesPattern: ''
   MapGetWithNotNullAssertionOperator:
     active: true
@@ -500,7 +500,7 @@ potential-bugs:
     active: true
   UnsafeCallOnNullableType:
     active: true
-    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**', '**/mingwX64Test/**']
   UnsafeCast:
     active: true
   UnusedUnaryOperator:
@@ -617,7 +617,7 @@ style:
     maxJumpCount: 1
   MagicNumber:
     active: true
-    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**', '**/*.kts']
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**', '**/mingwX64Test/**', '**/*.kts']
     ignoreNumbers:
       - '-1'
       - '0'

--- a/plugins/ApolloGraphQL/build.gradle.kts
+++ b/plugins/ApolloGraphQL/build.gradle.kts
@@ -37,7 +37,6 @@ kotlin {
     }
     ios()
     iosSimulatorArm64()
-    mingwX64()
     sourceSets {
         all {
             languageSettings.optIn("kotlin.RequiresOptIn")

--- a/plugins/ApolloGraphQL/build.gradle.kts
+++ b/plugins/ApolloGraphQL/build.gradle.kts
@@ -37,6 +37,7 @@ kotlin {
     }
     ios()
     iosSimulatorArm64()
+    mingwX64()
     sourceSets {
         all {
             languageSettings.optIn("kotlin.RequiresOptIn")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,7 +12,10 @@ include("Storage")
 include("Realtime")
 include("Functions")
 include("bom")
+
 include("test")
+include("test-w")
+
 include(":plugins:ApolloGraphQL")
 project(":GoTrue").name = "gotrue-kt"
 project(":Postgrest").name = "postgrest-kt"

--- a/src/commonMain/kotlin/io/github/jan/supabase/PlatformTarget.kt
+++ b/src/commonMain/kotlin/io/github/jan/supabase/PlatformTarget.kt
@@ -4,7 +4,7 @@ package io.github.jan.supabase
  * Represents a target platform
  */
 enum class PlatformTarget {
-    DESKTOP, ANDROID, WEB, IOS;
+    DESKTOP, ANDROID, WEB, IOS, WINDOWS;
 }
 
 /**

--- a/src/mingwX64Main/kotlin/io/github/jan/supabase/CurrentPlatformTarget.kt
+++ b/src/mingwX64Main/kotlin/io/github/jan/supabase/CurrentPlatformTarget.kt
@@ -1,0 +1,6 @@
+package io.github.jan.supabase
+
+/**
+ * The current target platform
+ */
+actual val CurrentPlatformTarget: PlatformTarget = PlatformTarget.WINDOWS

--- a/src/mingwX64Test/kotlin/PlatformTargetTest.kt
+++ b/src/mingwX64Test/kotlin/PlatformTargetTest.kt
@@ -1,0 +1,13 @@
+import io.github.jan.supabase.CurrentPlatformTarget
+import io.github.jan.supabase.PlatformTarget
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+actual class PlatformTargetTest {
+
+    @Test
+    actual fun testPlatformTarget() {
+        assertEquals(PlatformTarget.WINDOWS, CurrentPlatformTarget, "The current platform target should be WINDOWS")
+    }
+
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

No support for the mingw64 kotlin target

## What is the new behavior?

Support for MingwX64 for all modules excluding `apollo-graphql` as their library doesn't support mingwx64

## Additional context

No built-in deeplink / oauth handling. The library will however open an url in the browser when using `loginWith(OAuthProvier)`
