### PR TITLE
Remove error for Realtime when a channel is already connected

### DIFF
--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeImpl.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeImpl.kt
@@ -78,7 +78,7 @@ internal class RealtimeImpl(override val supabaseClient: SupabaseClient, overrid
                 }
             }
         }
-        if (status.value == Realtime.Status.CONNECTED) error("Websocket already connected")
+        if (status.value == Realtime.Status.CONNECTED) return
         _status.value = Realtime.Status.CONNECTING
         val realtimeUrl = websocketUrl
         try {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Update Realtime channels to not throw an error when trying to connect to a channel that is already connected.

## What is the current behavior?

Currently trying to connect with a channel that is already connected will throw an `IllegalStateException`

## What is the new behavior?

Now, the `connect()` function will just return if the channel is already connected.  

## Additional context

The reasoning behind this is that if you are trying to connect to a channel, and that channel is already connected, then you're in the state you want to be in and there's no need to throw an error.
