### PR TITLE
Add support for Realtime throttling

### DIFF
--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/Realtime.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/Realtime.kt
@@ -88,12 +88,20 @@ sealed interface Realtime : MainPlugin<Realtime.Config>, CustomSerializationPlug
     suspend fun block()
 
     /**
+     * Sends a message to the realtime websocket
+     * @param message The message to send
+     */
+    @SupabaseInternal
+    suspend fun send(message: RealtimeMessage)
+
+    /**
      * @property websocketConfig Custom configuration for the ktor websocket
      * @property secure Whether to use wss or ws. Defaults to [SupabaseClient.useHTTPS] when null
      * @property disconnectOnSessionLoss Whether to disconnect from the websocket when the session is lost. Defaults to true
      * @property reconnectDelay The delay between reconnect attempts. Defaults to 7 seconds
      * @property heartbeatInterval The interval between heartbeat messages. Defaults to 15 seconds
      * @property connectOnSubscribe Whether to connect to the websocket when subscribing to a channel. Defaults to true
+     * @property eventsPerSecond The maximum amount of events per second (client-side rate-limiting). Defaults to 10 (100 ms per event). Set to a negative number to disable rate-limiting.
      * @property disconnectOnNoSubscriptions Whether to disconnect from the websocket when there are no more subscriptions. Defaults to true
      * @property serializer A serializer used for serializing/deserializing objects e.g. in [PresenceAction.decodeJoinsAs] or [RealtimeChannel.broadcast]. Defaults to [KotlinXSerializer]
      */
@@ -105,6 +113,7 @@ sealed interface Realtime : MainPlugin<Realtime.Config>, CustomSerializationPlug
         var disconnectOnSessionLoss: Boolean = true,
         var connectOnSubscribe: Boolean = true,
         var disconnectOnNoSubscriptions: Boolean = true,
+        var eventsPerSecond: Int = 10,
     ): MainConfig(), CustomSerializationConfig {
 
         override var serializer: SupabaseSerializer? = null

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeImpl.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeImpl.kt
@@ -187,7 +187,7 @@ internal class RealtimeImpl(override val supabaseClient: SupabaseClient, overrid
         }
         Realtime.logger.d { "Sending heartbeat" }
         heartbeatRef = ++ref
-        ws?.sendSerialized(RealtimeMessage("phoenix", "heartbeat", buildJsonObject { }, heartbeatRef.toString()))
+        send(RealtimeMessage("phoenix", "heartbeat", buildJsonObject { }, heartbeatRef.toString()))
     }
 
     override suspend fun removeChannel(channel: RealtimeChannel) {

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeImpl.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeImpl.kt
@@ -263,7 +263,7 @@ internal class RealtimeImpl(override val supabaseClient: SupabaseClient, overrid
     }
 
     override suspend fun send(message: RealtimeMessage) {
-        if(message.event !in listOf("broadcast", "presence", "postgres_changes")) {
+        if(message.event !in listOf("broadcast", "presence", "postgres_changes") || msPerEvent < 0) {
             ws?.sendSerialized(message)
             return
         }

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeImpl.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeImpl.kt
@@ -39,6 +39,7 @@ import kotlin.time.Duration.Companion.milliseconds
 internal class RealtimeImpl(override val supabaseClient: SupabaseClient, override val config: Realtime.Config) : Realtime {
 
     private var ws: DefaultClientWebSocketSession? = null
+    @Suppress("MagicNumber")
     private val msPerEvent = 1000 / config.eventsPerSecond
     private val _status = MutableStateFlow(Realtime.Status.DISCONNECTED)
     override val status: StateFlow<Realtime.Status> = _status.asStateFlow()

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeRateLimitException.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeRateLimitException.kt
@@ -1,3 +1,7 @@
 package io.github.jan.supabase.realtime
 
+/**
+ * Exception thrown when the rate limit for sending messages to the realtime websocket is exceeded.
+ * @param eventsPerSecond the current rate limit. Can be changed within the realtime config.
+ */
 class RealtimeRateLimitException(eventsPerSecond: Int) : Exception("Rate limit exceeded. Your current limit is set to $eventsPerSecond events per second.")

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeRateLimitException.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeRateLimitException.kt
@@ -1,0 +1,3 @@
+package io.github.jan.supabase.realtime
+
+class RealtimeRateLimitException(eventsPerSecond: Int) : Exception("Rate limit exceeded. Your current limit is set to $eventsPerSecond events per second.")


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature (closes #468)

## What is the current behavior?

No support for client-side throttling.

## What is the new behavior?

You can now set the `eventsPerSecond` in the realtime config. Exceeding this limit will cause all sending methods (broadcast, track, etc.) to throw an exception.

