### PR TITLE
Add missing catch block on the Compose Auth CM implementation

### DIFF
--- a/plugins/ComposeAuth/src/androidMain/kotlin/io/github/jan/supabase/compose/auth/composable/GoogleAuth.kt
+++ b/plugins/ComposeAuth/src/androidMain/kotlin/io/github/jan/supabase/compose/auth/composable/GoogleAuth.kt
@@ -86,6 +86,12 @@ internal fun ComposeAuth.signInWithCM(onResult: (NativeSignInResult) -> Unit, fa
                                         e.localizedMessage ?: "error: google id parsing exception"
                                     )
                                 )
+                            } catch(e: Exception) {
+                                onResult.invoke(
+                                    NativeSignInResult.Error(
+                                        e.localizedMessage ?: "error"
+                                    )
+                                )
                             }
                         } else {
                             onResult.invoke(NativeSignInResult.Error("error: unexpected type of credential"))


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (closes #432)

## What is the current behavior?

Not all exceptions are catched and can result in a crash.

## What is the new behavior?

This should be fixed.

