### PR TITLE
Update .gitignore to avoid generated code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,7 @@
 /plugins/ApolloGraphQL/build
 /plugins/ComposeAuthUI/build
 /plugins/ComposeAuth/build
+/serializers/Jackson/build
+/serializers/Moshi/build
 .idea
 local.properties

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@
 /GoTrue/build/
 /Functions/build/
 /plugins/ApolloGraphQL/build
-/plugins/ApolloGraphQL/build/
 /plugins/ComposeAuthUI/build/
 /plugins/ComposeAuth/build/
 /serializers/

--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,9 @@
 /GoTrue/build/
 /Functions/build/
 /plugins/ApolloGraphQL/build
+/plugins/ApolloGraphQL/build/
+/plugins/ComposeAuthUI/build/
+/plugins/ComposeAuth/build/
+/serializers/
 .idea
 local.properties

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,5 @@
 /plugins/ApolloGraphQL/build
 /plugins/ComposeAuthUI/build/
 /plugins/ComposeAuth/build/
-/serializers/
 .idea
 local.properties

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@
 /GoTrue/build/
 /Functions/build/
 /plugins/ApolloGraphQL/build
-/plugins/ComposeAuthUI/build/
-/plugins/ComposeAuth/build/
+/plugins/ComposeAuthUI/build
+/plugins/ComposeAuth/build
 .idea
 local.properties


### PR DESCRIPTION
I just pulled latest code in my current repository and it generate thousands of files so I add them to git ignore

## What kind of change does this PR introduce?
Improve gitignore

## What is the current behavior?
I face there are too many generated fiels
<img width="565" alt="Screenshot 2023-09-10 at 16 49 17" src="https://github.com/supabase-community/supabase-kt/assets/43868345/e181738d-3c52-4c07-9d7a-7797ad958ca0">
<img width="565" alt="Screenshot 2023-09-10 at 16 48 42" src="https://github.com/supabase-community/supabase-kt/assets/43868345/c32fd5c0-cb42-473e-8780-7841a8a14c2f">
<img width="564" alt="Screenshot 2023-09-10 at 16 44 43" src="https://github.com/supabase-community/supabase-kt/assets/43868345/87842aa6-663e-454a-917d-16a83be03b59">


Please link any relevant issues here.

## What is the new behavior?
Generated change should be avoided

## Additional context
N/A
