### PR TITLE
Fix CM automatically triggering

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,4 +10,4 @@ kotlin.experimental.tryK2=false
 org.jetbrains.compose.experimental.uikit.enabled=true
 org.jetbrains.compose.experimental.jscanvas.enabled=true
 
-supabase-version = 2.0.1
+supabase-version = 2.0.2-dev

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,4 +10,4 @@ kotlin.experimental.tryK2=false
 org.jetbrains.compose.experimental.uikit.enabled=true
 org.jetbrains.compose.experimental.jscanvas.enabled=true
 
-supabase-version = 2.0.2-dev
+supabase-version = 2.0.2

--- a/plugins/ComposeAuth/src/androidMain/kotlin/io/github/jan/supabase/compose/auth/composable/GoogleAuth.kt
+++ b/plugins/ComposeAuth/src/androidMain/kotlin/io/github/jan/supabase/compose/auth/composable/GoogleAuth.kt
@@ -91,10 +91,10 @@ internal fun ComposeAuth.signInWithCM(onResult: (NativeSignInResult) -> Unit, fa
                             onResult.invoke(NativeSignInResult.Error("error: unexpected type of credential"))
                         }
                     }
-
-                    else -> onResult.invoke(NativeSignInResult.Error("error: unsupported credentials"))
+                    else -> {
+                        onResult.invoke(NativeSignInResult.Error("error: unsupported credentials"))
+                    }
                 }
-
             } catch (e: GetCredentialException) {
                 when (e) {
                     is GetCredentialCancellationException -> onResult.invoke(NativeSignInResult.ClosedByUser)
@@ -104,6 +104,8 @@ internal fun ComposeAuth.signInWithCM(onResult: (NativeSignInResult) -> Unit, fa
                         )
                     )
                 }
+            } finally {
+                state.reset()
             }
         }
     }

--- a/plugins/ComposeAuth/src/androidMain/kotlin/io/github/jan/supabase/compose/auth/composable/GoogleAuth.kt
+++ b/plugins/ComposeAuth/src/androidMain/kotlin/io/github/jan/supabase/compose/auth/composable/GoogleAuth.kt
@@ -90,8 +90,7 @@ internal fun ComposeAuth.signInWithCM(onResult: (NativeSignInResult) -> Unit, fa
                         } else {
                             onResult.invoke(NativeSignInResult.Error("error: unexpected type of credential"))
                         }
-                    }
-                    else -> {
+                    } else -> {
                         onResult.invoke(NativeSignInResult.Error("error: unsupported credentials"))
                     }
                 }

--- a/plugins/ComposeAuth/src/androidMain/kotlin/io/github/jan/supabase/compose/auth/composable/GoogleAuth.kt
+++ b/plugins/ComposeAuth/src/androidMain/kotlin/io/github/jan/supabase/compose/auth/composable/GoogleAuth.kt
@@ -20,6 +20,7 @@ import com.google.android.gms.common.api.ApiException
 import com.google.android.gms.common.api.CommonStatusCodes
 import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
 import com.google.android.libraries.identity.googleid.GoogleIdTokenParsingException
+import io.github.jan.supabase.annotations.SupabaseInternal
 import io.github.jan.supabase.compose.auth.ComposeAuth
 import io.github.jan.supabase.compose.auth.GoogleLoginConfig
 import io.github.jan.supabase.compose.auth.defaultSignOutBehavior
@@ -56,46 +57,55 @@ internal fun ComposeAuth.signInWithCM(onResult: (NativeSignInResult) -> Unit, fa
     val context = LocalContext.current
 
     LaunchedEffect(key1 = state.started){
-        val activity = context.getActivity()
+        if (state.started) {
+            val activity = context.getActivity()
 
-        if (activity == null || config.loginConfig["google"] == null) {
-            fallback.invoke()
-            state.reset()
-            return@LaunchedEffect
-        }
+            if (activity == null || config.loginConfig["google"] == null) {
+                fallback.invoke()
+                state.reset()
+                return@LaunchedEffect
+            }
 
-        try {
-            val request = GetCredentialRequest.Builder().addCredentialOption(getGoogleIDOptions(config.loginConfig["google"] as? GoogleLoginConfig)).build()
-            val result = CredentialManager.create(context).getCredential(activity, request)
+            try {
+                val request = GetCredentialRequest.Builder()
+                    .addCredentialOption(getGoogleIDOptions(config.loginConfig["google"] as? GoogleLoginConfig))
+                    .build()
+                val result = CredentialManager.create(context).getCredential(activity, request)
 
-            when (result.credential) {
-                is CustomCredential -> {
-                    if (result.credential.type == GoogleIdTokenCredential.TYPE_GOOGLE_ID_TOKEN_CREDENTIAL) {
-                        try {
-                            val googleIdTokenCredential = GoogleIdTokenCredential.createFrom(result.credential.data)
-                            signInWithGoogle(googleIdTokenCredential.idToken)
-                            onResult.invoke(NativeSignInResult.Success)
-                        } catch (e: GoogleIdTokenParsingException) {
-                            onResult.invoke(
-                                NativeSignInResult.Error(
-                                    e.localizedMessage ?: "error: google id parsing exception"
+                when (result.credential) {
+                    is CustomCredential -> {
+                        if (result.credential.type == GoogleIdTokenCredential.TYPE_GOOGLE_ID_TOKEN_CREDENTIAL) {
+                            try {
+                                val googleIdTokenCredential =
+                                    GoogleIdTokenCredential.createFrom(result.credential.data)
+                                signInWithGoogle(googleIdTokenCredential.idToken)
+                                onResult.invoke(NativeSignInResult.Success)
+                            } catch (e: GoogleIdTokenParsingException) {
+                                onResult.invoke(
+                                    NativeSignInResult.Error(
+                                        e.localizedMessage ?: "error: google id parsing exception"
+                                    )
                                 )
-                            )
+                            }
+                        } else {
+                            onResult.invoke(NativeSignInResult.Error("error: unexpected type of credential"))
                         }
-                    } else {
-                        onResult.invoke(NativeSignInResult.Error("error: unexpected type of credential"))
                     }
-                }
-                else -> onResult.invoke(NativeSignInResult.Error("error: unsupported credentials"))
-            }
 
-        } catch (e: GetCredentialException) {
-            when(e){
-                is GetCredentialCancellationException -> onResult.invoke(NativeSignInResult.ClosedByUser)
-                else -> onResult.invoke(NativeSignInResult.Error(e.localizedMessage ?: "error: getCredentialException"))
+                    else -> onResult.invoke(NativeSignInResult.Error("error: unsupported credentials"))
+                }
+
+            } catch (e: GetCredentialException) {
+                when (e) {
+                    is GetCredentialCancellationException -> onResult.invoke(NativeSignInResult.ClosedByUser)
+                    else -> onResult.invoke(
+                        NativeSignInResult.Error(
+                            e.localizedMessage ?: "error: getCredentialException"
+                        )
+                    )
+                }
             }
         }
-
     }
 
     return state
@@ -166,6 +176,7 @@ internal fun ComposeAuth.oneTapSignIn(onResult: (NativeSignInResult) -> Unit, fa
 /**
  * Composable for Google SignOut with native behavior
  */
+@OptIn(SupabaseInternal::class)
 @Composable
 actual fun ComposeAuth.rememberSignOutWithGoogle(signOutScope: SignOutScope): NativeSignInState {
     val context = LocalContext.current


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (closes #394)

## What is the current behavior?

Compose Auth automatically triggers the CM flow without calling `startFlow`.

## What is the new behavior?

This should now be fixed.