### PR TITLE
Fix crash when parsing params after hash in URL

### DIFF
--- a/GoTrue/src/jsMain/kotlin/io/github/jan/supabase/gotrue/setupPlatform.kt
+++ b/GoTrue/src/jsMain/kotlin/io/github/jan/supabase/gotrue/setupPlatform.kt
@@ -14,7 +14,15 @@ actual fun Auth.setupPlatform() {
 
     fun checkForHash() {
         if(window.location.hash.isBlank()) return
-        val map = window.location.hash.substring(1).split("&").associate {
+
+        val afterHash = window.location.hash.substring(1)
+
+        if(!afterHash.contains('=')) {
+            // No params after hash, no need to continue
+            return
+        }
+
+        val map = afterHash.split("&").associate {
             it.split("=").let { pair ->
                 pair[0] to pair[1]
             }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix ( closes #411 )

## What is the current behavior?

Application crashes with an IndexOutOfBoundsException when navigating to a URL containing a hash but not parameters.
Example from the issue : http://www.mysite.com/#/users

## What is the new behavior?

The application doesn't crash when the value after the hash does not contain any param.

## Additional context

This will happen for sure when using hash based navigation.
