### PR TITLE
Change lifecycle callbacks on Android and add previous status to SessionStatus.Authenticated

### DIFF
--- a/GoTrue/src/androidMain/kotlin/io/github/jan/supabase/gotrue/setupPlatform.kt
+++ b/GoTrue/src/androidMain/kotlin/io/github/jan/supabase/gotrue/setupPlatform.kt
@@ -38,14 +38,17 @@ private fun addLifecycleCallbacks(gotrue: Auth) {
                 override fun onStart(owner: LifecycleOwner) {
                     if(!gotrue.isAutoRefreshRunning && gotrue.config.alwaysAutoRefresh) {
                         Logger.d("Auth") {
-                            "Starting auto refresh"
+                            "Trying to re-load session from storage..."
                         }
                         scope.launch {
-                            try {
-                                gotrue.startAutoRefreshForCurrentSession()
-                            } catch(e: IllegalStateException) {
+                            val sessionFound = gotrue.loadFromStorage()
+                            if(!sessionFound) {
                                 Logger.d("Auth") {
-                                    "No session found for auto refresh"
+                                    "No session found, not starting auto refresh"
+                                }
+                            } else {
+                                Logger.d("Auth") {
+                                    "Session found, auto refresh started"
                                 }
                             }
                         }

--- a/GoTrue/src/androidMain/kotlin/io/github/jan/supabase/gotrue/setupPlatform.kt
+++ b/GoTrue/src/androidMain/kotlin/io/github/jan/supabase/gotrue/setupPlatform.kt
@@ -56,6 +56,7 @@ private fun addLifecycleCallbacks(gotrue: Auth) {
                         Logger.d("Auth") { "Cancelling auto refresh because app is switching to the background" }
                         scope.launch {
                             gotrue.stopAutoRefreshForCurrentSession()
+                            gotrue.resetLoadingState()
                         }
                     }
                 }

--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/AuthImpl.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/AuthImpl.kt
@@ -141,7 +141,7 @@ internal class AuthImpl(
             val session = currentSessionOrNull() ?: return
             val newUser = session.user?.copy(identities = session.user.identities?.filter { it.identityId != identityId })
             val newSession = session.copy(user = newUser)
-            _sessionStatus.value = SessionStatus.Authenticated(newSession)
+            _sessionStatus.value = SessionStatus.Authenticated(newSession, sessionStatus.value)
         }
     }
 
@@ -214,7 +214,7 @@ internal class AuthImpl(
             if (this.config.autoSaveToStorage) {
                 sessionManager.saveSession(newSession)
             }
-            _sessionStatus.value = SessionStatus.Authenticated(newSession)
+            _sessionStatus.value = SessionStatus.Authenticated(newSession, sessionStatus.value)
         }
         return userInfo
     }
@@ -350,7 +350,7 @@ internal class AuthImpl(
         val user = retrieveUser(currentAccessTokenOrNull() ?: error("No session found"))
         if (updateSession) {
             val session = currentSessionOrNull() ?: error("No session found")
-            val newStatus = SessionStatus.Authenticated(session.copy(user = user))
+            val newStatus = SessionStatus.Authenticated(session.copy(user = user), sessionStatus.value)
             _sessionStatus.value = newStatus
             if (config.autoSaveToStorage) sessionManager.saveSession(newStatus.session)
         }
@@ -395,7 +395,7 @@ internal class AuthImpl(
 
     override suspend fun importSession(session: UserSession, autoRefresh: Boolean) {
         if (!autoRefresh) {
-            _sessionStatus.value = SessionStatus.Authenticated(session)
+            _sessionStatus.value = SessionStatus.Authenticated(session, sessionStatus.value)
             if (session.refreshToken.isNotBlank() && session.expiresIn != 0L && config.autoSaveToStorage) {
                 sessionManager.saveSession(session)
             }
@@ -407,7 +407,7 @@ internal class AuthImpl(
                 { importSession(session) }
             )
         } else {
-            _sessionStatus.value = SessionStatus.Authenticated(session)
+            _sessionStatus.value = SessionStatus.Authenticated(session, sessionStatus.value)
             if (config.autoSaveToStorage) sessionManager.saveSession(session)
             sessionJob?.cancel()
             sessionJob = authScope.launch {

--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/AuthImpl.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/AuthImpl.kt
@@ -541,6 +541,10 @@ internal class AuthImpl(
         sessionStatus.first { it !is SessionStatus.LoadingFromStorage }
     }
 
+    fun resetLoadingState() {
+        _sessionStatus.value = SessionStatus.LoadingFromStorage
+    }
+
 }
 
 @SupabaseInternal

--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/SessionStatus.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/SessionStatus.kt
@@ -1,7 +1,6 @@
 package io.github.jan.supabase.gotrue
 
 import io.github.jan.supabase.gotrue.user.UserSession
-import kotlin.jvm.JvmInline
 
 /**
  * Represents the status of the current session in [Auth]
@@ -26,7 +25,7 @@ sealed interface SessionStatus {
     /**
      * This status means that [Auth] holds a valid session
      * @param session The session
+     * @param oldStatus The previous status. Useful for knowing if the user was already authenticated
      */
-    @JvmInline
-    value class Authenticated(val session: UserSession) : SessionStatus
+    data class Authenticated(val session: UserSession, val oldStatus: SessionStatus) : SessionStatus
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,4 +10,4 @@ kotlin.experimental.tryK2=false
 org.jetbrains.compose.experimental.uikit.enabled=true
 org.jetbrains.compose.experimental.jscanvas.enabled=true
 
-supabase-version = 2.1.2
+supabase-version = 2.1.3


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature/Bug fix

## What is the current behavior?

- When an Android app comes back into foreground, the session might be expired, but the status will still be `Authenticated`
- The session status flow emit a new value whenever the session changes, making it impossible to know if this is the actual first time the user was authenticated

## What is the new behavior?

- The session status now gets set to `LoadingFromStorage` after the app goes to background
- The session status `Authenticated` now has a new property `oldStatus` giving you the old status to check whether the user has been authenticated before