### PR TITLE
Automatically disconnect from realtime websocket

### DIFF
--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/Realtime.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/Realtime.kt
@@ -93,6 +93,7 @@ sealed interface Realtime : MainPlugin<Realtime.Config>, CustomSerializationPlug
      * @property reconnectDelay The delay between reconnect attempts. Defaults to 7 seconds
      * @property heartbeatInterval The interval between heartbeat messages. Defaults to 15 seconds
      * @property connectOnSubscribe Whether to connect to the websocket when subscribing to a channel. Defaults to true
+     * @property disconnectOnNoSubscriptions Whether to disconnect from the websocket when there are no more subscriptions. Defaults to true
      * @property serializer A serializer used for serializing/deserializing objects e.g. in [PresenceAction.decodeJoinsAs] or [RealtimeChannel.broadcast]. Defaults to [KotlinXSerializer]
      */
     data class Config(
@@ -104,6 +105,7 @@ sealed interface Realtime : MainPlugin<Realtime.Config>, CustomSerializationPlug
         override var jwtToken: String? = null,
         var disconnectOnSessionLoss: Boolean = true,
         var connectOnSubscribe: Boolean = true,
+        var disconnectOnNoSubscriptions: Boolean = true,
     ): MainConfig, CustomSerializationConfig {
 
         override var serializer: SupabaseSerializer? = null

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeImpl.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeImpl.kt
@@ -189,6 +189,10 @@ internal class RealtimeImpl(override val supabaseClient: SupabaseClient, overrid
             channel.unsubscribe()
         }
         _subscriptions.remove(channel.topic)
+        if(subscriptions.isEmpty() && config.disconnectOnNoSubscriptions) {
+            Logger.d { "No more subscriptions, disconnecting from realtime websocket" }
+            disconnect()
+        }
     }
 
     @SupabaseInternal
@@ -203,6 +207,10 @@ internal class RealtimeImpl(override val supabaseClient: SupabaseClient, overrid
             }
         }
         _subscriptions.clear()
+        if(config.disconnectOnNoSubscriptions) {
+            Logger.d { "No more subscriptions, disconnecting from realtime websocket" }
+            disconnect()
+        }
     }
 
     @SupabaseInternal


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature/Bug fix

## What is the current behavior?

Once subscribing to a realtime channel, there will be no automatic disconnect, so you have to execute `Realtime#disconnect` yourself.

## What is the new behavior?

If there is no channel cached within realtime, it will automatically disconnect from the websocket. (Channels get removed via `Realtime#removeChannel` and `Realtime#removeAllChannels`). You can change this behaviour in the config.