### PR TITLE
Fix realtime reconnecting suspending indefinitely

### DIFF
--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeImpl.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeImpl.kt
@@ -105,8 +105,10 @@ internal class RealtimeImpl(override val supabaseClient: SupabaseClient, overrid
                 Error while trying to connect to realtime websocket. Trying again in ${config.reconnectDelay}
                 URL: $realtimeUrl
                 """.trimIndent() }
-            disconnect()
-            connect(true)
+            scope.launch {
+                disconnect()
+                connect(true)
+            }
         }
     }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (closes #504)

## What is the current behavior?

Automatic reconnecting e.g. because of a network error doesn't work because of #483

## What is the new behavior?

This should be fixed.
