### PR TITLE
Rename `Auth#modifyUser` to `Auth#updateUser`

### DIFF
--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/Auth.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/Auth.kt
@@ -131,7 +131,7 @@ sealed interface Auth : MainPlugin<AuthConfig>, CustomSerializationPlugin {
     /**
      * Signs in the user without any credentials. This will create a new user session with a new access token.
      *
-     * If you want to upgrade this anonymous user to a real user, use [linkIdentity] to link an OAuth identity or [modifyUser] to add an email or phone.
+     * If you want to upgrade this anonymous user to a real user, use [linkIdentity] to link an OAuth identity or [updateUser] to add an email or phone.
      *
      * @param data Extra data for the user
      * @param captchaToken The captcha token to use
@@ -180,11 +180,26 @@ sealed interface Auth : MainPlugin<AuthConfig>, CustomSerializationPlugin {
      * @throws HttpRequestTimeoutException if the request timed out
      * @throws HttpRequestException on network related issues
      */
-    suspend fun modifyUser(
+    suspend fun updateUser(
         updateCurrentUser: Boolean = true,
         redirectUrl: String? = defaultRedirectUrl(),
         config: UserUpdateBuilder.() -> Unit
     ): UserInfo
+
+    /**
+     * Modifies the current user
+     * @param updateCurrentUser Whether to update the current user in the [SupabaseClient]
+     * @param config The configuration to use
+     * @throws RestException or one of its subclasses if receiving an error response
+     * @throws HttpRequestTimeoutException if the request timed out
+     * @throws HttpRequestException on network related issues
+     */
+    @Deprecated("Use updateUser instead")
+    suspend fun modifyUser(
+        updateCurrentUser: Boolean = true,
+        redirectUrl: String? = defaultRedirectUrl(),
+        config: UserUpdateBuilder.() -> Unit
+    ): UserInfo = updateUser(updateCurrentUser, redirectUrl, config)
 
     /**
      * Resends an existing signup confirmation email, email change email

--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/AuthExtensions.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/AuthExtensions.kt
@@ -59,7 +59,7 @@ fun Auth.parseSessionFromUrl(url: String): UserSession = parseSessionFromFragmen
 /**
  * Signs in the user without any credentials. This will create a new user session with a new access token.
  *
- * If you want to upgrade this anonymous user to a real user, use [Auth.linkIdentity] to link an OAuth identity or [Auth.modifyUser] to add an email or phone.
+ * If you want to upgrade this anonymous user to a real user, use [Auth.linkIdentity] to link an OAuth identity or [Auth.updateUser] to add an email or phone.
  *
  * @param data Extra data for the user
  * @param captchaToken The captcha token to use

--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/AuthImpl.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/AuthImpl.kt
@@ -205,7 +205,7 @@ internal class AuthImpl(
         }).body()
     }
 
-    override suspend fun modifyUser(
+    override suspend fun updateUser(
         updateCurrentUser: Boolean,
         redirectUrl: String?,
         config: UserUpdateBuilder.() -> Unit

--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/SessionStatus.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/SessionStatus.kt
@@ -85,7 +85,7 @@ sealed interface SessionSource {
     data class Refresh(val oldSession: UserSession) : SessionSource
 
     /**
-     * The session was changed due to a user change (e.g. via [Auth.modifyUser] or [Auth.retrieveUserForCurrentSession])
+     * The session was changed due to a user change (e.g. via [Auth.updateUser] or [Auth.retrieveUserForCurrentSession])
      * @param oldSession The old session
      */
     data class UserChanged(val oldSession: UserSession) : SessionSource


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

There is the method `Auth#modifyUser`, all other client libs have the method `updateUser`

## What is the new behavior?

There is a new `updateUser` method and the old one has been deprecated.
