### PR TITLE
Remove print statement in Compose Auth UI

### DIFF
--- a/plugins/ComposeAuthUI/src/commonMain/kotlin/io/github/jan/supabase/compose/auth/ui/email/EmailField.kt
+++ b/plugins/ComposeAuthUI/src/commonMain/kotlin/io/github/jan/supabase/compose/auth/ui/email/EmailField.kt
@@ -245,7 +245,6 @@ fun OutlinedEmailField(
     FormComponent(formKey, mandatory) {
         val isValidEmail = remember(value) { validator.validate(value) }
         LaunchedEffect(isValidEmail) {
-            println(isValidEmail)
             it.value = isValidEmail
         }
         OutlinedTextField(


### PR DESCRIPTION
## What kind of change does this PR introduce?

Small change

## What is the current behavior?

print statement in the email field.

## What is the new behavior?

This statement has been removed.