### PR TITLE
Fix textSearch method making an invalid query

### DIFF
--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/filter/PostgrestFilterBuilder.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/filter/PostgrestFilterBuilder.kt
@@ -203,7 +203,7 @@ class PostgrestFilterBuilder(
      */
     fun textSearch(column: String, query: String, textSearchType: TextSearchType, config: String? = null): PostgrestFilterBuilder {
         val configPart = if (config === null) "" else "(${config})"
-        _params[column] = listOf("${textSearchType.identifier}${configPart}.${query}")
+        _params[column] = listOf("${textSearchType.identifier}fts${configPart}.${query}")
         return this
     }
 

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/filter/TextSearchType.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/filter/TextSearchType.kt
@@ -9,8 +9,8 @@ package io.github.jan.supabase.postgrest.query.filter
  * Used to search rows using a full text search. See [Postgrest](https://postgrest.org/en/stable/api.html#full-text-search) for more information
  */
 enum class TextSearchType(val identifier: String) {
-    TSVECTOR("tsvector"),
-    PLAINTO("plainto"),
-    PHRASETO("phraseto"),
-    WEBSEARCH("websearch")
+    NONE(""),
+    PLAINTO("pl"),
+    PHRASETO("ph"),
+    WEBSEARCH("w")
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,4 +10,4 @@ kotlin.experimental.tryK2=false
 org.jetbrains.compose.experimental.uikit.enabled=true
 org.jetbrains.compose.experimental.jscanvas.enabled=true
 
-supabase-version = 2.0.3-dev
+supabase-version = 2.0.3

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,4 +10,4 @@ kotlin.experimental.tryK2=false
 org.jetbrains.compose.experimental.uikit.enabled=true
 org.jetbrains.compose.experimental.jscanvas.enabled=true
 
-supabase-version = 2.0.2
+supabase-version = 2.0.3-dev


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (closes #407)

## What is the current behavior?

The `PostgrestFilterBuilder#textSearch` method produces an invalid query.

## What is the new behavior?

This should have been fixed.

## Additional context

See #407 and #408
