### PR TITLE
Return full a full `UserInfo` on sign up

### DIFF
--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/providers/builtin/Email.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/providers/builtin/Email.kt
@@ -1,11 +1,10 @@
 package io.github.jan.supabase.gotrue.providers.builtin
 
 import io.github.jan.supabase.exceptions.SupabaseEncodingException
+import io.github.jan.supabase.gotrue.user.UserInfo
 import io.github.jan.supabase.supabaseJson
-import kotlinx.datetime.Instant
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.MissingFieldException
-import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.decodeFromJsonElement
@@ -15,7 +14,7 @@ import kotlinx.serialization.json.jsonObject
 /**
  * Authentication method with email and password
  */
-data object Email : DefaultAuthProvider<Email.Config, Email.Result> {
+data object Email : DefaultAuthProvider<Email.Config, UserInfo> {
 
     override val grantType: String = "password"
 
@@ -27,25 +26,8 @@ data object Email : DefaultAuthProvider<Email.Config, Email.Result> {
     @Serializable
     data class Config(var email: String = "", var password: String = ""): DefaultAuthProvider.Config()
 
-    /**
-     * The sign up result of the email authentication method
-     * @param id The id of the created user
-     * @param email The email of the created user
-     * @param confirmationSentAt The time the confirmation was sent
-     * @param createdAt The time the user was created
-     * @param updatedAt The time the user was updated
-     */
-    @Serializable
-    data class Result(
-        val id: String,
-        val email: String,
-        @SerialName("confirmation_sent_at") val confirmationSentAt: Instant,
-        @SerialName("created_at") val createdAt: Instant,
-        @SerialName("updated_at") val updatedAt: Instant,
-    )
-
     @OptIn(ExperimentalSerializationApi::class)
-    override fun decodeResult(json: JsonObject): Result = try {
+    override fun decodeResult(json: JsonObject): UserInfo = try {
         supabaseJson.decodeFromJsonElement(json)
     } catch(e: MissingFieldException) {
         throw SupabaseEncodingException("Couldn't decode sign up email result. Input: $json")

--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/providers/builtin/IDToken.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/providers/builtin/IDToken.kt
@@ -6,8 +6,8 @@ import io.github.jan.supabase.gotrue.providers.Azure
 import io.github.jan.supabase.gotrue.providers.Facebook
 import io.github.jan.supabase.gotrue.providers.Google
 import io.github.jan.supabase.gotrue.providers.IDTokenProvider
+import io.github.jan.supabase.gotrue.user.UserInfo
 import io.github.jan.supabase.supabaseJson
-import kotlinx.datetime.Instant
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.MissingFieldException
 import kotlinx.serialization.SerialName
@@ -23,7 +23,7 @@ import kotlinx.serialization.json.jsonObject
  * Only [Apple], [Google], [Facebook] and [Azure] are supported as providers.
  *
  */
-data object IDToken : DefaultAuthProvider<IDToken.Config, IDToken.Result> {
+data object IDToken : DefaultAuthProvider<IDToken.Config, UserInfo> {
 
     override val grantType: String = "id_token"
 
@@ -42,23 +42,8 @@ data object IDToken : DefaultAuthProvider<IDToken.Config, IDToken.Result> {
         var nonce: String? = null
     ) : DefaultAuthProvider.Config()
 
-    /**
-     * The sign-up result of the id token authentication method
-     * @param id The id of the created user
-     * @param confirmationSentAt The time the confirmation was sent
-     * @param createdAt The time the user was created
-     * @param updatedAt The time the user was updated
-     */
-    @Serializable
-    data class Result(
-        val id: String,
-        @SerialName("confirmation_sent_at") val confirmationSentAt: Instant,
-        @SerialName("created_at") val createdAt: Instant,
-        @SerialName("updated_at") val updatedAt: Instant,
-    )
-
     @OptIn(ExperimentalSerializationApi::class)
-    override fun decodeResult(json: JsonObject): Result = try {
+    override fun decodeResult(json: JsonObject): UserInfo = try {
         supabaseJson.decodeFromJsonElement(json)
     } catch(e: MissingFieldException) {
         throw SupabaseEncodingException("Couldn't decode sign up id token result. Input: $json")

--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/providers/builtin/Phone.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/providers/builtin/Phone.kt
@@ -1,8 +1,8 @@
 package io.github.jan.supabase.gotrue.providers.builtin
 
 import io.github.jan.supabase.exceptions.SupabaseEncodingException
+import io.github.jan.supabase.gotrue.user.UserInfo
 import io.github.jan.supabase.supabaseJson
-import kotlinx.datetime.Instant
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.MissingFieldException
@@ -20,7 +20,7 @@ import kotlinx.serialization.json.jsonObject
 /**
  * Authentication method with phone numbers and password
  */
-data object Phone : DefaultAuthProvider<Phone.Config, Phone.Result> {
+data object Phone : DefaultAuthProvider<Phone.Config, UserInfo> {
 
     override val grantType: String = "password"
 
@@ -65,25 +65,8 @@ data object Phone : DefaultAuthProvider<Phone.Config, Phone.Result> {
         }
     }
 
-    /**
-     * The sign up result of the phone authentication method
-     * @param id The id of the created user
-     * @param phone The phone number of the created user
-     * @param confirmationSentAt The time the confirmation was sent
-     * @param createdAt The time the user was created
-     * @param updatedAt The time the user was updated
-     */
-    @Serializable
-    data class Result(
-        val id: String,
-        val phone: String,
-        @SerialName("confirmation_sent_at") val confirmationSentAt: Instant,
-        @SerialName("created_at") val createdAt: Instant,
-        @SerialName("updated_at") val updatedAt: Instant,
-    )
-
     @OptIn(ExperimentalSerializationApi::class)
-    override fun decodeResult(json: JsonObject): Result = try {
+    override fun decodeResult(json: JsonObject): UserInfo = try {
         supabaseJson.decodeFromJsonElement(json)
     } catch(e: MissingFieldException) {
         throw SupabaseEncodingException("Couldn't decode sign up phone result. Input: $json")

--- a/GoTrue/src/commonTest/kotlin/GoTrueMock.kt
+++ b/GoTrue/src/commonTest/kotlin/GoTrueMock.kt
@@ -1,5 +1,3 @@
-import io.github.jan.supabase.gotrue.providers.builtin.Email
-import io.github.jan.supabase.gotrue.providers.builtin.Phone
 import io.github.jan.supabase.gotrue.user.UserInfo
 import io.github.jan.supabase.gotrue.user.UserSession
 import io.ktor.client.engine.mock.MockEngine
@@ -118,10 +116,10 @@ class GoTrueMock {
 
         return when {
             body.containsKey("email") -> {
-                respond(Email.Result("uuid", body["email"]!!.jsonPrimitive.content, Clock.System.now(), Clock.System.now(), Clock.System.now()))
+                respond(UserInfo(id ="uuid", email = body["email"]!!.jsonPrimitive.content, aud = ""))
             }
             body.containsKey("phone") -> {
-                respond(Phone.Result("uuid", body["phone"]!!.jsonPrimitive.content, Clock.System.now(), Clock.System.now(), Clock.System.now()))
+                respond(UserInfo(id ="uuid", phone = body["phone"]!!.jsonPrimitive.content, aud = ""))
             }
             !body.containsKey("password") -> respondBadRequest("Missing password")
             else -> respondBadRequest("Missing email or phone")


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

Separate `Result` objects are being returned depending on the provider.

## What is the new behavior?

The return type for `Email`, `Phone` and `IDToken` is now `UserInfo`. This closes #508 and also makes more sense because they essentially all return the same thing.

