### PR TITLE
Rename sendRecoveryEmail method and add PKCE support

### DIFF
--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/Auth.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/Auth.kt
@@ -171,12 +171,12 @@ sealed interface Auth : MainPlugin<AuthConfig>, CustomSerializationPlugin {
     /**
      * Sends a password reset email to the user with the specified [email]
      * @param email The email to send the password reset email to
-     * @param redirectUrl The redirect url to use. If you don't specify this, the platform specific will be use, like deeplinks on android.
+     * @param redirectUrl The redirect url to use. If you don't specify this, the platform specific will be used, like deeplinks on android.
      * @throws RestException or one of its subclasses if receiving an error response
      * @throws HttpRequestTimeoutException if the request timed out
      * @throws HttpRequestException on network related issues
      */
-    suspend fun sendRecoveryEmail(email: String, redirectUrl: String? = null, captchaToken: String? = null)
+    suspend fun resetPasswordForEmail(email: String, redirectUrl: String? = null, captchaToken: String? = null)
 
     /**
      * Sends a nonce to the user's email (preferred) or phone

--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/AuthImpl.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/AuthImpl.kt
@@ -214,18 +214,31 @@ internal class AuthImpl(
         }
     }
 
-    override suspend fun sendRecoveryEmail(
+    override suspend fun resetPasswordForEmail(
         email: String,
         redirectUrl: String?,
         captchaToken: String?
     ) {
+        require(email.isNotBlank()) {
+            "Email must not be blank"
+        }
         val finalRedirectUrl = generateRedirectUrl(redirectUrl)
+        var codeChallenge: String? = null
+        if (this.config.flowType == FlowType.PKCE) {
+            val codeVerifier = generateCodeVerifier()
+            codeVerifierCache.saveCodeVerifier(codeVerifier)
+            codeChallenge = generateCodeChallenge(codeVerifier)
+        }
         val body = buildJsonObject {
             put("email", email)
             captchaToken?.let {
                 putJsonObject("gotrue_meta_security") {
                     put("captcha_token", captchaToken)
                 }
+            }
+            codeChallenge?.let {
+                put("code_challenge", it)
+                put("code_challenge_method", "s256")
             }
         }.toString()
         api.postJson("recover", body) {

--- a/GoTrue/src/commonTest/kotlin/GoTrueTest.kt
+++ b/GoTrue/src/commonTest/kotlin/GoTrueTest.kt
@@ -236,7 +236,7 @@ class GoTrueTest {
     fun test_recovery() {
         val client = createSupabaseClient()
         runTest(dispatcher) {
-            client.auth.sendRecoveryEmail("example@email.com")
+            client.auth.resetPasswordForEmail("example@email.com")
             client.close()
         }
     }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

The method is named `sendRecoveryEmail` and does not support PKCE

## What is the new behavior?

The method was renamed to `resetPasswordForEmail` to match the JS Client library. PKCE support was also added.
