### PR TITLE
Remove default values for Android & Apple platform deeplinks in the GoTrue config

### DIFF
--- a/GoTrue/src/androidMain/kotlin/io/github/jan/supabase/gotrue/GoTrueConfig.kt
+++ b/GoTrue/src/androidMain/kotlin/io/github/jan/supabase/gotrue/GoTrueConfig.kt
@@ -11,12 +11,12 @@ actual class GoTrueConfig : MainConfig, CustomSerializationConfig, GoTrueConfigD
     /**
      * The scheme for the redirect url, when using deep linking
      */
-    var scheme: String = "supabase"
+    var scheme: String? = null
 
     /**
      * The host for the redirect url, when using deep linking
      */
-    var host: String = "login"
+    var host: String? = null
 
     /**
      * Whether to stop auto-refresh on focus loss, and resume it on focus again

--- a/GoTrue/src/androidMain/kotlin/io/github/jan/supabase/gotrue/RedirectUrl.kt
+++ b/GoTrue/src/androidMain/kotlin/io/github/jan/supabase/gotrue/RedirectUrl.kt
@@ -5,8 +5,15 @@ import io.github.jan.supabase.annotations.SupabaseInternal
 @SupabaseInternal
 actual fun GoTrue.generateRedirectUrl(fallbackUrl: String?): String? {
     if(fallbackUrl != null) return fallbackUrl
-    val scheme = config.scheme ?: error(noDeeplinkMessage("scheme"))
-    val host = config.host ?: error(noDeeplinkMessage("host"))
+    val scheme = config.scheme ?: return null
+    val host = config.host ?: return null
     this as GoTrueImpl
-    return "${config.scheme}://${config.host}"
+    return "${scheme}://${host}"
 }
+
+internal val GoTrueConfig.deepLink: String
+    get() {
+        val scheme = scheme ?: return noDeeplinkMessage("scheme")
+        val host = host ?: return noDeeplinkMessage("host")
+        return "${scheme}://${host}"
+    }

--- a/GoTrue/src/androidMain/kotlin/io/github/jan/supabase/gotrue/RedirectUrl.kt
+++ b/GoTrue/src/androidMain/kotlin/io/github/jan/supabase/gotrue/RedirectUrl.kt
@@ -13,7 +13,7 @@ actual fun GoTrue.generateRedirectUrl(fallbackUrl: String?): String? {
 
 internal val GoTrueConfig.deepLink: String
     get() {
-        val scheme = scheme ?: return noDeeplinkMessage("scheme")
-        val host = host ?: return noDeeplinkMessage("host")
+        val scheme = scheme ?: noDeeplinkError("scheme")
+        val host = host ?: noDeeplinkError("host")
         return "${scheme}://${host}"
     }

--- a/GoTrue/src/androidMain/kotlin/io/github/jan/supabase/gotrue/RedirectUrl.kt
+++ b/GoTrue/src/androidMain/kotlin/io/github/jan/supabase/gotrue/RedirectUrl.kt
@@ -5,6 +5,8 @@ import io.github.jan.supabase.annotations.SupabaseInternal
 @SupabaseInternal
 actual fun GoTrue.generateRedirectUrl(fallbackUrl: String?): String? {
     if(fallbackUrl != null) return fallbackUrl
+    val scheme = config.scheme ?: error(noDeeplinkMessage("scheme"))
+    val host = config.host ?: error(noDeeplinkMessage("host"))
     this as GoTrueImpl
     return "${config.scheme}://${config.host}"
 }

--- a/GoTrue/src/androidMain/kotlin/io/github/jan/supabase/gotrue/providers/OAuthProvider.kt
+++ b/GoTrue/src/androidMain/kotlin/io/github/jan/supabase/gotrue/providers/OAuthProvider.kt
@@ -2,6 +2,7 @@ package io.github.jan.supabase.gotrue.providers
 
 import io.github.jan.supabase.SupabaseClient
 import io.github.jan.supabase.gotrue.GoTrueImpl
+import io.github.jan.supabase.gotrue.deepLink
 import io.github.jan.supabase.gotrue.gotrue
 import io.github.jan.supabase.gotrue.openOAuth
 import io.github.jan.supabase.gotrue.user.UserSession
@@ -23,9 +24,9 @@ actual abstract class OAuthProvider : AuthProvider<ExternalAuthConfig, Unit> {
         config: (ExternalAuthConfig.() -> Unit)?
     ) {
         val gotrue = supabaseClient.gotrue as GoTrueImpl
-        val deepLink = "${gotrue.config.scheme}://${gotrue.config.host}"
+        val redirectTo = redirectUrl ?: gotrue.config.deepLink
         val externalConfig = ExternalAuthConfig().apply { config?.invoke(this) }
-        gotrue.openOAuth(this, redirectUrl ?: deepLink, externalConfig)
+        gotrue.openOAuth(this, redirectTo, externalConfig)
     }
 
     actual override suspend fun signUp(

--- a/GoTrue/src/androidMain/kotlin/io/github/jan/supabase/gotrue/providers/builtin/loginWithSSO.kt
+++ b/GoTrue/src/androidMain/kotlin/io/github/jan/supabase/gotrue/providers/builtin/loginWithSSO.kt
@@ -2,6 +2,7 @@ package io.github.jan.supabase.gotrue.providers.builtin
 
 import android.net.Uri
 import io.github.jan.supabase.SupabaseClient
+import io.github.jan.supabase.gotrue.deepLink
 import io.github.jan.supabase.gotrue.gotrue
 import io.github.jan.supabase.gotrue.openUrl
 import io.github.jan.supabase.gotrue.user.UserSession
@@ -13,6 +14,6 @@ internal actual suspend fun <Config : SSO.Config> SSO<Config>.loginWithSSO(
     config: (Config.() -> Unit)?
 ) {
     val gotrueConfig = supabaseClient.gotrue.config
-    val result = supabaseClient.gotrue.retrieveSSOUrl(this, redirectUrl ?: "${gotrueConfig.scheme}://${gotrueConfig.host}", config)
+    val result = supabaseClient.gotrue.retrieveSSOUrl(this, redirectUrl ?: gotrueConfig.deepLink, config)
     openUrl(Uri.parse(result.url))
 }

--- a/GoTrue/src/appleMain/kotlin/io/github/jan/supabase/gotrue/Apple.kt
+++ b/GoTrue/src/appleMain/kotlin/io/github/jan/supabase/gotrue/Apple.kt
@@ -4,8 +4,6 @@ import co.touchlab.kermit.Logger
 import io.github.jan.supabase.SupabaseClient
 import io.github.jan.supabase.annotations.SupabaseExperimental
 import io.github.jan.supabase.gotrue.user.UserSession
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import platform.Foundation.NSURL
 import platform.Foundation.NSURLComponents
@@ -35,7 +33,7 @@ fun SupabaseClient.handleDeeplinks(url: NSURL, onSessionSuccess: (UserSession) -
         FlowType.PKCE -> {
             val components = NSURLComponents(url, false)
             val code = (components.queryItems?.firstOrNull { it is NSURLQueryItem && it.name == "code" } as? NSURLQueryItem)?.value ?: return
-            val scope = CoroutineScope(Dispatchers.Default)
+            val scope = (gotrue as GoTrueImpl).authScope
             scope.launch {
                 gotrue.exchangeCodeForSession(code)
                 onSessionSuccess(gotrue.currentSessionOrNull() ?: error("No session available"))

--- a/GoTrue/src/appleMain/kotlin/io/github/jan/supabase/gotrue/GoTrueConfig.kt
+++ b/GoTrue/src/appleMain/kotlin/io/github/jan/supabase/gotrue/GoTrueConfig.kt
@@ -11,11 +11,11 @@ actual class GoTrueConfig : MainConfig, CustomSerializationConfig, GoTrueConfigD
     /**
      * The scheme for the redirect url, when using deep linking
      */
-    var scheme: String = "supabase"
+    var scheme: String? = null
 
     /**
      * The host for the redirect url, when using deep linking
      */
-    var host: String = "login"
+    var host: String? = null
 
 }

--- a/GoTrue/src/appleMain/kotlin/io/github/jan/supabase/gotrue/RedirectUrl.kt
+++ b/GoTrue/src/appleMain/kotlin/io/github/jan/supabase/gotrue/RedirectUrl.kt
@@ -5,8 +5,15 @@ import io.github.jan.supabase.annotations.SupabaseInternal
 @SupabaseInternal
 actual fun GoTrue.generateRedirectUrl(fallbackUrl: String?): String? {
     if(fallbackUrl != null) return fallbackUrl
-    val scheme = config.scheme ?: error(noDeeplinkMessage("scheme"))
-    val host = config.host ?: error(noDeeplinkMessage("host"))
+    val scheme = config.scheme ?: return null
+    val host = config.host ?: return null
     this as GoTrueImpl
-    return "${config.scheme}://${config.host}"
+    return "${scheme}://${host}"
 }
+
+internal val GoTrueConfig.deepLink: String
+    get() {
+        val scheme = scheme ?: return noDeeplinkMessage("scheme")
+        val host = host ?: return noDeeplinkMessage("host")
+        return "${scheme}://${host}"
+    }

--- a/GoTrue/src/appleMain/kotlin/io/github/jan/supabase/gotrue/RedirectUrl.kt
+++ b/GoTrue/src/appleMain/kotlin/io/github/jan/supabase/gotrue/RedirectUrl.kt
@@ -13,7 +13,7 @@ actual fun GoTrue.generateRedirectUrl(fallbackUrl: String?): String? {
 
 internal val GoTrueConfig.deepLink: String
     get() {
-        val scheme = scheme ?: return noDeeplinkMessage("scheme")
-        val host = host ?: return noDeeplinkMessage("host")
+        val scheme = scheme ?: noDeeplinkError("scheme")
+        val host = host ?: noDeeplinkError("host")
         return "${scheme}://${host}"
     }

--- a/GoTrue/src/appleMain/kotlin/io/github/jan/supabase/gotrue/RedirectUrl.kt
+++ b/GoTrue/src/appleMain/kotlin/io/github/jan/supabase/gotrue/RedirectUrl.kt
@@ -5,6 +5,8 @@ import io.github.jan.supabase.annotations.SupabaseInternal
 @SupabaseInternal
 actual fun GoTrue.generateRedirectUrl(fallbackUrl: String?): String? {
     if(fallbackUrl != null) return fallbackUrl
+    val scheme = config.scheme ?: error(noDeeplinkMessage("scheme"))
+    val host = config.host ?: error(noDeeplinkMessage("host"))
     this as GoTrueImpl
     return "${config.scheme}://${config.host}"
 }

--- a/GoTrue/src/appleMain/kotlin/io/github/jan/supabase/gotrue/providers/OAuthProvider.kt
+++ b/GoTrue/src/appleMain/kotlin/io/github/jan/supabase/gotrue/providers/OAuthProvider.kt
@@ -1,6 +1,7 @@
 package io.github.jan.supabase.gotrue.providers
 
 import io.github.jan.supabase.SupabaseClient
+import io.github.jan.supabase.gotrue.deepLink
 import io.github.jan.supabase.gotrue.gotrue
 import io.github.jan.supabase.gotrue.user.UserSession
 import platform.Foundation.NSURL
@@ -38,8 +39,7 @@ actual abstract class OAuthProvider : AuthProvider<ExternalAuthConfig, Unit> {
         externalConfig: ExternalAuthConfig
     ) {
         val gotrue = supabaseClient.gotrue
-        val deepLink = "${gotrue.config.scheme}://${gotrue.config.host}"
-        val url = NSURL(string = supabaseClient.gotrue.oAuthUrl(this, redirectUrl ?: deepLink) {
+        val url = NSURL(string = supabaseClient.gotrue.oAuthUrl(this, redirectUrl ?: gotrue.config.deepLink) {
             scopes.addAll(externalConfig.scopes)
             queryParams.putAll(externalConfig.queryParams)
         })

--- a/GoTrue/src/appleMain/kotlin/io/github/jan/supabase/gotrue/providers/builtin/loginWithSSO.kt
+++ b/GoTrue/src/appleMain/kotlin/io/github/jan/supabase/gotrue/providers/builtin/loginWithSSO.kt
@@ -14,8 +14,7 @@ internal actual suspend fun <Config : SSO.Config> SSO<Config>.loginWithSSO(
     config: (Config.() -> Unit)?
 ) {
     val gotrue = supabaseClient.gotrue
-    val deepLink = redirectUrl ?: gotrue.config.deepLink
-    val result = supabaseClient.gotrue.retrieveSSOUrl(this@loginWithSSO, deepLink, config)
+    val result = supabaseClient.gotrue.retrieveSSOUrl(this@loginWithSSO, redirectUrl ?: gotrue.config.deepLink, config)
     val url = NSURL(string = result.url)
     openUrl(url)
 }

--- a/GoTrue/src/appleMain/kotlin/io/github/jan/supabase/gotrue/providers/builtin/loginWithSSO.kt
+++ b/GoTrue/src/appleMain/kotlin/io/github/jan/supabase/gotrue/providers/builtin/loginWithSSO.kt
@@ -1,6 +1,7 @@
 package io.github.jan.supabase.gotrue.providers.builtin
 
 import io.github.jan.supabase.SupabaseClient
+import io.github.jan.supabase.gotrue.deepLink
 import io.github.jan.supabase.gotrue.gotrue
 import io.github.jan.supabase.gotrue.providers.openUrl
 import io.github.jan.supabase.gotrue.user.UserSession
@@ -13,7 +14,7 @@ internal actual suspend fun <Config : SSO.Config> SSO<Config>.loginWithSSO(
     config: (Config.() -> Unit)?
 ) {
     val gotrue = supabaseClient.gotrue
-    val deepLink = redirectUrl ?: "${gotrue.config.scheme}://${gotrue.config.host}"
+    val deepLink = redirectUrl ?: gotrue.config.deepLink
     val result = supabaseClient.gotrue.retrieveSSOUrl(this@loginWithSSO, deepLink, config)
     val url = NSURL(string = result.url)
     openUrl(url)

--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/GoTrueExt.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/GoTrueExt.kt
@@ -4,12 +4,13 @@ import co.touchlab.kermit.Logger
 import io.github.jan.supabase.gotrue.user.UserSession
 
 internal fun noDeeplinkMessage(arg: String) = """
-        Trying to generate a redirect url, but neither a fallback url was provided nor a deeplink $arg is set in the GoTrueConfig.
+        Trying to use a deeplink as a redirect url, but no deeplink $arg is set in the GoTrueConfig.
         If you want to use deep linking, set the scheme and host in the GoTrueConfig:
         install(GoTrue) {
             scheme = "YOUR_SCHEME"
             host = "YOUR_HOST"
         }
+        You can also provide a custom redirect url.
     """.trimIndent()
 
 /**

--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/GoTrueExt.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/GoTrueExt.kt
@@ -3,6 +3,15 @@ package io.github.jan.supabase.gotrue
 import co.touchlab.kermit.Logger
 import io.github.jan.supabase.gotrue.user.UserSession
 
+internal fun noDeeplinkMessage(arg: String) = """
+        Trying to generate a redirect url, but neither a fallback url was provided nor a deeplink $arg is set in the GoTrueConfig.
+        If you want to use deep linking, set the scheme and host in the GoTrueConfig:
+        install(GoTrue) {
+            scheme = "YOUR_SCHEME"
+            host = "YOUR_HOST"
+        }
+    """.trimIndent()
+
 /**
  * Parses a session from a fragment.
  * @param fragment The fragment to parse the session from

--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/GoTrueExt.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/GoTrueExt.kt
@@ -3,7 +3,7 @@ package io.github.jan.supabase.gotrue
 import co.touchlab.kermit.Logger
 import io.github.jan.supabase.gotrue.user.UserSession
 
-internal fun noDeeplinkMessage(arg: String) = """
+internal fun noDeeplinkError(arg: String): Nothing = error("""
         Trying to use a deeplink as a redirect url, but no deeplink $arg is set in the GoTrueConfig.
         If you want to use deep linking, set the scheme and host in the GoTrueConfig:
         install(GoTrue) {
@@ -11,7 +11,7 @@ internal fun noDeeplinkMessage(arg: String) = """
             host = "YOUR_HOST"
         }
         You can also provide a custom redirect url.
-    """.trimIndent()
+    """.trimIndent())
 
 /**
  * Parses a session from a fragment.


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

For Android and Apple platform implementations, GoTrue has default values for `GoTrue#scheme` and `GoTrue#host`.

## What is the new behavior?

Both the `scheme` and the `host` now default to null and if you are trying to log in using OAuth (or SSO) without setting both values (or a custom redirect url), you get an error.

This is done to avoid confusion when forgetting to set both values.