### PR TITLE
Remove double quotes for query modifiers

### DIFF
--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/PostgrestRequestBuilder.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/PostgrestRequestBuilder.kt
@@ -67,7 +67,7 @@ class PostgrestRequestBuilder(@PublishedApi internal val propertyConversionMetho
      * @param referencedTable If the column is from a foreign table, specify the table name here
      */
     fun order(column: String, order: Order, nullsFirst: Boolean = false, referencedTable: String? = null) {
-        val key = if (referencedTable == null) "order" else "\"$referencedTable\".order"
+        val key = if (referencedTable == null) "order" else "$referencedTable.order"
         _params[key] = listOf("${column}.${order.value}.${if (nullsFirst) "nullsfirst" else "nullslast"}")
     }
 
@@ -77,7 +77,7 @@ class PostgrestRequestBuilder(@PublishedApi internal val propertyConversionMetho
      * @param referencedTable If the column is from a foreign table, specify the table name here
      */
     fun limit(count: Long, referencedTable: String? = null) {
-        val key = if (referencedTable == null) "limit" else "\"$referencedTable\".limit"
+        val key = if (referencedTable == null) "limit" else "$referencedTable.limit"
         _params[key] = listOf(count.toString())
     }
 
@@ -88,8 +88,8 @@ class PostgrestRequestBuilder(@PublishedApi internal val propertyConversionMetho
      * @param referencedTable If the column is from a foreign table, specify the table name here
      */
     fun range(from: Long, to: Long, referencedTable: String? = null) {
-        val keyOffset = if (referencedTable == null) "offset" else "\"$referencedTable\".offset"
-        val keyLimit = if (referencedTable == null) "limit" else "\"$referencedTable\".limit"
+        val keyOffset = if (referencedTable == null) "offset" else "$referencedTable.offset"
+        val keyLimit = if (referencedTable == null) "limit" else "$referencedTable.limit"
 
         _params[keyOffset] = listOf(from.toString())
         _params[keyLimit] = listOf((to - from + 1).toString())

--- a/Postgrest/src/commonTest/kotlin/PostgrestRequestBuilderTest.kt
+++ b/Postgrest/src/commonTest/kotlin/PostgrestRequestBuilderTest.kt
@@ -53,7 +53,7 @@ class PostgrestRequestBuilderTest {
         val request = postgrestRequest {
             order("messages", Order.ASCENDING, true, "table")
         }
-        assertEquals(listOf("messages.asc.nullsfirst"), request.params["\"table\".order"])
+        assertEquals(listOf("messages.asc.nullsfirst"), request.params["table.order"])
     }
 
     @Test
@@ -69,7 +69,7 @@ class PostgrestRequestBuilderTest {
         val request = postgrestRequest {
             limit(10, "table")
         }
-        assertEquals(listOf("10"), request.params["\"table\".limit"])
+        assertEquals(listOf("10"), request.params["table.limit"])
     }
 
     @Test
@@ -86,8 +86,8 @@ class PostgrestRequestBuilderTest {
         val request = postgrestRequest {
             range(10, 20, "table")
         }
-        assertEquals(listOf("10"), request.params["\"table\".offset"])
-        assertEquals(listOf("11"), request.params["\"table\".limit"])
+        assertEquals(listOf("10"), request.params["table.offset"])
+        assertEquals(listOf("11"), request.params["table.limit"])
     }
 
     @Test

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,4 +10,4 @@ kotlin.experimental.tryK2=false
 org.jetbrains.compose.experimental.uikit.enabled=true
 org.jetbrains.compose.experimental.jscanvas.enabled=true
 
-supabase-version = 2.1.3
+supabase-version = 2.1.4-dev

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,4 +10,4 @@ kotlin.experimental.tryK2=false
 org.jetbrains.compose.experimental.uikit.enabled=true
 org.jetbrains.compose.experimental.jscanvas.enabled=true
 
-supabase-version = 2.1.4-dev
+supabase-version = 2.1.4


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (closes #474)

## What is the new behavior?

Removes double quotes for query modifiers.
