### PR TITLE
Fix iOS Native Apple Sign in Digest error

### DIFF
--- a/plugins/ComposeAuth/build.gradle.kts
+++ b/plugins/ComposeAuth/build.gradle.kts
@@ -52,6 +52,7 @@ kotlin {
             dependencies {
                 api(project(":gotrue-kt"))
                 implementation(compose.runtime)
+                implementation(libs.krypto)
             }
         }
         val noDefaultMain by creating {

--- a/plugins/ComposeAuth/src/commonMain/kotlin/io/github/jan/supabase/compose/auth/Utils.common.kt
+++ b/plugins/ComposeAuth/src/commonMain/kotlin/io/github/jan/supabase/compose/auth/Utils.common.kt
@@ -1,11 +1,9 @@
 package io.github.jan.supabase.compose.auth
 
-import io.ktor.util.Digest
 import io.ktor.utils.io.core.toByteArray
+import korlibs.crypto.SHA256
 
-@OptIn(ExperimentalStdlibApi::class)
-internal suspend fun String.hash(): String {
-    val digest = Digest("SHA-256")
-    digest += this.toByteArray()
-    return digest.build().toHexString()
+internal fun String.hash(): String {
+    val hash = SHA256.digest(this.toByteArray())
+    return hash.hex
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Using Native Apple Sign In will always fail.

## What is the new behavior?

This happens because Ktor's `Digest` method doesn't support Darwin. I changed the implementation to use Krypto instead.
