### PR TITLE
Add support for WASM

### DIFF
--- a/src/commonMain/kotlin/io/github/jan/supabase/PlatformTarget.kt
+++ b/src/commonMain/kotlin/io/github/jan/supabase/PlatformTarget.kt
@@ -4,7 +4,7 @@ package io.github.jan.supabase
  * Represents a target platform
  */
 enum class PlatformTarget {
-    JVM, ANDROID, JS, WASM, IOS, WINDOWS, MACOS, TVOS, WATCHOS, LINUX;
+    JVM, ANDROID, JS, WASM_JS, IOS, WINDOWS, MACOS, TVOS, WATCHOS, LINUX;
 }
 
 /**


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature (closes #86)

## What is the current behavior?

N/A

## What is the new behavior?

New `wasm-js` target for supabase-kt

**Supported modules:**

- [ ] supabase-kt
- [ ] gotrue-kt
- [ ] storage-kt
- [ ] functions-kt
- [ ] postgrest-kt
- [ ] realtime-kt
- [ ] compose-auth
- [ ] compose-auth-ui
- [ ] apollo-graphql

**Limitations:**
- Unreleased KotlinX library versions are being used, resulting in `mingwx64` and `linuxX64` not being supported

# Additional context

The implementation should be almost the same as the js browser implementation. `wasm-wasi` support may also come if the libraries support it.