### PR TITLE
Fix small realtime documentation issue

### DIFF
--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeChannel.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeChannel.kt
@@ -37,7 +37,7 @@ sealed interface RealtimeChannel {
 
     /**
      * Subscribes to the channel
-     * @param blockUntilSubscribed if true, the method will block the coroutine until the [status] is [Status.JOINED]
+     * @param blockUntilSubscribed if true, the method will block the coroutine until the [status] is [Status.SUBSCRIBED]
      */
     suspend fun subscribe(blockUntilSubscribed: Boolean = false)
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

The docs refer to the old status name

## What is the new behavior?

This has been fixed.
