### PR TITLE
Ignore exception thrown by missing Json property by default

### DIFF
--- a/src/commonMain/kotlin/io/github/jan/supabase/SupabaseClientBuilder.kt
+++ b/src/commonMain/kotlin/io/github/jan/supabase/SupabaseClientBuilder.kt
@@ -10,6 +10,7 @@ import io.github.jan.supabase.serializer.KotlinXSerializer
 import io.ktor.client.HttpClientConfig
 import io.ktor.client.engine.HttpClientEngine
 import io.ktor.client.plugins.HttpRequestTimeoutException
+import kotlinx.serialization.json.Json
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
@@ -63,7 +64,7 @@ class SupabaseClientBuilder @PublishedApi internal constructor(private val supab
      *
      * Default: [KotlinXSerializer]
      */
-    var defaultSerializer: SupabaseSerializer = KotlinXSerializer()
+    var defaultSerializer: SupabaseSerializer = KotlinXSerializer(Json { ignoreUnknownKeys = true })
 
     private val httpConfigOverrides = mutableListOf<HttpClientConfig<*>.() -> Unit>()
     private val plugins = mutableMapOf<String, ((SupabaseClient) -> SupabasePlugin<*>)>()


### PR DESCRIPTION
## What kind of change does this PR introduce?
Ignore missing json key by default to avoid `kotlinx.serialization.json.internal.JsonDecodingException ` thrown when there's no Json property

## What is the current behavior?
- `kotlinx.serialization.json.internal.JsonDecodingException `is thrown when some Json properties are not specified

## What is the new behavior?
- There's no exception thrown when a Json property is missing
https://github.com/supabase-community/supabase-kt/issues/509