### PR TITLE
Stabilize Auth and Realtime features

### DIFF
--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/Auth.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/Auth.kt
@@ -1,7 +1,6 @@
 package io.github.jan.supabase.gotrue
 
 import io.github.jan.supabase.SupabaseClient
-import io.github.jan.supabase.annotations.SupabaseExperimental
 import io.github.jan.supabase.exceptions.HttpRequestException
 import io.github.jan.supabase.exceptions.RestException
 import io.github.jan.supabase.gotrue.admin.AdminApi
@@ -136,7 +135,6 @@ sealed interface Auth : MainPlugin<AuthConfig>, CustomSerializationPlugin {
      * @param data Extra data for the user
      * @param captchaToken The captcha token to use
      */
-    @SupabaseExperimental
     suspend fun signInAnonymously(data: JsonObject? = null, captchaToken: String? = null)
 
     /**
@@ -147,7 +145,6 @@ sealed interface Auth : MainPlugin<AuthConfig>, CustomSerializationPlugin {
      * @param redirectUrl The redirect url to use. If you don't specify this, the platform specific will be used, like deeplinks on android.
      * @param config Extra configuration
      */
-    @SupabaseExperimental
     suspend fun linkIdentity(
         provider: OAuthProvider,
         redirectUrl: String? = defaultRedirectUrl(),
@@ -159,7 +156,6 @@ sealed interface Auth : MainPlugin<AuthConfig>, CustomSerializationPlugin {
      * @param identityId The id of the OAuth identity
      * @param updateLocalUser Whether to delete the identity from the local user or not
      */
-    @SupabaseExperimental
     suspend fun unlinkIdentity(
         identityId: String,
         updateLocalUser: Boolean = true

--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/AuthImpl.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/AuthImpl.kt
@@ -133,7 +133,6 @@ internal class AuthImpl(
         importSession(it, source = SessionSource.SignUp(provider))
     }, redirectUrl, config)
 
-    @SupabaseExperimental
     override suspend fun linkIdentity(
         provider: OAuthProvider,
         redirectUrl: String?,
@@ -154,7 +153,6 @@ internal class AuthImpl(
         )
     }
 
-    @SupabaseExperimental
     override suspend fun unlinkIdentity(identityId: String, updateLocalUser: Boolean) {
         api.delete("user/identities/$identityId")
         if (updateLocalUser) {

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeExt.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeExt.kt
@@ -1,7 +1,6 @@
 @file:Suppress("MatchingDeclarationName")
 package io.github.jan.supabase.realtime
 
-import io.github.jan.supabase.annotations.SupabaseExperimental
 import io.github.jan.supabase.collections.AtomicMutableMap
 import io.github.jan.supabase.exceptions.NotFoundRestException
 import io.github.jan.supabase.exceptions.UnknownRestException
@@ -28,7 +27,6 @@ data class PrimaryKey<Data>(val columnName: String, val producer: (Data) -> Stri
  * If you want more control, use the [presenceChangeFlow] function.
  * @return a [Flow] of the current presences in a list. This list is updated and emitted whenever a presence joins or leaves.
  */
-@SupabaseExperimental
 inline fun <reified Data> RealtimeChannel.presenceDataFlow(): Flow<List<Data>> {
     val cache = AtomicMutableMap<String, Data>()
     return presenceChangeFlow().map {
@@ -52,7 +50,6 @@ inline fun <reified Data> RealtimeChannel.presenceDataFlow(): Flow<List<Data>> {
  * @param primaryKey the primary key of the [Data] type
  * @return a [Flow] of the current data in a list. This list is updated and emitted whenever a change occurs.
  */
-@SupabaseExperimental
 suspend inline fun <reified Data : Any> RealtimeChannel.postgresListDataFlow(
     schema: String = "public",
     table: String,
@@ -120,7 +117,6 @@ suspend inline fun <reified Data : Any> RealtimeChannel.postgresListDataFlow(
  * @param primaryKey the primary key of the [Data] type
  * @return a [Flow] of the current data in a list. This list is updated and emitted whenever a change occurs.
  */
-@SupabaseExperimental
 suspend inline fun <reified Data : Any, Value> RealtimeChannel.postgresListDataFlow(
     schema: String = "public",
     table: String,
@@ -147,7 +143,6 @@ suspend inline fun <reified Data : Any, Value> RealtimeChannel.postgresListDataF
  * @param primaryKey the primary key of the [Data] type
  * @return a [Flow] of the current data. This flow emits a new value whenever a change occurs.
  */
-@SupabaseExperimental
 suspend inline fun <reified Data : Any> RealtimeChannel.postgresSingleDataFlow(
     schema: String = "public",
     table: String,
@@ -200,7 +195,6 @@ suspend inline fun <reified Data : Any> RealtimeChannel.postgresSingleDataFlow(
  * @param primaryKey the primary key of the [Data] type
  * @return a [Flow] of the current data. This flow emits a new value whenever a change occurs.
  */
-@SupabaseExperimental
 suspend inline fun <reified Data, Value> RealtimeChannel.postgresSingleDataFlow(
     schema: String = "public",
     table: String,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

The methods `Auth#signInAnonymously`, `Auth#linkIdentity`, `Auth#unlinkIdentity`, `RealtimeChannel#presenceDataFlow`, `RealtimeChannel#postgresListDataFlow` and `RealtimeChannel#postgresSingleDataFlow` are marked experimental.

## What is the new behavior?

They are no longer experimental.
