### PR TITLE
Add support for linking identities

### DIFF
--- a/GoTrue/src/appleMain/kotlin/io/github/jan/supabase/gotrue/Utils.apple.kt
+++ b/GoTrue/src/appleMain/kotlin/io/github/jan/supabase/gotrue/Utils.apple.kt
@@ -1,0 +1,9 @@
+package io.github.jan.supabase.gotrue
+
+import io.github.jan.supabase.SupabaseClient
+import io.github.jan.supabase.gotrue.providers.openUrl
+import platform.Foundation.NSURL
+
+internal actual suspend fun SupabaseClient.openExternalUrl(url: String) {
+    openUrl(NSURL(url))
+}

--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/Auth.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/Auth.kt
@@ -125,6 +125,16 @@ sealed interface Auth : MainPlugin<AuthConfig>, CustomSerializationPlugin {
         config: (C.() -> Unit)? = null
     )
 
+    suspend fun linkIdentity(
+        provider: OAuthProvider,
+        redirectUrl: String? = null,
+        config: ExternalAuthConfigDefaults.() -> Unit = {}
+    )
+
+    suspend fun unlinkIdentity(
+        identityId: String
+    )
+
     /**
      * Retrieves the sso url for the specified [type]
      * @param redirectUrl The redirect url to use
@@ -294,7 +304,7 @@ sealed interface Auth : MainPlugin<AuthConfig>, CustomSerializationPlugin {
      * @param provider The provider to use
      * @param redirectUrl The redirect url to use
      */
-    fun oAuthUrl(provider: OAuthProvider, redirectUrl: String? = null, additionalConfig: ExternalAuthConfigDefaults.() -> Unit = {}): String
+    fun oAuthUrl(provider: OAuthProvider, redirectUrl: String? = null, url: String = "authorize", additionalConfig: ExternalAuthConfigDefaults.() -> Unit = {}): String
 
     /**
      * Stops auto-refreshing the current session

--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/Utils.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/Utils.kt
@@ -1,6 +1,7 @@
 package io.github.jan.supabase.gotrue
 
 import co.touchlab.kermit.Logger
+import io.github.jan.supabase.SupabaseClient
 import io.github.jan.supabase.annotations.SupabaseInternal
 import io.github.jan.supabase.gotrue.user.UserSession
 import io.ktor.client.request.HttpRequestBuilder
@@ -25,3 +26,5 @@ fun HttpRequestBuilder.redirectTo(url: String) {
 }
 
 internal fun invalidArg(message: String): Nothing = throw IllegalArgumentException(message)
+
+internal expect suspend fun SupabaseClient.openExternalUrl(url: String)

--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/user/Identity.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/user/Identity.kt
@@ -5,21 +5,24 @@ package io.github.jan.supabase.gotrue.user
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
 
 @Serializable
 data class Identity(
-    @SerialName("created_at")
-    val createdAt: String,
     @SerialName("id")
     val id: String,
     @SerialName("identity_data")
-    val identityData: Map<String, JsonElement>,
+    val identityData: JsonObject,
+    @SerialName("identity_id")
+    val identityId: String,
     @SerialName("last_sign_in_at")
     val lastSignInAt: String? = null,
+    @SerialName("updated_at")
+    val updatedAt: String? = null,
+    @SerialName("created_at")
+    val createdAt: String? = null,
     @SerialName("provider")
     val provider: String,
-    @SerialName("updated_at")
-    val updatedAt: String,
     @SerialName("user_id")
     val userId: String
 )

--- a/GoTrue/src/jsMain/kotlin/io/github/jan/supabase/gotrue/Utils.js.kt
+++ b/GoTrue/src/jsMain/kotlin/io/github/jan/supabase/gotrue/Utils.js.kt
@@ -1,0 +1,8 @@
+package io.github.jan.supabase.gotrue
+
+import io.github.jan.supabase.SupabaseClient
+import kotlinx.browser.window
+
+internal actual suspend fun SupabaseClient.openExternalUrl(url: String) {
+    window.location.href = url
+}

--- a/GoTrue/src/jvmMain/kotlin/io/github/jan/supabase/gotrue/Utils.jvm.kt
+++ b/GoTrue/src/jvmMain/kotlin/io/github/jan/supabase/gotrue/Utils.jvm.kt
@@ -1,0 +1,14 @@
+package io.github.jan.supabase.gotrue
+
+import io.github.jan.supabase.SupabaseClient
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.awt.Desktop
+import java.net.URI
+
+internal actual suspend fun SupabaseClient.openExternalUrl(url: String) {
+    withContext(Dispatchers.IO) {
+        Desktop.getDesktop()
+            .browse(URI(url))
+    }
+}

--- a/GoTrue/src/linuxMain/kotlin/io/github/jan/supabase/gotrue/Utils.linux.kt
+++ b/GoTrue/src/linuxMain/kotlin/io/github/jan/supabase/gotrue/Utils.linux.kt
@@ -1,0 +1,8 @@
+package io.github.jan.supabase.gotrue
+
+import io.github.jan.supabase.SupabaseClient
+import platform.posix.system
+
+internal actual suspend fun SupabaseClient.openExternalUrl(url: String) {
+    system("xdg-open $url")
+}

--- a/GoTrue/src/mingwMain/kotlin/io/github/jan/supabase/gotrue/Utils.mingw.kt
+++ b/GoTrue/src/mingwMain/kotlin/io/github/jan/supabase/gotrue/Utils.mingw.kt
@@ -1,0 +1,11 @@
+package io.github.jan.supabase.gotrue
+
+import io.github.jan.supabase.SupabaseClient
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.windows.SW_SHOWNORMAL
+import platform.windows.ShellExecuteW
+
+@OptIn(ExperimentalForeignApi::class)
+internal actual suspend fun SupabaseClient.openExternalUrl(url: String) {
+    ShellExecuteW(null, "open", url, null, null, SW_SHOWNORMAL);
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

N/A

## What is the new behavior?

Adds two new methods: `linkIdentity`, `unlinkIdentity` (which adds new identities to signed-in users)
Example:
```kotlin
supabase.auth.linkIdentity(Google) //Works the same as signInWith(Google) under the hood
supabase.auth.unlinkIdentity("identity-id")
```

## Additional context

See https://github.com/supabase/gotrue-js/pull/814
