### PR TITLE
User filter in realtime list data flow initial value

### DIFF
--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeExt.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeExt.kt
@@ -61,7 +61,13 @@ suspend inline fun <reified Data : Any> RealtimeChannel.postgresListDataFlow(
 ): Flow<List<Data>> {
     val cache = AtomicMutableMap<String, Data>()
     val initialData = try {
-        val result = supabaseClient.postgrest.from(schema, table).select()
+        val result = supabaseClient.postgrest.from(schema, table).select {
+            filter?.let {
+                filter {
+                    this.filter(it)
+                }
+            }
+        }
         val data = result.decodeList<Data>()
         data.forEach {
             val key = primaryKey.producer(it)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes a bug where the filter was not being used in the new realtime list data flow

## What is the current behavior?

`postgresListDataFlow()` accepts a filter, but doesn't use it when retrieving the initial value, so it just gets the entire table.

## What is the new behavior?

`postgresListDataFlow()` now applies the filter on the initial data retrieval
