### PR TITLE
Add "from" extension function to the SupabaseClient

### DIFF
--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/Postgrest.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/Postgrest.kt
@@ -99,3 +99,16 @@ sealed interface Postgrest : MainPlugin<Postgrest.Config>, CustomSerializationPl
  */
 val SupabaseClient.postgrest: Postgrest
     get() = pluginManager.getPlugin(Postgrest)
+
+/**
+ * Creates a new [PostgrestBuilder] for the given table
+ * @param table The table to use for the requests
+ */
+fun SupabaseClient.from(table: String): PostgrestBuilder = pluginManager.getPlugin(Postgrest).from(table)
+
+/**
+ * Creates a new [PostgrestBuilder] for the given schema and table
+ * @param schema The schema to use for the requests
+ * @param table The table to use for the requests
+ */
+fun SupabaseClient.from(schema: String, table: String): PostgrestBuilder = pluginManager.getPlugin(Postgrest).from(schema, table)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature (see #346)

## What is the current behavior?

You can only make postgrest requests through `supabase.postgrest.from("table")`

## What is the new behavior?

You can now also use the new extension function which allows this: `supabase.from("table")`

