### PR TITLE
Refactor Realtime methods to match other client libraries

### DIFF
--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/Realtime.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/Realtime.kt
@@ -96,6 +96,7 @@ sealed interface Realtime : MainPlugin<Realtime.Config>, CustomSerializationPlug
      * @property disconnectOnSessionLoss Whether to disconnect from the websocket when the session is lost. Defaults to true
      * @property reconnectDelay The delay between reconnect attempts. Defaults to 7 seconds
      * @property heartbeatInterval The interval between heartbeat messages. Defaults to 15 seconds
+     * @property connectOnSubscribe Whether to connect to the websocket when subscribing to a channel. Defaults to true
      * @property serializer A serializer used for serializing/deserializing objects e.g. in [PresenceAction.decodeJoinsAs] or [RealtimeChannel.broadcast]. Defaults to [KotlinXSerializer]
      */
     data class Config(

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/Realtime.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/Realtime.kt
@@ -106,6 +106,7 @@ sealed interface Realtime : MainPlugin<Realtime.Config>, CustomSerializationPlug
         override var customUrl: String? = null,
         override var jwtToken: String? = null,
         var disconnectOnSessionLoss: Boolean = true,
+        var connectOnSubscribe: Boolean = true,
     ): MainConfig, CustomSerializationConfig {
 
         override var serializer: SupabaseSerializer? = null
@@ -149,7 +150,15 @@ sealed interface Realtime : MainPlugin<Realtime.Config>, CustomSerializationPlug
 /**
  * Creates a new [RealtimeChannel]
  */
+@Deprecated("Use channel instead", ReplaceWith("channel(channelId, builder)", "io.github.jan.supabase.realtime"))
 inline fun Realtime.createChannel(channelId: String, builder: RealtimeChannelBuilder.() -> Unit = {}): RealtimeChannel {
+    return RealtimeChannelBuilder("realtime:$channelId", this as RealtimeImpl).apply(builder).build()
+}
+
+/**
+ * Creates a new [RealtimeChannel]
+ */
+inline fun Realtime.channel(channelId: String, builder: RealtimeChannelBuilder.() -> Unit = {}): RealtimeChannel {
     return RealtimeChannelBuilder("realtime:$channelId", this as RealtimeImpl).apply(builder).build()
 }
 
@@ -158,3 +167,8 @@ inline fun Realtime.createChannel(channelId: String, builder: RealtimeChannelBui
  */
 val SupabaseClient.realtime: Realtime
     get() = pluginManager.getPlugin(Realtime)
+
+/**
+ * Creates a new [RealtimeChannel]
+ */
+inline fun SupabaseClient.channel(channelId: String, builder: RealtimeChannelBuilder.() -> Unit = {}): RealtimeChannel = realtime.channel(channelId, builder)

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeChannel.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeChannel.kt
@@ -39,6 +39,7 @@ sealed interface RealtimeChannel {
      * Joins the channel
      * @param blockUntilJoined if true, the method will block until the [status] is [Status.JOINED]
      */
+    @Deprecated("Use subscribe instead", ReplaceWith("subscribe(blockUntilJoined)"))
     suspend fun join(blockUntilJoined: Boolean = false) = subscribe(blockUntilJoined)
 
     /**

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeChannel.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeChannel.kt
@@ -39,7 +39,13 @@ sealed interface RealtimeChannel {
      * Joins the channel
      * @param blockUntilJoined if true, the method will block until the [status] is [Status.JOINED]
      */
-    suspend fun join(blockUntilJoined: Boolean = false)
+    suspend fun join(blockUntilJoined: Boolean = false) = subscribe(blockUntilJoined)
+
+    /**
+     * Subscribes to the channel
+     * @param blockUntilSubscribed if true, the method will block the coroutine until the [status] is [Status.JOINED]
+     */
+    suspend fun subscribe(blockUntilSubscribed: Boolean = false)
 
     /**
      * Updates the JWT token for this client

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeChannelImpl.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeChannelImpl.kt
@@ -39,7 +39,7 @@ internal class RealtimeChannelImpl(
     private val clientChanges = AtomicMutableList<PostgresJoinConfig>()
     @SupabaseInternal
     override val callbackManager = CallbackManagerImpl(realtimeImpl)
-    private val _status = MutableStateFlow(RealtimeChannel.Status.CLOSED)
+    private val _status = MutableStateFlow(RealtimeChannel.Status.UNSUBSCRIBED)
     override val status = _status.asStateFlow()
 
     override val supabaseClient = realtimeImpl.supabaseClient
@@ -57,8 +57,8 @@ internal class RealtimeChannelImpl(
         realtimeImpl.run {
             addChannel(this@RealtimeChannelImpl)
         }
-        _status.value = RealtimeChannel.Status.JOINING
-        Logger.d { "Joining channel $topic" }
+        _status.value = RealtimeChannel.Status.SUBSCRIBING
+        Logger.d { "Subscribing to channel $topic" }
         val currentJwt = realtimeImpl.config.jwtToken ?: supabaseClient.pluginManager.getPluginOrNull(Auth)?.currentSessionOrNull()?.let {
             if(it.expiresAt > Clock.System.now()) it.accessToken else null
         }
@@ -70,10 +70,10 @@ internal class RealtimeChannelImpl(
                 put("access_token", currentJwt)
             }
         }
-        Logger.d { "Joining realtime socket with body $joinConfigObject" }
+        Logger.d { "Subscribing to channel with body $joinConfigObject" }
         realtimeImpl.ws?.sendSerialized(RealtimeMessage(topic, RealtimeChannel.CHANNEL_EVENT_JOIN, joinConfigObject, null))
         if(blockUntilSubscribed) {
-            status.first { it == RealtimeChannel.Status.JOINED }
+            status.first { it == RealtimeChannel.Status.SUBSCRIBED }
         }
     }
 
@@ -88,15 +88,15 @@ internal class RealtimeChannelImpl(
                 Logger.w { "Received token expired event. This should not happen, please report this warning." }
             }
             RealtimeMessage.EventType.SYSTEM -> {
-                Logger.d { "Joined channel ${message.topic}" }
-                _status.value = RealtimeChannel.Status.JOINED
+                Logger.d { "Subscribed to channel ${message.topic}" }
+                _status.value = RealtimeChannel.Status.SUBSCRIBED
             }
             RealtimeMessage.EventType.POSTGRES_SERVER_CHANGES -> { //check if the server postgres_changes match with the client's and add the given id to the postgres change objects (to identify them later in the events)
                 val serverPostgresChanges = message.payload["response"]?.jsonObject?.get("postgres_changes")?.jsonArray?.let { Json.decodeFromJsonElement<List<PostgresJoinConfig>>(it) } ?: listOf() //server postgres changes
                 callbackManager.setServerChanges(serverPostgresChanges)
-                if(status.value != RealtimeChannel.Status.JOINED) {
+                if(status.value != RealtimeChannel.Status.SUBSCRIBED) {
                     Logger.d { "Joined channel ${message.topic}" }
-                    _status.value = RealtimeChannel.Status.JOINED
+                    _status.value = RealtimeChannel.Status.SUBSCRIBED
                 }
             }
             RealtimeMessage.EventType.POSTGRES_CHANGES -> {
@@ -120,7 +120,7 @@ internal class RealtimeChannelImpl(
                 realtimeImpl.run {
                     deleteChannel(this@RealtimeChannelImpl)
                 }
-                Logger.d { "Left channel ${message.topic}" }
+                Logger.d { "Unsubscribed from channel ${message.topic}" }
             }
             RealtimeMessage.EventType.ERROR -> {
                 Logger.e { "Received an error in channel ${message.topic}. That could be as a result of an invalid access token" }
@@ -137,9 +137,9 @@ internal class RealtimeChannelImpl(
         }
     }
 
-    override suspend fun leave() {
-        _status.value = RealtimeChannel.Status.LEAVING
-        Logger.d { "Leaving channel $topic" }
+    override suspend fun unsubscribe() {
+        _status.value = RealtimeChannel.Status.UNSUBSCRIBING
+        Logger.d { "Unsubscribing from channel $topic" }
         realtimeImpl.ws?.sendSerialized(RealtimeMessage(topic, RealtimeChannel.CHANNEL_EVENT_LEAVE, buildJsonObject {}, null))
     }
 
@@ -151,7 +151,7 @@ internal class RealtimeChannelImpl(
     }
 
     override suspend fun broadcast(event: String, message: JsonObject) {
-        if(status.value != RealtimeChannel.Status.JOINED) {
+        if(status.value != RealtimeChannel.Status.SUBSCRIBED) {
             val response = httpClient.postJson(
                 url = broadcastUrl,
                 body = BroadcastApiBody(listOf(BroadcastApiMessage(subTopic, event, message)))
@@ -179,8 +179,8 @@ internal class RealtimeChannelImpl(
     }
 
     override suspend fun track(state: JsonObject) {
-        if(status.value != RealtimeChannel.Status.JOINED) {
-            error("You can only track your presence after joining the channel. Did you forget to call `channel.join()`?")
+        if(status.value != RealtimeChannel.Status.SUBSCRIBED) {
+            error("You can only track your presence after subscribing to the channel. Did you forget to call `channel.subscribe()`?")
         }
         val payload = buildJsonObject {
             put("type", "presence")


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature (closes #343)

## What is the current behavior?

You create a channel and join it like this:
```kotlin
val channel = supabase.realtime.createChannel("id")
supabase.realtime.connect()
channel.join()
//...
channel.leave()
// or:
supabase.realtime.removeChannel(channel)
```

## What is the new behavior?

This is now done with new renamed methods (the old ones have been deprecated):
```kotlin
val channel = supabase.realtime.channel("id")
//...
channel.subscribe()
//...
channel.unsubscribe()
// or:
supabase.realtime.removeChannel(channel)
```
or
```kotlin
val channel = supabase.channel("id")
//...
channel.subscribe()
//...
channel.unsubscribe()
// or:
supabase.realtime.removeChannel(channel)
```

## Additional context

Calling `subscribe` automatically calls `Realtime#connect` if `Realtime.Config#connectOnSubscribe` is true (which is by default).
`RealtimeChannel.Status` properties have been renamed accordingly.
