### PR TITLE
Add custom tab option to Android GoTrue OAuth

### DIFF
--- a/GoTrue/build.gradle.kts
+++ b/GoTrue/build.gradle.kts
@@ -82,6 +82,7 @@ kotlin {
             dependsOn(nonLinuxMain)
             dependencies {
                 api(libs.androidx.startup.runtime)
+                api(libs.androidx.browser)
             }
         }
         val mingwX64Main by getting {

--- a/GoTrue/src/androidMain/kotlin/io/github/jan/supabase/gotrue/Android.kt
+++ b/GoTrue/src/androidMain/kotlin/io/github/jan/supabase/gotrue/Android.kt
@@ -2,25 +2,40 @@ package io.github.jan.supabase.gotrue
 
 import android.content.Intent
 import android.net.Uri
+import androidx.browser.customtabs.CustomTabsIntent
 import io.github.jan.supabase.SupabaseClient
 import io.github.jan.supabase.annotations.SupabaseExperimental
+import io.github.jan.supabase.gotrue.OAuthAction.CUSTOM_TABS
+import io.github.jan.supabase.gotrue.OAuthAction.EXTERNAL_BROWSER
 import io.github.jan.supabase.gotrue.providers.ExternalAuthConfigDefaults
 import io.github.jan.supabase.gotrue.providers.OAuthProvider
 import io.github.jan.supabase.gotrue.user.UserSession
 import kotlinx.coroutines.launch
 
+
 internal fun GoTrue.openOAuth(provider: OAuthProvider, redirectTo: String, config: ExternalAuthConfigDefaults) {
     this as GoTrueImpl
-    openUrl(Uri.parse(oAuthUrl(provider, redirectTo) {
-        scopes.addAll(config.scopes)
-        queryParams.putAll(config.queryParams)
-    }))
+    openUrl(
+        uri = Uri.parse(oAuthUrl(provider, redirectTo) {
+            scopes.addAll(config.scopes)
+            queryParams.putAll(config.queryParams)
+        }),
+        action = this.config.defaultOAuthAction
+    )
 }
 
-internal fun openUrl(uri: Uri) {
-    val browserIntent = Intent(Intent.ACTION_VIEW, uri)
-    browserIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
-    applicationContext().startActivity(browserIntent)
+internal fun openUrl(uri: Uri, action: OAuthAction) {
+    when(action) {
+        EXTERNAL_BROWSER -> {
+            val browserIntent = Intent(Intent.ACTION_VIEW, uri)
+            browserIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
+            applicationContext().startActivity(browserIntent)
+        }
+        CUSTOM_TABS -> {
+            val intent = CustomTabsIntent.Builder().build()
+            intent.launchUrl(applicationContext(), uri)
+        }
+    }
 }
 
 //TODO: Add context receiver 'Activity'

--- a/GoTrue/src/androidMain/kotlin/io/github/jan/supabase/gotrue/GoTrueConfig.kt
+++ b/GoTrue/src/androidMain/kotlin/io/github/jan/supabase/gotrue/GoTrueConfig.kt
@@ -1,5 +1,7 @@
 package io.github.jan.supabase.gotrue
 
+import io.github.jan.supabase.gotrue.OAuthAction.CUSTOM_TABS
+import io.github.jan.supabase.gotrue.OAuthAction.EXTERNAL_BROWSER
 import io.github.jan.supabase.plugins.CustomSerializationConfig
 import io.github.jan.supabase.plugins.MainConfig
 
@@ -23,4 +25,19 @@ actual class GoTrueConfig : MainConfig, CustomSerializationConfig, GoTrueConfigD
      */
     var enableLifecycleCallbacks: Boolean = true
 
+    /**
+     * The action to use for the OAuth flow
+     */
+    var defaultOAuthAction: OAuthAction = OAuthAction.EXTERNAL_BROWSER
+
+}
+
+/**
+ * Represents the available actions for OAuth.
+ * @property EXTERNAL_BROWSER Open the OAuth flow in an external browser
+ * @property CUSTOM_TABS Open the OAuth flow in a custom tab
+ * @see [GoTrueConfig.defaultOAuthAction]
+ */
+enum class OAuthAction {
+    EXTERNAL_BROWSER, CUSTOM_TABS
 }

--- a/GoTrue/src/androidMain/kotlin/io/github/jan/supabase/gotrue/providers/builtin/loginWithSSO.kt
+++ b/GoTrue/src/androidMain/kotlin/io/github/jan/supabase/gotrue/providers/builtin/loginWithSSO.kt
@@ -14,5 +14,5 @@ internal actual suspend fun <Config : SSO.Config> SSO<Config>.loginWithSSO(
 ) {
     val gotrueConfig = supabaseClient.gotrue.config
     val result = supabaseClient.gotrue.retrieveSSOUrl(this, redirectUrl ?: "${gotrueConfig.scheme}://${gotrueConfig.host}", config)
-    openUrl(Uri.parse(result.url))
+    openUrl(Uri.parse(result.url), gotrueConfig.defaultOAuthAction)
 }

--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/Utils.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/Utils.kt
@@ -13,8 +13,9 @@ fun GoTrue.parseFragmentAndImportSession(fragment: String, onSessionSuccess: (Us
     this as GoTrueImpl
     authScope.launch {
         val user = retrieveUser(session.accessToken)
-        onSessionSuccess(session.copy(user = user))
-        importSession(session)
+        val newSession = session.copy(user = user)
+        onSessionSuccess(newSession)
+        importSession(newSession)
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,7 @@ korlibs = "4.0.9"
 detekt = "1.23.0"
 moshi = "1.15.0"
 jackson = "2.15.2"
+browser = "1.5.0"
 
 [plugins]
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
@@ -46,6 +47,7 @@ ktor-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = 
 kermit = { module = "co.touchlab:kermit", version.ref = "kermit" }
 
 android-lifecycle-process = { module = "androidx.lifecycle:lifecycle-process", version.ref = "android-lifecycle" }
+androidx-browser = { module = "androidx.browser:browser", version.ref = "browser" }
 androidx-startup-runtime = { module = "androidx.startup:startup-runtime", version.ref = "androidx-startup" }
 
 multiplatform-settings-no-arg = { module = "com.russhwolf:multiplatform-settings-no-arg", version.ref = "multiplatform-settings" }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

When using OAuth on Android, you can currently only open the OAuth url in an external browser.

## What is the new behavior?

This PR adds a new property to the Android GoTrue config:

```kotlin
install(GoTrue) {
    defaultOAuthAction = OAuthAction.CUSTOM_TABS //defaults to OAuthAction.EXTERNAL_BROWSER
}
```

Once changed, this works exactly like opening the OAuth url in an external browser using deeplinks but using custom tabs.

Example video:

https://github.com/supabase-community/supabase-kt/assets/26686035/2cc5de2e-b574-42d8-ba2f-47dd85e38729
