### PR TITLE
Add missing OTP type

### DIFF
--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/OtpType.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/OtpType.kt
@@ -16,11 +16,12 @@ sealed interface OtpType {
      * Email OTP types
      */
     enum class Email(override val type: String): OtpType {
-        MAGIC_LINK("magiclink"),
-        SIGNUP("signup"),
+        @Deprecated("Use OtpType.Email.EMAIL instead", ReplaceWith("OtpType.Email.EMAIL")) MAGIC_LINK("magiclink"),
+        @Deprecated("Use OtpType.Email.EMAIL instead", ReplaceWith("OtpType.Email.EMAIL")) SIGNUP("signup"),
         INVITE("invite"),
         RECOVERY("recovery"),
-        EMAIL_CHANGE("email_change")
+        EMAIL_CHANGE("email_change"),
+        EMAIL("email")
     }
 
     /**

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,4 +10,4 @@ kotlin.experimental.tryK2=false
 org.jetbrains.compose.experimental.uikit.enabled=true
 org.jetbrains.compose.experimental.jscanvas.enabled=true
 
-supabase-version = 2.1.1
+supabase-version = 2.1.2


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (closes #450)

## What is the current behavior?

You have to either use the deprecated types `SIGNUP` and `MAGIC_LINK`

## What is the new behavior?

These have been deprecated and the type `EMAIL` which combines both has been added.

