### PR TITLE
Add identities parameter

### DIFF
--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/providers/builtin/Email.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/providers/builtin/Email.kt
@@ -1,6 +1,7 @@
 package io.github.jan.supabase.gotrue.providers.builtin
 
 import io.github.jan.supabase.exceptions.SupabaseEncodingException
+import io.github.jan.supabase.gotrue.user.Identity
 import io.github.jan.supabase.supabaseJson
 import kotlinx.datetime.Instant
 import kotlinx.serialization.ExperimentalSerializationApi
@@ -31,6 +32,7 @@ data object Email : DefaultAuthProvider<Email.Config, Email.Result> {
      * The sign up result of the email authentication method
      * @param id The id of the created user
      * @param email The email of the created user
+     * @param identities The identities of the created user
      * @param confirmationSentAt The time the confirmation was sent
      * @param createdAt The time the user was created
      * @param updatedAt The time the user was updated
@@ -39,6 +41,7 @@ data object Email : DefaultAuthProvider<Email.Config, Email.Result> {
     data class Result(
         val id: String,
         val email: String,
+        val identities: List<Identity>?,
         @SerialName("confirmation_sent_at") val confirmationSentAt: Instant,
         @SerialName("created_at") val createdAt: Instant,
         @SerialName("updated_at") val updatedAt: Instant,

--- a/GoTrue/src/commonTest/kotlin/GoTrueMock.kt
+++ b/GoTrue/src/commonTest/kotlin/GoTrueMock.kt
@@ -1,5 +1,6 @@
 import io.github.jan.supabase.gotrue.providers.builtin.Email
 import io.github.jan.supabase.gotrue.providers.builtin.Phone
+import io.github.jan.supabase.gotrue.user.Identity
 import io.github.jan.supabase.gotrue.user.UserInfo
 import io.github.jan.supabase.gotrue.user.UserSession
 import io.ktor.client.engine.mock.MockEngine
@@ -118,7 +119,17 @@ class GoTrueMock {
 
         return when {
             body.containsKey("email") -> {
-                respond(Email.Result("uuid", body["email"]!!.jsonPrimitive.content, Clock.System.now(), Clock.System.now(), Clock.System.now()))
+                val identity = Identity(
+                    id = "uuid",
+                    identityData = JsonObject(emptyMap()),
+                    identityId = "uuid2",
+                    lastSignInAt = Clock.System.now().toString(),
+                    createdAt = Clock.System.now().toString(),
+                    provider = "email",
+                    userId = "uuid",
+                    updatedAt = Clock.System.now().toString(),
+                )
+                respond(Email.Result("uuid", body["email"]!!.jsonPrimitive.content, listOf(identity), Clock.System.now(), Clock.System.now(), Clock.System.now()))
             }
             body.containsKey("phone") -> {
                 respond(Phone.Result("uuid", body["phone"]!!.jsonPrimitive.content, Clock.System.now(), Clock.System.now(), Clock.System.now()))


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR adds a parameter to Email.Result.

## What is the current behavior?

Currently, Supabase does not have a solution for checking if an account is already registered at the time of new registration, although there is an alternative in JavaScript. However, this cannot be used in Kotlin.
https://github.com/supabase/gotrue-js/issues/513
https://github.com/supabase/supabase-js/issues/296

## What is the new behavior?

By using a parameter, it will be possible to check for duplicates at the time of account registration.

## Additional context

I am Japanese and not proficient in English. I am using ChatGPT and DeepL to translate.