### PR TITLE
Add a new method for clearing the local session

### DIFF
--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/GoTrue.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/GoTrue.kt
@@ -303,6 +303,11 @@ sealed interface GoTrue : MainPlugin<GoTrueConfig>, CustomSerializationPlugin {
     suspend fun refreshCurrentSession()
 
     /**
+     * Deletes the current session from storage and sets [sessionStatus] to [SessionStatus.NotAuthenticated]
+     */
+    suspend fun clearSession()
+
+    /**
      * Exchanges a code for a session. Used when using the [FlowType.PKCE] flow
      * @param code The code to exchange
      * @param saveSession Whether to save the session in storage

--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/GoTrueImpl.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/GoTrueImpl.kt
@@ -249,11 +249,7 @@ internal class GoTrueImpl(
             Logger.i { "Skipping session logout as there is no session available. Proceeding to clean up local data..." }
         }
         if (scope != LogoutScope.OTHERS) {
-            codeVerifierCache.deleteCodeVerifier()
-            sessionManager.deleteSession()
-            sessionJob?.cancel()
-            _sessionStatus.value = SessionStatus.NotAuthenticated
-            sessionJob = null
+            clearSession()
         }
         Logger.d { "Successfully logged out" }
     }
@@ -485,6 +481,14 @@ internal class GoTrueImpl(
                 }
             }
         })
+    }
+
+    override suspend fun clearSession() {
+        codeVerifierCache.deleteCodeVerifier()
+        sessionManager.deleteSession()
+        sessionJob?.cancel()
+        _sessionStatus.value = SessionStatus.NotAuthenticated
+        sessionJob = null
     }
 
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature (closes #305)

## What is the current behavior?

You can only use `logout` to clear the logout storage, which requires calling the Supabase API with a valid session.

## What is the new behavior?

There is a new `GoTrue#clearSession` method which clears the storage from the session & updates the GoTrue status.

## Additional context

See #305 
