### PR TITLE
Refactor and rename Compose Auth methods

### DIFF
--- a/plugins/ComposeAuth/src/androidMain/kotlin/io/github/jan/supabase/compose/auth/composable/AppleAuth.kt
+++ b/plugins/ComposeAuth/src/androidMain/kotlin/io/github/jan/supabase/compose/auth/composable/AppleAuth.kt
@@ -7,4 +7,4 @@ import io.github.jan.supabase.compose.auth.ComposeAuth
  * Composable for Apple login with default behavior
  */
 @Composable
-actual fun ComposeAuth.rememberLoginWithApple(onResult: (NativeSignInResult) -> Unit, fallback: suspend () -> Unit): NativeSignInState = defaultLoginBehavior(fallback)
+actual fun ComposeAuth.rememberSignInWithApple(onResult: (NativeSignInResult) -> Unit, fallback: suspend () -> Unit): NativeSignInState = defaultLoginBehavior(fallback)

--- a/plugins/ComposeAuth/src/androidMain/kotlin/io/github/jan/supabase/compose/auth/composable/GoogleAuth.kt
+++ b/plugins/ComposeAuth/src/androidMain/kotlin/io/github/jan/supabase/compose/auth/composable/GoogleAuth.kt
@@ -25,7 +25,7 @@ import io.github.jan.supabase.compose.auth.GoogleLoginConfig
 import io.github.jan.supabase.compose.auth.getActivity
 import io.github.jan.supabase.compose.auth.getGoogleIDOptions
 import io.github.jan.supabase.compose.auth.getSignInRequest
-import io.github.jan.supabase.compose.auth.loginWithGoogle
+import io.github.jan.supabase.compose.auth.signInWithGoogle
 import io.github.jan.supabase.gotrue.SignOutScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -37,7 +37,7 @@ import kotlinx.coroutines.tasks.await
  * As of Android 14 Credential Manager is preferred implementation of the SignIn with Google
  */
 @Composable
-actual fun ComposeAuth.rememberLoginWithGoogle(onResult: (NativeSignInResult) -> Unit, fallback: suspend () -> Unit): NativeSignInState {
+actual fun ComposeAuth.rememberSignInWithGoogle(onResult: (NativeSignInResult) -> Unit, fallback: suspend () -> Unit): NativeSignInState {
     return if (android.os.Build.VERSION.SDK_INT > android.os.Build.VERSION_CODES.TIRAMISU) {
         signInWithCM(onResult, fallback)
     } else {
@@ -68,7 +68,7 @@ internal fun ComposeAuth.signInWithCM(onResult: (NativeSignInResult) -> Unit, fa
                     if (result.credential.type == GoogleIdTokenCredential.TYPE_GOOGLE_ID_TOKEN_CREDENTIAL) {
                         try {
                             val googleIdTokenCredential = GoogleIdTokenCredential.createFrom(result.credential.data)
-                            loginWithGoogle(googleIdTokenCredential.idToken)
+                            signInWithGoogle(googleIdTokenCredential.idToken)
                             onResult.invoke(NativeSignInResult.Success)
                         } catch (e: GoogleIdTokenParsingException) {
                             onResult.invoke(
@@ -111,7 +111,7 @@ internal fun ComposeAuth.oneTapSignIn(onResult: (NativeSignInResult) -> Unit, fa
                     val credential =
                         Identity.getSignInClient(context).getSignInCredentialFromIntent(result.data)
                     credential.googleIdToken?.let {
-                        loginWithGoogle(it)
+                        signInWithGoogle(it)
                         onResult.invoke(NativeSignInResult.Success)
                     } ?: run {
                         onResult.invoke(NativeSignInResult.Error("error: idToken is missing"))
@@ -162,7 +162,7 @@ internal fun ComposeAuth.oneTapSignIn(onResult: (NativeSignInResult) -> Unit, fa
  * Composable for Google SignOut with native behavior
  */
 @Composable
-actual fun ComposeAuth.rememberSignOut(signOutScope: SignOutScope): NativeSignInState {
+actual fun ComposeAuth.rememberSignOutWithGoogle(signOutScope: SignOutScope): NativeSignInState {
     val context = LocalContext.current
     return defaultSignOutBehavior(signOutScope) {
         if (android.os.Build.VERSION.SDK_INT > android.os.Build.VERSION_CODES.TIRAMISU) {

--- a/plugins/ComposeAuth/src/appleMain/kotlin/io/github/jan/supabase/compose/auth/composable/AppleAuth.kt
+++ b/plugins/ComposeAuth/src/appleMain/kotlin/io/github/jan/supabase/compose/auth/composable/AppleAuth.kt
@@ -6,7 +6,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import io.github.jan.supabase.compose.auth.AppleLoginConfig
 import io.github.jan.supabase.compose.auth.ComposeAuth
-import io.github.jan.supabase.compose.auth.loginWithApple
+import io.github.jan.supabase.compose.auth.signInWithApple
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import platform.AuthenticationServices.ASAuthorization
@@ -30,7 +30,7 @@ import platform.darwin.NSObject
  * Composable for Apple login with native behavior
  */
 @Composable
-actual fun ComposeAuth.rememberLoginWithApple(
+actual fun ComposeAuth.rememberSignInWithApple(
     onResult: (NativeSignInResult) -> Unit,
     fallback: suspend () -> Unit
 ): NativeSignInState {
@@ -83,7 +83,7 @@ internal fun ComposeAuth.authorizationController(
                     NSUTF8StringEncoding
                 )?.let { idToken ->
                     scope.launch {
-                        loginWithApple(idToken)
+                        signInWithApple(idToken)
                         onResult.invoke(NativeSignInResult.Success)
                     }
                 }

--- a/plugins/ComposeAuth/src/appleMain/kotlin/io/github/jan/supabase/compose/auth/composable/GoogleAuth.kt
+++ b/plugins/ComposeAuth/src/appleMain/kotlin/io/github/jan/supabase/compose/auth/composable/GoogleAuth.kt
@@ -8,10 +8,10 @@ import io.github.jan.supabase.gotrue.SignOutScope
  * Composable for Google login with default behavior
  */
 @Composable
-actual fun ComposeAuth.rememberLoginWithGoogle(onResult: (NativeSignInResult) -> Unit, fallback: suspend () -> Unit): NativeSignInState = defaultLoginBehavior(fallback)
+actual fun ComposeAuth.rememberSignInWithGoogle(onResult: (NativeSignInResult) -> Unit, fallback: suspend () -> Unit): NativeSignInState = defaultLoginBehavior(fallback)
 
 /**
  * Composable for SignOut with default behavior
  */
 @Composable
-actual fun ComposeAuth.rememberSignOut(signOutScope: SignOutScope): NativeSignInState = defaultSignOutBehavior(signOutScope)
+actual fun ComposeAuth.rememberSignOutWithGoogle(signOutScope: SignOutScope): NativeSignInState = defaultSignOutBehavior(signOutScope)

--- a/plugins/ComposeAuth/src/commonMain/kotlin/io/github/jan/supabase/compose/auth/ComposeAuth.kt
+++ b/plugins/ComposeAuth/src/commonMain/kotlin/io/github/jan/supabase/compose/auth/ComposeAuth.kt
@@ -30,7 +30,7 @@ import io.github.jan.supabase.plugins.SupabasePluginProvider
  *
  * then on you screen call
  *  ```kotlin
- *  val action = auth.rememberLoginWithGoogle(
+ *  val action = auth.rememberSignInWithGoogle(
  *     onResult = {
  *        // returns NativeSignInResult
  *     },
@@ -94,7 +94,7 @@ internal class ComposeAuthImpl(
     override val supabaseClient: SupabaseClient,
 ) : ComposeAuth
 
-internal suspend fun ComposeAuth.loginWithGoogle(idToken: String) {
+internal suspend fun ComposeAuth.signInWithGoogle(idToken: String) {
     val config = config.loginConfig["google"] as? GoogleLoginConfig
 
     supabaseClient.auth.signInWith(IDToken) {
@@ -105,7 +105,7 @@ internal suspend fun ComposeAuth.loginWithGoogle(idToken: String) {
     }
 }
 
-internal suspend fun ComposeAuth.loginWithApple(idToken: String) {
+internal suspend fun ComposeAuth.signInWithApple(idToken: String) {
     val config = config.loginConfig["apple"] as? GoogleLoginConfig
 
     supabaseClient.auth.signInWith(IDToken) {

--- a/plugins/ComposeAuth/src/commonMain/kotlin/io/github/jan/supabase/compose/auth/DefaultBehavior.kt
+++ b/plugins/ComposeAuth/src/commonMain/kotlin/io/github/jan/supabase/compose/auth/DefaultBehavior.kt
@@ -1,0 +1,41 @@
+package io.github.jan.supabase.compose.auth
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import io.github.jan.supabase.annotations.SupabaseInternal
+import io.github.jan.supabase.compose.auth.composable.NativeSignInState
+import io.github.jan.supabase.gotrue.SignOutScope
+
+/**
+ * Composable used to Sign Out from GoTrue
+ */
+@Composable
+@SupabaseInternal
+fun ComposeAuth.defaultSignOutBehavior(signOutScope: SignOutScope, nativeSignOut: suspend () -> Unit = {}): NativeSignInState {
+    val state = remember { NativeSignInState() }
+    LaunchedEffect(key1 = state.started) {
+        if (state.started) {
+            nativeSignOut.invoke()
+            signOut(signOutScope)
+            state.reset()
+        }
+    }
+    return state
+}
+
+/**
+ * Composable of default behavior if Native Login is not supported on the platform
+ */
+@Composable
+@SupabaseInternal
+fun defaultLoginBehavior(fallback: suspend () -> Unit): NativeSignInState {
+    val state = remember { NativeSignInState() }
+    LaunchedEffect(key1 = state.started) {
+        if (state.started) {
+            fallback.invoke()
+            state.reset()
+        }
+    }
+    return state
+}

--- a/plugins/ComposeAuth/src/commonMain/kotlin/io/github/jan/supabase/compose/auth/composable/NativeAppleAuth.kt
+++ b/plugins/ComposeAuth/src/commonMain/kotlin/io/github/jan/supabase/compose/auth/composable/NativeAppleAuth.kt
@@ -6,7 +6,14 @@ import io.github.jan.supabase.compose.auth.fallbackLogin
 import io.github.jan.supabase.gotrue.providers.Apple
 
 /**
- * Composable function that implements native Auth flow for Apple login
+ * Composable function that implements Native Auth flow for Apple login
  */
 @Composable
-expect fun ComposeAuth.rememberLoginWithApple(onResult: (NativeSignInResult) -> Unit, fallback: suspend () -> Unit = { fallbackLogin(Apple) }) : NativeSignInState
+expect fun ComposeAuth.rememberSignInWithApple(onResult: (NativeSignInResult) -> Unit, fallback: suspend () -> Unit = { fallbackLogin(Apple) }) : NativeSignInState
+
+/**
+ * Composable function that implements Native Auth flow for Apple login
+ */
+@Composable
+@Deprecated("Use rememberSignInWithApple instead", ReplaceWith("rememberSignInWithApple(onResult, fallback)"), DeprecationLevel.WARNING)
+fun ComposeAuth.rememberLoginWithApple(onResult: (NativeSignInResult) -> Unit, fallback: suspend () -> Unit = { fallbackLogin(Apple) }) : NativeSignInState = rememberSignInWithApple(onResult, fallback)

--- a/plugins/ComposeAuth/src/commonMain/kotlin/io/github/jan/supabase/compose/auth/composable/NativeGoogleAuth.kt
+++ b/plugins/ComposeAuth/src/commonMain/kotlin/io/github/jan/supabase/compose/auth/composable/NativeGoogleAuth.kt
@@ -1,11 +1,8 @@
 package io.github.jan.supabase.compose.auth.composable
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.remember
 import io.github.jan.supabase.compose.auth.ComposeAuth
 import io.github.jan.supabase.compose.auth.fallbackLogin
-import io.github.jan.supabase.compose.auth.signOut
 import io.github.jan.supabase.gotrue.SignOutScope
 import io.github.jan.supabase.gotrue.providers.Google
 
@@ -14,42 +11,20 @@ import io.github.jan.supabase.gotrue.providers.Google
  * @return [NativeSignInState]
  */
 @Composable
-expect fun ComposeAuth.rememberLoginWithGoogle(onResult: (NativeSignInResult) -> Unit = {}, fallback: suspend () -> Unit = { fallbackLogin(Google) }): NativeSignInState
+expect fun ComposeAuth.rememberSignInWithGoogle(onResult: (NativeSignInResult) -> Unit = {}, fallback: suspend () -> Unit = { fallbackLogin(Google) }): NativeSignInState
 
 /**
- * Composable of default behavior if Native Login is not supported on the platform
+ * Composable function what implements Native Google Login flow with default fallback
+ * @return [NativeSignInState]
  */
 @Composable
-fun defaultLoginBehavior(fallback: suspend () -> Unit): NativeSignInState {
-    val state = remember { NativeSignInState() }
-    LaunchedEffect(key1 = state.started) {
-        if (state.started) {
-            fallback.invoke()
-            state.reset()
-        }
-    }
-    return state
-}
+@Deprecated("Use rememberSignInWithGoogle instead", ReplaceWith("rememberSignInWithGoogle(onResult, fallback)"), DeprecationLevel.WARNING)
+fun ComposeAuth.rememberLoginWithGoogle(onResult: (NativeSignInResult) -> Unit = {}, fallback: suspend () -> Unit = { fallbackLogin(Google) }): NativeSignInState = rememberSignInWithGoogle(onResult, fallback)
 
 /**
  * Composable for sign out flow
  * @return [NativeSignInState]
  */
 @Composable
-expect fun ComposeAuth.rememberSignOut(signOutScope: SignOutScope = SignOutScope.LOCAL): NativeSignInState
+expect fun ComposeAuth.rememberSignOutWithGoogle(signOutScope: SignOutScope = SignOutScope.LOCAL): NativeSignInState
 
-/**
- * Composable used to Sign Out from GoTrue
- */
-@Composable
-fun ComposeAuth.defaultSignOutBehavior(signOutScope: SignOutScope, nativeSignOut: suspend () -> Unit = {}): NativeSignInState {
-    val state = remember { NativeSignInState() }
-    LaunchedEffect(key1 = state.started) {
-        if (state.started) {
-            nativeSignOut.invoke()
-            signOut(signOutScope)
-            state.reset()
-        }
-    }
-    return state
-}

--- a/plugins/ComposeAuth/src/commonMain/kotlin/io/github/jan/supabase/compose/auth/composable/NativeSignInResult.kt
+++ b/plugins/ComposeAuth/src/commonMain/kotlin/io/github/jan/supabase/compose/auth/composable/NativeSignInResult.kt
@@ -14,7 +14,7 @@ sealed interface NativeSignInResult {
 
     /**
      *
-     * User canceled or clicked away
+     * User cancelled or clicked away
      *
      */
     data object ClosedByUser : NativeSignInResult

--- a/plugins/ComposeAuth/src/jsMain/kotlin/io/github/jan/supabase/compose/auth/composable/AppleAuth.kt
+++ b/plugins/ComposeAuth/src/jsMain/kotlin/io/github/jan/supabase/compose/auth/composable/AppleAuth.kt
@@ -7,4 +7,4 @@ import io.github.jan.supabase.compose.auth.ComposeAuth
  * Composable for Apple login with default behavior
  */
 @Composable
-actual fun ComposeAuth.rememberLoginWithApple(onResult: (NativeSignInResult) -> Unit, fallback: suspend () -> Unit): NativeSignInState = defaultLoginBehavior(fallback)
+actual fun ComposeAuth.rememberSignInWithApple(onResult: (NativeSignInResult) -> Unit, fallback: suspend () -> Unit): NativeSignInState = defaultLoginBehavior(fallback)

--- a/plugins/ComposeAuth/src/jsMain/kotlin/io/github/jan/supabase/compose/auth/composable/GoogleAuth.kt
+++ b/plugins/ComposeAuth/src/jsMain/kotlin/io/github/jan/supabase/compose/auth/composable/GoogleAuth.kt
@@ -8,10 +8,10 @@ import io.github.jan.supabase.gotrue.SignOutScope
  * Composable for Google login with default behavior
  */
 @Composable
-actual fun ComposeAuth.rememberLoginWithGoogle(onResult: (NativeSignInResult) -> Unit, fallback: suspend () -> Unit): NativeSignInState = defaultLoginBehavior(fallback)
+actual fun ComposeAuth.rememberSignInWithGoogle(onResult: (NativeSignInResult) -> Unit, fallback: suspend () -> Unit): NativeSignInState = defaultLoginBehavior(fallback)
 
 /**
  * Composable for signOut login with default behavior
  */
 @Composable
-actual fun ComposeAuth.rememberSignOut(signOutScope: SignOutScope): NativeSignInState = defaultSignOutBehavior(signOutScope)
+actual fun ComposeAuth.rememberSignOutWithGoogle(signOutScope: SignOutScope): NativeSignInState = defaultSignOutBehavior(signOutScope)

--- a/plugins/ComposeAuth/src/jvmMain/kotlin/io/github/jan/supabase/compose/auth/composable/AppleAuth.kt
+++ b/plugins/ComposeAuth/src/jvmMain/kotlin/io/github/jan/supabase/compose/auth/composable/AppleAuth.kt
@@ -7,4 +7,4 @@ import io.github.jan.supabase.compose.auth.ComposeAuth
  * Composable for Apple login with default behavior
  */
 @Composable
-actual fun ComposeAuth.rememberLoginWithApple(onResult: (NativeSignInResult) -> Unit, fallback: suspend () -> Unit): NativeSignInState = defaultLoginBehavior(fallback)
+actual fun ComposeAuth.rememberSignInWithApple(onResult: (NativeSignInResult) -> Unit, fallback: suspend () -> Unit): NativeSignInState = defaultLoginBehavior(fallback)

--- a/plugins/ComposeAuth/src/jvmMain/kotlin/io/github/jan/supabase/compose/auth/composable/GoogleAuth.kt
+++ b/plugins/ComposeAuth/src/jvmMain/kotlin/io/github/jan/supabase/compose/auth/composable/GoogleAuth.kt
@@ -8,10 +8,10 @@ import io.github.jan.supabase.gotrue.SignOutScope
  * Composable for Google login with default behavior
  */
 @Composable
-actual fun ComposeAuth.rememberLoginWithGoogle(onResult: (NativeSignInResult) -> Unit, fallback: suspend () -> Unit): NativeSignInState = defaultLoginBehavior(fallback)
+actual fun ComposeAuth.rememberSignInWithGoogle(onResult: (NativeSignInResult) -> Unit, fallback: suspend () -> Unit): NativeSignInState = defaultLoginBehavior(fallback)
 
 /**
  * Composable for SignOut with default behavior
  */
 @Composable
-actual fun ComposeAuth.rememberSignOut(signOutScope: SignOutScope): NativeSignInState = defaultSignOutBehavior(signOutScope)
+actual fun ComposeAuth.rememberSignOutWithGoogle(signOutScope: SignOutScope): NativeSignInState = defaultSignOutBehavior(signOutScope)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

Compose Auth has these three public methods:
- `ComposeAuth#rememberLoginWithGoogle`
- `ComposeAuth#rememberLoginWithApple`
- `ComposeAuth#rememberSignOut`

## What is the new behavior?

These methods have been renamed:
- `ComposeAuth#rememberSignInWithGoogle` (old one deprecated)
- `ComposeAuth#rememberSignInWithApple` (old one deprecated)
- `ComposeAuth#rememberSignOutWithGoogle`

and some internal improvements
