### PR TITLE
Fix Github test workflow running duplicate tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -120,7 +120,7 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Test supabase-kt
-        run: ./gradlew tvosX64Test tvosSimulatorArm64Test macosX64Test --stacktrace
+        run: ./gradlew tvosX64Test tvosSimulatorArm64Test --stacktrace
   testWatchOS:
     runs-on: macos-latest
     steps:
@@ -142,7 +142,7 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Test supabase-kt
-        run: ./gradlew watchosX64Test watchosSimulatorArm64Test macosX64Test --stacktrace
+        run: ./gradlew watchosX64Test watchosSimulatorArm64Test --stacktrace
   testWindows:
     runs-on: windows-latest
     steps:


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix

## What is the current behavior?

The macosX64 test is getting ran in `testTvOS` and `testWatchOS`.

## What is the new behavior?

This has been fixed.

