### PR TITLE
compose-1.3.0-alpha-2: Broken Config helper functions

### DIFF
--- a/plugins/ComposeAuth/src/commonMain/kotlin/io/github/jan/supabase/compose/auth/LoginConfig.kt
+++ b/plugins/ComposeAuth/src/commonMain/kotlin/io/github/jan/supabase/compose/auth/LoginConfig.kt
@@ -51,7 +51,7 @@ fun ComposeAuth.Config.googleNativeLogin(
     nonce: String? = null,
     extraData: JsonObject? = null
 ) {
-    loginConfig["google"].apply {
+    loginConfig["google"] =
         GoogleLoginConfig(
             serverClientId,
             isSupported,
@@ -60,7 +60,6 @@ fun ComposeAuth.Config.googleNativeLogin(
             nonce,
             extraData
         )
-    }
 }
 
 /**
@@ -71,5 +70,5 @@ fun ComposeAuth.Config.appleNativeLogin(
     nonce: String? = null,
     extraData: JsonObject? = null
 ) {
-    loginConfig["apple"].apply { AppleLoginConfig(serverClientId, nonce, extraData) }
+    loginConfig["apple"] = AppleLoginConfig(serverClientId, nonce, extraData)
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes the broken helper function for creating configs

## What is the current behavior?

Broken helper config functions, devs have to manually  add native config to config map

## What is the new behavior?

The provided helper function work as intended 

