### PR TITLE
compose-1.3.0-alpha-2: Google Auth improved error handling

### DIFF
--- a/plugins/ComposeAuth/src/androidMain/kotlin/io/github/jan/supabase/compose/auth/composable/GoogleAuth.kt
+++ b/plugins/ComposeAuth/src/androidMain/kotlin/io/github/jan/supabase/compose/auth/composable/GoogleAuth.kt
@@ -126,6 +126,10 @@ internal fun ComposeAuth.oneTapSignIn(onResult: (NativeSignInResult) -> Unit, fa
                 } catch (e: Exception) {
                     onResult.invoke(NativeSignInResult.Error(e.localizedMessage ?: "error"))
                 }
+            } else if (result.resultCode == Activity.RESULT_CANCELED) {
+                onResult.invoke(NativeSignInResult.Error("error: operation canceled"))
+            } else {
+                onResult.invoke(NativeSignInResult.Error("error: ${result.resultCode}"))
             }
             state.reset()
         }
@@ -143,10 +147,15 @@ internal fun ComposeAuth.oneTapSignIn(onResult: (NativeSignInResult) -> Unit, fa
 
             val config = config.loginConfig["google"] as GoogleLoginConfig
             val signInRequest = getSignInRequest(config)
-            val oneTapResult = Identity.getSignInClient(context).beginSignIn(signInRequest).await()
-            request.launch(
-                IntentSenderRequest.Builder(oneTapResult.pendingIntent.intentSender).build()
-            )
+            try {
+                val oneTapResult = Identity.getSignInClient(context).beginSignIn(signInRequest).await()
+                request.launch(
+                    IntentSenderRequest.Builder(oneTapResult.pendingIntent.intentSender).build()
+                )
+            }catch (e:Exception){
+                onResult.invoke(NativeSignInResult.Error(e.localizedMessage))
+                state.reset()
+            }
         }
     }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Improves Google API exception handling and activity results 

## What is the current behavior?

`beginSignIn` error response is not handled causing crash in some scenarios
 There is no callback when activity result is not OK

## What is the new behavior?

The missing error handling now return callback to onResult
