### PR TITLE
Auto remove line breaks on Columns.Raw

### DIFF
--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/Columns.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/Columns.kt
@@ -21,7 +21,7 @@ value class Columns @PublishedApi internal constructor(val value: String) {
          * Select all columns given in the [value] parameter
          * @param value The columns to select, separated by a comma
          */
-        fun raw(value: String) = Columns(value)
+        fun raw(value: String) = Columns(value.replace("\n", ""))
 
         /**
          * Select all columns given in the [columns] parameter


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Solves #543 

## What is the new behavior?

`Columns.Raw` now automatically gets rid of line breaks

## Additional context

Let me know if that's not the correct place to introduce it.
Should we also auto add `trimIndent()`?
