### PR TITLE
Refactor SSO Auth

### DIFF
--- a/GoTrue/src/androidMain/kotlin/io/github/jan/supabase/gotrue/providers/builtin/loginWithSSO.kt
+++ b/GoTrue/src/androidMain/kotlin/io/github/jan/supabase/gotrue/providers/builtin/loginWithSSO.kt
@@ -7,13 +7,13 @@ import io.github.jan.supabase.gotrue.deepLink
 import io.github.jan.supabase.gotrue.openUrl
 import io.github.jan.supabase.gotrue.user.UserSession
 
-internal actual suspend fun <Config : SSO.Config> SSO<Config>.loginWithSSO(
+internal actual suspend fun SSO.loginWithSSO(
     supabaseClient: SupabaseClient,
     onSuccess: suspend (UserSession) -> Unit,
     redirectUrl: String?,
-    config: (Config.() -> Unit)?
+    config: (SSO.Config.() -> Unit)?
 ) {
     val gotrueConfig = supabaseClient.auth.config
-    val result = supabaseClient.auth.retrieveSSOUrl(this, redirectUrl ?: gotrueConfig.deepLink, config)
+    val result = supabaseClient.auth.retrieveSSOUrl(redirectUrl ?: gotrueConfig.deepLink) { config?.invoke(this) }
     openUrl(Uri.parse(result.url), gotrueConfig.defaultExternalAuthAction)
 }

--- a/GoTrue/src/appleMain/kotlin/io/github/jan/supabase/gotrue/providers/builtin/loginWithSSO.kt
+++ b/GoTrue/src/appleMain/kotlin/io/github/jan/supabase/gotrue/providers/builtin/loginWithSSO.kt
@@ -7,14 +7,14 @@ import io.github.jan.supabase.gotrue.providers.openUrl
 import io.github.jan.supabase.gotrue.user.UserSession
 import platform.Foundation.NSURL
 
-internal actual suspend fun <Config : SSO.Config> SSO<Config>.loginWithSSO(
+internal actual suspend fun SSO.loginWithSSO(
     supabaseClient: SupabaseClient,
     onSuccess: suspend (UserSession) -> Unit,
     redirectUrl: String?,
-    config: (Config.() -> Unit)?
+    config: (SSO.Config.() -> Unit)?
 ) {
-    val gotrue = supabaseClient.auth
-    val result = supabaseClient.auth.retrieveSSOUrl(this@loginWithSSO, redirectUrl ?: gotrue.config.deepLink, config)
+    val auth = supabaseClient.auth
+    val result = supabaseClient.auth.retrieveSSOUrl(redirectUrl ?: auth.config.deepLink) { config?.invoke(this) }
     val url = NSURL(string = result.url)
     openUrl(url)
 }

--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/Auth.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/Auth.kt
@@ -158,11 +158,10 @@ sealed interface Auth : MainPlugin<AuthConfig>, CustomSerializationPlugin {
 
     /**
      * Retrieves the sso url for the specified [type]
-     * @param type The type of sso to retrieve e.g. [SSO.withDomain] or [SSO.withProvider]
      * @param redirectUrl The redirect url to use
      * @param config The configuration to use
      */
-    suspend fun <Config: SSO.Config> retrieveSSOUrl(type: SSO<Config>, redirectUrl: String? = null, config: (Config.() -> Unit)? = null): SSO.Result
+    suspend fun retrieveSSOUrl(redirectUrl: String? = null, config: SSO.Config.() -> Unit): SSO.Result
 
     /**
      * Modifies the current user

--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/providers/builtin/OTP.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/providers/builtin/OTP.kt
@@ -61,7 +61,10 @@ data object OTP: AuthProvider<OTP.Config, Unit> {
         config: (Config.() -> Unit)?
     ) {
         val otpConfig = Config(supabaseClient.auth.serializer).apply(config ?: {})
+
         require((otpConfig.email != null && otpConfig.email!!.isNotBlank()) || (otpConfig.phone != null && otpConfig.phone!!.isNotBlank())) { "You need to provide either an email or a phone number" }
+        require(!(otpConfig.email != null && otpConfig.phone != null)) { "You can only provide either an email or a phone number" }
+
         val finalRedirectUrl = supabaseClient.auth.generateRedirectUrl(redirectUrl)
         val body = buildJsonObject {
             put("create_user", otpConfig.createUser)

--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/providers/builtin/SSO.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/providers/builtin/SSO.kt
@@ -10,9 +10,6 @@ import kotlinx.serialization.Serializable
  *
  * Check the [docs](https://supabase.com/docs/guides/auth/sso/auth-sso-saml) for more information.
  *
- * Create a new instance with [withDomain] or [withProvider].
- *
- * @param config The config for the SSO provider
  */
 data object SSO: AuthProvider<SSO.Config, Unit> {
 

--- a/GoTrue/src/jsMain/kotlin/io/github/jan/supabase/gotrue/providers/builtin/loginWithSSO.kt
+++ b/GoTrue/src/jsMain/kotlin/io/github/jan/supabase/gotrue/providers/builtin/loginWithSSO.kt
@@ -5,12 +5,12 @@ import io.github.jan.supabase.gotrue.auth
 import io.github.jan.supabase.gotrue.user.UserSession
 import kotlinx.browser.window
 
-internal actual suspend fun <Config : SSO.Config> SSO<Config>.loginWithSSO(
+internal actual suspend fun SSO.loginWithSSO(
     supabaseClient: SupabaseClient,
     onSuccess: suspend (UserSession) -> Unit,
     redirectUrl: String?,
-    config: (Config.() -> Unit)?
+    config: (SSO.Config.() -> Unit)?
 ) {
-    val result = supabaseClient.auth.retrieveSSOUrl(this@loginWithSSO, redirectUrl ?: window.location.origin, config)
+    val result = supabaseClient.auth.retrieveSSOUrl(redirectUrl ?: window.location.origin) { config?.invoke(this) }
     window.location.href = result.url
 }

--- a/GoTrue/src/jvmMain/kotlin/io/github/jan/supabase/gotrue/providers/builtin/loginWithSSO.kt
+++ b/GoTrue/src/jvmMain/kotlin/io/github/jan/supabase/gotrue/providers/builtin/loginWithSSO.kt
@@ -8,16 +8,16 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
-internal actual suspend fun <Config : SSO.Config> SSO<Config>.loginWithSSO(
+internal actual suspend fun SSO.loginWithSSO(
     supabaseClient: SupabaseClient,
     onSuccess: suspend (UserSession) -> Unit,
     redirectUrl: String?,
-    config: (Config.() -> Unit)?
+    config: (SSO.Config.() -> Unit)?
 ) {
     withContext(Dispatchers.IO) {
         launch {
             createServer({
-                val result = supabaseClient.auth.retrieveSSOUrl(this@loginWithSSO, redirectUrl ?: it, config)
+                val result = supabaseClient.auth.retrieveSSOUrl(redirectUrl ?: it) { config?.invoke(this) }
                 result.url
             }, supabaseClient.auth, onSuccess)
         }

--- a/GoTrue/src/linuxMain/kotlin/io/github/jan/supabase/gotrue/providers/builtin/loginWithSSO.kt
+++ b/GoTrue/src/linuxMain/kotlin/io/github/jan/supabase/gotrue/providers/builtin/loginWithSSO.kt
@@ -5,12 +5,12 @@ import io.github.jan.supabase.gotrue.auth
 import io.github.jan.supabase.gotrue.user.UserSession
 import platform.posix.system
 
-internal actual suspend fun <Config : SSO.Config> SSO<Config>.loginWithSSO(
+internal actual suspend fun SSO.loginWithSSO(
     supabaseClient: SupabaseClient,
     onSuccess: suspend (UserSession) -> Unit,
     redirectUrl: String?,
-    config: (Config.() -> Unit)?
+    config: (SSO.Config.() -> Unit)?
 ) {
-    val result = supabaseClient.auth.retrieveSSOUrl(this@loginWithSSO, redirectUrl, config)
+    val result = supabaseClient.auth.retrieveSSOUrl(redirectUrl) { config?.invoke(this) }
     system("xdg-open ${result.url}")
 }

--- a/GoTrue/src/mingwX64Main/kotlin/io/github/jan/supabase/gotrue/providers/builtin/loginWithSSO.kt
+++ b/GoTrue/src/mingwX64Main/kotlin/io/github/jan/supabase/gotrue/providers/builtin/loginWithSSO.kt
@@ -8,12 +8,12 @@ import platform.windows.SW_SHOWNORMAL
 import platform.windows.ShellExecuteW
 
 @OptIn(ExperimentalForeignApi::class)
-internal actual suspend fun <Config : SSO.Config> SSO<Config>.loginWithSSO(
+internal actual suspend fun SSO.loginWithSSO(
     supabaseClient: SupabaseClient,
     onSuccess: suspend (UserSession) -> Unit,
     redirectUrl: String?,
-    config: (Config.() -> Unit)?
+    config: (SSO.Config.() -> Unit)?
 ) {
-    val result = supabaseClient.auth.retrieveSSOUrl(this@loginWithSSO, redirectUrl, config)
+    val result = supabaseClient.auth.retrieveSSOUrl(redirectUrl) { config?.invoke(this) }
     ShellExecuteW(null, "open", result.url, null, null, SW_SHOWNORMAL);
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

You can sign in with SSO like this:
```kotlin
supabase.auth.signInWith(SSO.withDomain("domain"))
```

## What is the new behavior?

This has been changed to match other auth providers:
```kotlin
supabase.auth.signInWith(SSO) {
    domain = "domain"
}
```
