### PR TITLE
Rename `filter` param to `request` in Postgrest#rpc

### DIFF
--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/PostgrestExt.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/PostgrestExt.kt
@@ -14,17 +14,17 @@ import kotlinx.serialization.json.JsonElement
  * @param function The name of the function
  * @param parameters The parameters for the function
  * @param head If true, select will delete the selected data.
- * @param filter Filter the result
+ * @param request Filter the result
  * @throws RestException or one of its subclasses if the request failed
  */
 suspend inline fun <reified T : Any> Postgrest.rpc(
     function: String,
     parameters: T,
     head: Boolean = false,
-    filter: PostgrestRequestBuilder.() -> Unit = {},
+    request: PostgrestRequestBuilder.() -> Unit = {},
 ): PostgrestResult {
     val encodedParameters = if (parameters is JsonElement) parameters else serializer.encodeToJsonElement(parameters)
-    val requestBuilder = PostgrestRequestBuilder(config.propertyConversionMethod).apply(filter)
+    val requestBuilder = PostgrestRequestBuilder(config.propertyConversionMethod).apply(request)
     val rpcRequest = RpcRequest(
         head = head,
         count = requestBuilder.count,
@@ -39,15 +39,15 @@ suspend inline fun <reified T : Any> Postgrest.rpc(
  *
  * @param function The name of the function
  * @param head If true, select will delete the selected data.
- * @param filter Filter the result
+ * @param request Filter the result
  * @throws RestException or one of its subclasses if the request failed
  */
 suspend inline fun Postgrest.rpc(
     function: String,
     head: Boolean = false,
-    filter: PostgrestRequestBuilder.() -> Unit = {}
+    request: PostgrestRequestBuilder.() -> Unit = {}
 ): PostgrestResult {
-    val requestBuilder = PostgrestRequestBuilder(config.propertyConversionMethod).apply(filter)
+    val requestBuilder = PostgrestRequestBuilder(config.propertyConversionMethod).apply(request)
     val rpcRequest = RpcRequest(
         head = head,
         count = requestBuilder.count,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Small change

## What is the current behavior?

The param name is `filter` which is inconsistent looking at other methods (select, update etc)

## What is the new behavior?

This param has been renamed.