### PR TITLE
Fix crash when uploading data using Android URIs

### DIFF
--- a/Storage/src/androidMain/kotlin/io/github/jan/supabase/storage/AndroidUtils.kt
+++ b/Storage/src/androidMain/kotlin/io/github/jan/supabase/storage/AndroidUtils.kt
@@ -1,5 +1,6 @@
 package io.github.jan.supabase.storage
 
+import android.annotation.SuppressLint
 import android.net.Uri
 import io.ktor.utils.io.ByteReadChannel
 import io.ktor.utils.io.jvm.javaio.toByteReadChannel
@@ -59,10 +60,9 @@ suspend fun BucketApi.update(path: String, uri: Uri, upsert: Boolean = false) = 
  */
 fun BucketApi.updateAsFlow(path: String, uri: Uri, upsert: Boolean = false) = updateAsFlow(path, UploadData(uri.readChannel(), uri.contentSize), upsert)
 
+@SuppressLint("Recycle") //toByteReadChannel closes the input stream automatically
 private fun Uri.readChannel(): ByteReadChannel {
     val context = applicationContext()
     val inputStream = context.contentResolver.openInputStream(this) ?: throw IllegalArgumentException("Uri is not readable")
-    return inputStream.use {
-        it.toByteReadChannel()
-    }
+    return inputStream.toByteReadChannel()
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (closes #370)

## What is the current behavior?

Uploading data using an Android URI crashes due to the input stream being closes before data is read.

## What is the new behavior?

This is fixed.
