### PR TITLE
Allow customizing the custom tab intent on Android

### DIFF
--- a/GoTrue/src/androidMain/kotlin/io/github/jan/supabase/gotrue/Android.kt
+++ b/GoTrue/src/androidMain/kotlin/io/github/jan/supabase/gotrue/Android.kt
@@ -5,20 +5,18 @@ import android.net.Uri
 import androidx.browser.customtabs.CustomTabsIntent
 import io.github.jan.supabase.SupabaseClient
 import io.github.jan.supabase.annotations.SupabaseInternal
-import io.github.jan.supabase.gotrue.ExternalAuthAction.CUSTOM_TABS
-import io.github.jan.supabase.gotrue.ExternalAuthAction.EXTERNAL_BROWSER
 import io.github.jan.supabase.gotrue.user.UserSession
 import kotlinx.coroutines.launch
 
 internal fun openUrl(uri: Uri, action: ExternalAuthAction) {
     when(action) {
-        EXTERNAL_BROWSER -> {
+        ExternalAuthAction.ExternalBrowser -> {
             val browserIntent = Intent(Intent.ACTION_VIEW, uri)
             browserIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
             applicationContext().startActivity(browserIntent)
         }
-        CUSTOM_TABS -> {
-            val intent = CustomTabsIntent.Builder().build()
+        is ExternalAuthAction.CustomTabs -> {
+            val intent = CustomTabsIntent.Builder().apply(action.intentBuilder).build()
             intent.intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
             intent.launchUrl(applicationContext(), uri)
         }

--- a/GoTrue/src/androidMain/kotlin/io/github/jan/supabase/gotrue/AuthConfig.kt
+++ b/GoTrue/src/androidMain/kotlin/io/github/jan/supabase/gotrue/AuthConfig.kt
@@ -1,7 +1,9 @@
 package io.github.jan.supabase.gotrue
 
-import io.github.jan.supabase.gotrue.ExternalAuthAction.CUSTOM_TABS
-import io.github.jan.supabase.gotrue.ExternalAuthAction.EXTERNAL_BROWSER
+import androidx.browser.customtabs.CustomTabsIntent
+import io.github.jan.supabase.gotrue.ExternalAuthAction.Companion.CUSTOM_TABS
+import io.github.jan.supabase.gotrue.ExternalAuthAction.Companion.EXTERNAL_BROWSER
+import io.github.jan.supabase.gotrue.providers.ExternalAuthConfig
 import io.github.jan.supabase.plugins.CustomSerializationConfig
 
 /**
@@ -15,9 +17,9 @@ actual class AuthConfig : CustomSerializationConfig, AuthConfigDefaults() {
     var enableLifecycleCallbacks: Boolean = true
 
     /**
-     * The action to use for the OAuth flow
+     * The action to use for the OAuth flow. Can be overriden per-request in the [ExternalAuthConfig]
      */
-    var defaultExternalAuthAction: ExternalAuthAction = ExternalAuthAction.EXTERNAL_BROWSER
+    var defaultExternalAuthAction: ExternalAuthAction = ExternalAuthAction.DEFAULT
 
 }
 
@@ -27,6 +29,36 @@ actual class AuthConfig : CustomSerializationConfig, AuthConfigDefaults() {
  * @property CUSTOM_TABS Open the OAuth/SSO flow in a custom tab
  * @see [AuthConfig.defaultExternalAuthAction]
  */
-enum class ExternalAuthAction {
-    EXTERNAL_BROWSER, CUSTOM_TABS
+sealed interface ExternalAuthAction {
+
+    /**
+     * Open the OAuth/SSO flow in an external browser
+     */
+    data object ExternalBrowser : ExternalAuthAction
+
+    /**
+     * Open the OAuth/SSO flow in a custom tab
+     * @property intentBuilder The builder for the custom tabs intent
+     */
+    data class CustomTabs(val intentBuilder: CustomTabsIntent.Builder.() -> Unit = {}) : ExternalAuthAction
+
+    companion object {
+        /**
+         * The default action to use for the OAuth flow
+         */
+        val DEFAULT: ExternalAuthAction = ExternalBrowser
+
+        /**
+         * External browser action
+         */
+        @Deprecated("Use ExternalBrowser object instead", ReplaceWith("ExternalBrowser"))
+        val EXTERNAL_BROWSER: ExternalAuthAction = ExternalBrowser
+
+        /**
+         * Custom tabs action
+         */
+        @Deprecated("Use CustomTabs class instead", ReplaceWith("CustomTabs"))
+        val CUSTOM_TABS: ExternalAuthAction = CustomTabs()
+    }
+
 }

--- a/GoTrue/src/androidMain/kotlin/io/github/jan/supabase/gotrue/AuthConfig.kt
+++ b/GoTrue/src/androidMain/kotlin/io/github/jan/supabase/gotrue/AuthConfig.kt
@@ -51,13 +51,13 @@ sealed interface ExternalAuthAction {
         /**
          * External browser action
          */
-        @Deprecated("Use ExternalBrowser object instead", ReplaceWith("ExternalBrowser"))
+        @Deprecated("Use ExternalBrowser object instead", ReplaceWith("ExternalAuthAction.ExternalBrowser"))
         val EXTERNAL_BROWSER: ExternalAuthAction = ExternalBrowser
 
         /**
          * Custom tabs action
          */
-        @Deprecated("Use CustomTabs class instead", ReplaceWith("CustomTabs()"))
+        @Deprecated("Use CustomTabs class instead", ReplaceWith("ExternalAuthAction.CustomTabs()"))
         val CUSTOM_TABS: ExternalAuthAction = CustomTabs()
     }
 

--- a/GoTrue/src/androidMain/kotlin/io/github/jan/supabase/gotrue/AuthConfig.kt
+++ b/GoTrue/src/androidMain/kotlin/io/github/jan/supabase/gotrue/AuthConfig.kt
@@ -57,7 +57,7 @@ sealed interface ExternalAuthAction {
         /**
          * Custom tabs action
          */
-        @Deprecated("Use CustomTabs class instead", ReplaceWith("CustomTabs"))
+        @Deprecated("Use CustomTabs class instead", ReplaceWith("CustomTabs()"))
         val CUSTOM_TABS: ExternalAuthAction = CustomTabs()
     }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature (closes #522)

## What is the current behavior?

You can only change between `ExternalAuthAction.EXTERNAL_BROWSER` and `ExternalAuthAction.CUSTOM_TABS`.

## What is the new behavior?

The enum is now a sealed interface which can either be the data object `ExternalAuthAction.ExternalBrowser` or the data class `ExternalAuthAction.CustomTabs(CustomTabsIntent.Builder)`, where you can customize the custom tab.

