### PR TITLE
Fix documentation of the BucketApi in the Storage module

### DIFF
--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/Storage.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/Storage.kt
@@ -6,6 +6,7 @@ import io.github.jan.supabase.annotations.SupabaseInternal
 import io.github.jan.supabase.bodyOrNull
 import io.github.jan.supabase.collections.AtomicMutableMap
 import io.github.jan.supabase.exceptions.BadRequestRestException
+import io.github.jan.supabase.exceptions.HttpRequestException
 import io.github.jan.supabase.exceptions.NotFoundRestException
 import io.github.jan.supabase.exceptions.RestException
 import io.github.jan.supabase.exceptions.UnauthorizedRestException
@@ -48,8 +49,9 @@ sealed interface Storage : MainPlugin<Storage.Config> {
 
     /**
      * Creates a new bucket in the storage
-     * @param name the name of the bucket
      * @param id the id of the bucket
+     * @param builder overrides bucket config options (like whether the bucket should be public,
+     * file size limit, etc)
      * @throws RestException or one of its subclasses if receiving an error response
      * @throws HttpRequestTimeoutException if the request timed out
      * @throws HttpRequestException on network related issues
@@ -72,7 +74,7 @@ sealed interface Storage : MainPlugin<Storage.Config> {
     suspend fun retrieveBuckets(): List<Bucket>
 
     /**
-     * Retrieves a bucket by its [id]
+     * Retrieves a bucket by its [bucketId]
      * @throws RestException or one of its subclasses if receiving an error response
      * @throws HttpRequestTimeoutException if the request timed out
      * @throws HttpRequestException on network related issues
@@ -88,7 +90,7 @@ sealed interface Storage : MainPlugin<Storage.Config> {
     suspend fun emptyBucket(bucketId: String)
 
     /**
-     * Deletes a bucket by its [id]
+     * Deletes a bucket by its [bucketId]
      * @throws RestException or one of its subclasses if receiving an error response
      * @throws HttpRequestTimeoutException if the request timed out
      * @throws HttpRequestException on network related issues


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR fixes the following issues in the documentation of the BucketApi in the Storage module:
1. Fix incorrect variable names
2. Add missing import

## What is the current behavior?

The documentation mentions variables that do not exist anymore (e.g. in the `createBucket` method, the documentation mentions a param called `name` that has been replaced with `builder` now)

<img width="1077" alt="Screenshot 2023-11-05 at 1 29 04 PM" src="https://github.com/supabase-community/supabase-kt/assets/46640516/abae2a91-55c2-4f27-8828-8ff6eb41b01a">

## What is the new behavior?

The updated documentation fixes all issues mentioned above, for example:

<img width="384" alt="Screenshot 2023-11-05 at 1 47 16 PM" src="https://github.com/supabase-community/supabase-kt/assets/46640516/1667929d-9115-46db-84b2-a18caf131fa8">