### PR TITLE
Restructure READMEs

### DIFF
--- a/GoTrue/README.md
+++ b/GoTrue/README.md
@@ -8,9 +8,9 @@ Supported targets:
 |--------|---------|-------------|--------|---------|----------|-------------|-----------|-------------|-----------|
 | Status | ✅       | ✅           | ✅      | ✅       | 	☑️      | 	 ☑️         | 	 ✅       | ☑️           | ☑️         |
 
-> Note: Native support is experimental and needs feedback
-
-☑️ = No built-in OAuth support. Linux has no support for persistent session storage.
+> Native support is experimental and needs feedback
+> 
+> ☑️ = No built-in OAuth support. Linux has no support for persistent session storage.
 
 <details>
 
@@ -32,9 +32,9 @@ Supported targets:
 
 </details>
 
-Newest version: [![Maven Central](https://img.shields.io/maven-central/v/io.github.jan-tennert.supabase/supabase-kt)](https://search.maven.org/search?q=g%3Aio.github.jan-tennert.supabase)
-
 # Installation
+
+Newest version: [![](https://img.shields.io/github/release/supabase-community/supabase-kt?label=)](https://github.com/supabase-community/supabase-kt/releases)
 
 ```kotlin
 dependencies {

--- a/GoTrue/README.md
+++ b/GoTrue/README.md
@@ -2,6 +2,36 @@
 
 Extends Supabase-kt with a multiplatform GoTrue client.
 
+Supported targets:
+
+| Target | **JVM** | **Android** | **JS** | **iOS** | **tvOS** | **watchOS** | **macOS** | **Windows** | **Linux** |
+|--------|---------|-------------|--------|---------|----------|-------------|-----------|-------------|-----------|
+| Status | ✅       | ✅           | ✅      | ✅       | 	☑️      | 	 ☑️         | 	 ✅       | ☑️           | ☑️         |
+
+> Note: Native support is experimental and needs feedback
+
+☑️ = No built-in OAuth support. Linux has no support for persistent session storage.
+
+<details>
+
+<summary>In-depth Kotlin targets</summary>
+
+**iOS:** iosArm64, iosSimulatorArm64, iosX64
+
+**JS**: Browser, NodeJS
+
+**tvOS**: tvosArm64, tvosX64, tvosSimulatorArm64
+
+**watchOS**: watchosArm64, watchosX64, watchosSimulatorArm64
+
+**MacOS**: macosX64, macosArm64
+
+**Windows**: mingwX64
+
+**Linux**: linuxX64
+
+</details>
+
 Newest version: [![Maven Central](https://img.shields.io/maven-central/v/io.github.jan-tennert.supabase/supabase-kt)](https://search.maven.org/search?q=g%3Aio.github.jan-tennert.supabase)
 
 # Installation

--- a/Postgrest/README.md
+++ b/Postgrest/README.md
@@ -2,6 +2,32 @@
 
 Extends Supabase-kt with a multiplatform Postgrest client.
 
+Supported targets:
+
+| Target | **JVM** | **Android** | **JS** | **iOS** | **tvOS** | **watchOS** | **macOS** | **Windows** | **Linux** |
+|--------|---------|-------------|--------|---------|----------|-------------|-----------|-------------|-----------|
+| Status | ✅       | ✅           | ✅      | ✅       | 	 ✅      | 	 ✅         | 	 ✅       | ✅           | ✅         |
+
+<details>
+
+<summary>In-depth Kotlin targets</summary>
+
+**iOS:** iosArm64, iosSimulatorArm64, iosX64
+
+**JS**: Browser, NodeJS
+
+**tvOS**: tvosArm64, tvosX64, tvosSimulatorArm64
+
+**watchOS**: watchosArm64, watchosX64, watchosSimulatorArm64
+
+**MacOS**: macosX64, macosArm64
+
+**Windows**: mingwX64
+
+**Linux**: linuxX64
+
+</details>
+
 Newest version: [![Maven Central](https://img.shields.io/maven-central/v/io.github.jan-tennert.supabase/supabase-kt)](https://search.maven.org/search?q=g%3Aio.github.jan-tennert.supabase)
 
 # Installation

--- a/Postgrest/README.md
+++ b/Postgrest/README.md
@@ -28,9 +28,9 @@ Supported targets:
 
 </details>
 
-Newest version: [![Maven Central](https://img.shields.io/maven-central/v/io.github.jan-tennert.supabase/supabase-kt)](https://search.maven.org/search?q=g%3Aio.github.jan-tennert.supabase)
-
 # Installation
+
+Newest version: [![](https://img.shields.io/github/release/supabase-community/supabase-kt?label=)](https://github.com/supabase-community/supabase-kt/releases)
 
 ```kotlin
 dependencies {

--- a/README.md
+++ b/README.md
@@ -1,21 +1,6 @@
 # supabase-kt
 
 A Kotlin Multiplatform Client for Supabase.
-Supported targets:
-
-|             | **GoTrue** | **Realtime** | **Postgrest** | **Storage** | **Functions** |
-|-------------|------------|--------------|---------------|-------------|---------------|
-| **JVM**     | ✅          | ✅            | ✅             | ✅           | ✅             |
-| **Android** | ✅          | ✅            | ✅             | ✅           | ✅             |
-| **JS**      | ✅          | ✅            | ✅             | ✅           | ✅             |
-| **IOS**     | ✅          | ✅            | ✅             | ✅           | ✅             |
-| **tvOS**    | ☑️         | ✅            | ✅             | ✅           | ✅             |
-| **watchOS** | ☑️         | ✅            | ✅             | ✅           | ✅             |
-| **MacOS**   | ✅          | ✅            | ✅             | ✅           | ✅             |
-| **Windows** | ☑️         | ✅            | ✅             | ✅           | ✅             |
-| **Linux**   | ☑️         | ✅            | ✅             | ✅           | ✅             |
-
-For supported targets for plugins like Compose Auth, check the corresponding README.
 
 <details>
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Kotlin Multiplatform Client for Supabase.
 
 For information about supported Kotlin targets, see the corresponding module README.
 
-*Note: WASM planned see [issue](https://github.com/supabase-community/supabase-kt/issues/86)*
+*Note: WASM support planned see [issue](https://github.com/supabase-community/supabase-kt/issues/86)*
 
 [![](https://img.shields.io/github/release/supabase-community/supabase-kt?label=stable)](https://github.com/supabase-community/supabase-kt/releases) [![](https://img.shields.io/maven-central/v/io.github.jan-tennert.supabase/supabase-kt?label=experimental)](https://central.sonatype.com/search?q=io.github.jan.supabase&smo=true)
 

--- a/README.md
+++ b/README.md
@@ -2,31 +2,7 @@
 
 A Kotlin Multiplatform Client for Supabase.
 
-<details>
-
-<summary>In-depth Kotlin targets</summary>
-
-**iOS:** iosArm64, iosSimulatorArm64, iosX64
-
-**JS**: Browser, NodeJS
-
-**tvOS**: tvosArm64, tvosX64, tvosSimulatorArm64
-
-**watchOS**: watchosArm64, watchosX64, watchosSimulatorArm64  
-
-**MacOS**: macosX64, macosArm64          
-
-**Windows**: mingwX64    
-
-**Linux**: linuxX64
-
-</details>
-
-✅ = full support
-
-☑️ = partial support: check the corresponding README for more information
-
-❌ = not supported
+For information about supported Kotlin targets, see the corresponding module README.
 
 *Note: WASM planned see [issue](https://github.com/supabase-community/supabase-kt/issues/86)*
 

--- a/README.md
+++ b/README.md
@@ -3,17 +3,19 @@
 A Kotlin Multiplatform Client for Supabase.
 Supported targets:
 
-|                  | **GoTrue** | **Realtime** | **Postgrest** | **Storage** | **Functions** | **Apollo-GraphQL** | **Compose Auth 🚧** | **Compose Auth UI 🚧** |
-|------------------|------------|--------------|---------------|-------------|---------------|--------------------|---------------------|------------------------|
-| **JVM**          | ✅          | ✅            | ✅             | ✅           | ✅             | ✅                  | ☑️                  | ✅                      |
-| **Android**      | ✅          | ✅            | ✅             | ✅           | ✅             | ✅                  | ✅                   | ✅                      |
-| **JS**           | ✅          | ✅            | ✅             | ✅           | ✅             | ✅                  | ☑️                  | ✅                      |
-| **IOS**          | ✅          | ✅            | ✅             | ✅           | ✅             | ✅                  | 🚧                  | ✅                      |
-| **tvOS**  🚧     | ☑️         | ✅            | ✅             | ✅           | ✅             | ✅                  | ❌                   | ❌                      |
-| **watchOS**  🚧  | ☑️         | ✅            | ✅             | ✅           | ✅             | ✅                  | ❌                   | ❌                      |
-| **MacOS**   🚧   | ✅          | ✅            | ✅             | ✅           | ✅             | ✅                  | ❌                   | ❌                      |
-| **Windows**   🚧 | ☑️         | ✅            | ✅             | ✅           | ✅             | ❌                  | ❌                   | ❌                      |
-| **Linux**  🚧    | ☑️         | ✅            | ✅             | ✅           | ✅             | ❌                  | ❌                   | ❌                      |
+|             | **GoTrue** | **Realtime** | **Postgrest** | **Storage** | **Functions** |
+|-------------|------------|--------------|---------------|-------------|---------------|
+| **JVM**     | ✅          | ✅            | ✅             | ✅           | ✅             |
+| **Android** | ✅          | ✅            | ✅             | ✅           | ✅             |
+| **JS**      | ✅          | ✅            | ✅             | ✅           | ✅             |
+| **IOS**     | ✅          | ✅            | ✅             | ✅           | ✅             |
+| **tvOS**    | ☑️         | ✅            | ✅             | ✅           | ✅             |
+| **watchOS** | ☑️         | ✅            | ✅             | ✅           | ✅             |
+| **MacOS**   | ✅          | ✅            | ✅             | ✅           | ✅             |
+| **Windows** | ☑️         | ✅            | ✅             | ✅           | ✅             |
+| **Linux**   | ☑️         | ✅            | ✅             | ✅           | ✅             |
+
+For supported targets for plugins like Compose Auth, check the corresponding README.
 
 <details>
 
@@ -37,9 +39,7 @@ Supported targets:
 
 ✅ = full support
 
-☑️ = partial support: no built-in OAuth/OTP link handling. Linux also has no support for persistent storage. For Compose Auth, it relies on GoTrue as fallback.
-
-🚧 = experimental/needs feedback
+☑️ = partial support: check the corresponding README for more information
 
 ❌ = not supported
 

--- a/Realtime/README.md
+++ b/Realtime/README.md
@@ -2,6 +2,32 @@
 
 Extends Supabase-kt with a multiplatform Realtime client.
 
+Supported targets:
+
+| Target | **JVM** | **Android** | **JS** | **iOS** | **tvOS** | **watchOS** | **macOS** | **Windows** | **Linux** |
+|--------|---------|-------------|--------|---------|----------|-------------|-----------|-------------|-----------|
+| Status | ✅       | ✅           | ✅      | ✅       | 	 ✅      | 	 ✅         | 	 ✅       | ✅           | ✅         |
+
+<details>
+
+<summary>In-depth Kotlin targets</summary>
+
+**iOS:** iosArm64, iosSimulatorArm64, iosX64
+
+**JS**: Browser, NodeJS
+
+**tvOS**: tvosArm64, tvosX64, tvosSimulatorArm64
+
+**watchOS**: watchosArm64, watchosX64, watchosSimulatorArm64
+
+**MacOS**: macosX64, macosArm64
+
+**Windows**: mingwX64
+
+**Linux**: linuxX64
+
+</details>
+
 Newest version: [![Maven Central](https://img.shields.io/maven-central/v/io.github.jan-tennert.supabase/supabase-kt)](https://search.maven.org/search?q=g%3Aio.github.jan-tennert.supabase)
 
 # Installation

--- a/Realtime/README.md
+++ b/Realtime/README.md
@@ -28,9 +28,9 @@ Supported targets:
 
 </details>
 
-Newest version: [![Maven Central](https://img.shields.io/maven-central/v/io.github.jan-tennert.supabase/supabase-kt)](https://search.maven.org/search?q=g%3Aio.github.jan-tennert.supabase)
-
 # Installation
+
+Newest version: [![](https://img.shields.io/github/release/supabase-community/supabase-kt?label=)](https://github.com/supabase-community/supabase-kt/releases)
 
 ```kotlin
 dependencies {

--- a/Storage/README.md
+++ b/Storage/README.md
@@ -2,6 +2,34 @@
 
 Extends Supabase-kt with a multiplatform Storage client.
 
+Supported targets:
+
+| Target | **JVM** | **Android** | **JS** | **iOS** | **tvOS** | **watchOS** | **macOS** | **Windows** | **Linux** |
+|--------|---------|-------------|--------|---------|----------|-------------|-----------|-------------|-----------|
+| Status | ✅       | ✅           | ✅      | ✅       | 	 ✅      | 	 ✅         | 	 ✅       | ✅           | ✅         |
+
+> Linux has no support for persistent resumable upload url caching.
+
+<details>
+
+<summary>In-depth Kotlin targets</summary>
+
+**iOS:** iosArm64, iosSimulatorArm64, iosX64
+
+**JS**: Browser, NodeJS
+
+**tvOS**: tvosArm64, tvosX64, tvosSimulatorArm64
+
+**watchOS**: watchosArm64, watchosX64, watchosSimulatorArm64
+
+**MacOS**: macosX64, macosArm64
+
+**Windows**: mingwX64
+
+**Linux**: linuxX64
+
+</details>
+
 Newest version: [![Maven Central](https://img.shields.io/maven-central/v/io.github.jan-tennert.supabase/supabase-kt)](https://search.maven.org/search?q=g%3Aio.github.jan-tennert.supabase)
 
 # Installation

--- a/Storage/README.md
+++ b/Storage/README.md
@@ -30,9 +30,9 @@ Supported targets:
 
 </details>
 
-Newest version: [![Maven Central](https://img.shields.io/maven-central/v/io.github.jan-tennert.supabase/supabase-kt)](https://search.maven.org/search?q=g%3Aio.github.jan-tennert.supabase)
-
 # Installation
+
+Newest version: [![](https://img.shields.io/github/release/supabase-community/supabase-kt?label=)](https://github.com/supabase-community/supabase-kt/releases)
 
 ```kotlin
 dependencies {

--- a/plugins/ApolloGraphQL/README.md
+++ b/plugins/ApolloGraphQL/README.md
@@ -28,9 +28,9 @@ Supported targets:
 
 </details>
 
-Newest version: [![Maven Central](https://img.shields.io/maven-central/v/io.github.jan-tennert.supabase/supabase-kt)](https://search.maven.org/search?q=g%3Aio.github.jan-tennert.supabase)
-
 # Installation
+
+Newest version: [![](https://img.shields.io/github/release/supabase-community/supabase-kt?label=)](https://github.com/supabase-community/supabase-kt/releases)
 
 ```kotlin
 dependencies {

--- a/plugins/ApolloGraphQL/README.md
+++ b/plugins/ApolloGraphQL/README.md
@@ -2,6 +2,32 @@
 
 Extends Supabase-kt with an Apollo GraphQL Client.
 
+Supported targets:
+
+| Target | **JVM** | **Android** | **JS** | **iOS** | **tvOS** | **watchOS** | **macOS** | **Windows** | **Linux** |
+|--------|---------|-------------|--------|---------|----------|-------------|-----------|-------------|-----------|
+| Status | ✅       | ✅           | ✅      | ✅       | ✅        | ✅           | ✅         | ❌           | ❌         |
+
+<details>
+
+<summary>In-depth Kotlin targets</summary>
+
+**iOS:** iosArm64, iosSimulatorArm64, iosX64
+
+**JS**: Browser, NodeJS
+
+**tvOS**: tvosArm64, tvosX64, tvosSimulatorArm64
+
+**watchOS**: watchosArm64, watchosX64, watchosSimulatorArm64
+
+**MacOS**: macosX64, macosArm64
+
+**Windows**: mingwX64
+
+**Linux**: linuxX64
+
+</details>
+
 Newest version: [![Maven Central](https://img.shields.io/maven-central/v/io.github.jan-tennert.supabase/supabase-kt)](https://search.maven.org/search?q=g%3Aio.github.jan-tennert.supabase)
 
 # Installation

--- a/plugins/ComposeAuth/README.md
+++ b/plugins/ComposeAuth/README.md
@@ -2,6 +2,34 @@
 
 Extends gotrue-kt with auth composables for Compose Multiplatform
 
+Supported targets:
+
+| Target | **JVM** | **Android** | **JS** | **iOS** | **tvOS** | **watchOS** | **macOS** | **Windows** | **Linux** |
+|--------|---------|-------------|--------|---------|----------|-------------|-----------|-------------|-----------|
+| Status | ☑️      | ✅           | 	☑️    | ✅      | 	❌       | 	❌          | 	❌        | ❌           | ❌         |
+
+> Note: iOS support is experimental and needs feedback
+
+<details>
+
+<summary>In-depth Kotlin targets</summary>
+
+**iOS:** iosArm64, iosSimulatorArm64, iosX64
+
+**JS**: Browser, NodeJS
+
+**tvOS**: tvosArm64, tvosX64, tvosSimulatorArm64
+
+**watchOS**: watchosArm64, watchosX64, watchosSimulatorArm64
+
+**MacOS**: macosX64, macosArm64
+
+**Windows**: mingwX64
+
+**Linux**: linuxX64
+
+</details>
+
 Newest version: [![Maven Central](https://img.shields.io/maven-central/v/io.github.jan-tennert.supabase/supabase-kt)](https://search.maven.org/search?q=g%3Aio.github.jan-tennert.supabase)
 
 # Installation
@@ -32,7 +60,7 @@ val client = createSupabaseClient(
 # Support
 
 Currently, Compose Auth only supports native login for
-Android with Google and iOS with Apple, other variations such as JS rely on fallback which
+Android with Google and iOS with Apple, other variations such as JS and JVM rely on fallback which
 by default is GoTrue-kt OAuth flow.
 
 To learn how you can use this plugin in your compose project, visit [Compose Multiplatform](https://github.com/JetBrains/compose-multiplatform/#readme)

--- a/plugins/ComposeAuth/README.md
+++ b/plugins/ComposeAuth/README.md
@@ -9,6 +9,8 @@ Supported targets:
 | Status | ☑️      | ✅           | 	☑️    | ✅      | 	❌       | 	❌          | 	❌        | ❌           | ❌         |
 
 > Note: iOS support is experimental and needs feedback
+> 
+> ☑️ = Has no support for neither Google and Apple authentication, relies on gotrue-kt for OAuth. 
 
 <details>
 
@@ -30,9 +32,9 @@ Supported targets:
 
 </details>
 
-Newest version: [![Maven Central](https://img.shields.io/maven-central/v/io.github.jan-tennert.supabase/supabase-kt)](https://search.maven.org/search?q=g%3Aio.github.jan-tennert.supabase)
-
 # Installation
+
+Newest version: [![](https://img.shields.io/github/release/supabase-community/supabase-kt?label=)](https://github.com/supabase-community/supabase-kt/releases)
 
 ```kotlin
 dependencies {

--- a/plugins/ComposeAuthUI/README.md
+++ b/plugins/ComposeAuthUI/README.md
@@ -2,6 +2,32 @@
 
 Extends Supabase-kt with UI composables
 
+Supported targets:
+
+| Target | **JVM** | **Android** | **JS** | **iOS** | **tvOS** | **watchOS** | **macOS** | **Windows** | **Linux** |
+|--------|---------|-------------|--------|---------|----------|-------------|-----------|-------------|-----------|
+| Status | ✅       | ✅           | ✅      | ✅       | ❌        | ❌           | ❌         | ❌           | ❌         |
+
+<details>
+
+<summary>In-depth Kotlin targets</summary>
+
+**iOS:** iosArm64, iosSimulatorArm64, iosX64
+
+**JS**: Browser, NodeJS
+
+**tvOS**: tvosArm64, tvosX64, tvosSimulatorArm64
+
+**watchOS**: watchosArm64, watchosX64, watchosSimulatorArm64
+
+**MacOS**: macosX64, macosArm64
+
+**Windows**: mingwX64
+
+**Linux**: linuxX64
+
+</details>
+
 Newest version: [![Maven Central](https://img.shields.io/maven-central/v/io.github.jan-tennert.supabase/supabase-kt)](https://search.maven.org/search?q=g%3Aio.github.jan-tennert.supabase)
 
 # Installation

--- a/plugins/ComposeAuthUI/README.md
+++ b/plugins/ComposeAuthUI/README.md
@@ -28,9 +28,9 @@ Supported targets:
 
 </details>
 
-Newest version: [![Maven Central](https://img.shields.io/maven-central/v/io.github.jan-tennert.supabase/supabase-kt)](https://search.maven.org/search?q=g%3Aio.github.jan-tennert.supabase)
-
 # Installation
+
+Newest version: [![](https://img.shields.io/github/release/supabase-community/supabase-kt?label=)](https://github.com/supabase-community/supabase-kt/releases)
 
 ```kotlin
 dependencies {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

The Kotlin target support table is on the main README. 

## What is the new behavior?

This table is growing bigger and bigger so I decided to move the Kotlin target support information to the corresponding module READMEs and remove it from the main README. This should make the main README way more readable.

