### PR TITLE
Add referenced table parameter to `or` and `and`

### DIFF
--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/filter/PostgrestFilterBuilder.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/filter/PostgrestFilterBuilder.kt
@@ -188,9 +188,12 @@ class PostgrestFilterBuilder(
      */
     @PostgrestFilterDSL
     inline fun or(negate: Boolean = false, referencedTable: String? = null, filter: @PostgrestFilterDSL PostgrestFilterBuilder.() -> Unit) {
-        val prefix = (if (negate) "not." else "") + (if(referencedTable !== null) "$referencedTable." else "")
+        val prefix = buildString {
+            if(negate) append("not.")
+            if(referencedTable !== null) append("$referencedTable.")
+        }
         val joiningFilter = formatJoiningFilter(filter)
-        if(joiningFilter == "()") return
+        if(joiningFilter == "()") return //empty logical expressions return a postgrest error
         _params[prefix + "or"] = listOf(joiningFilter) + if(isInLogicalExpression) _params[prefix + "or"] ?: emptyList() else emptyList()
     }
 
@@ -201,9 +204,12 @@ class PostgrestFilterBuilder(
      */
     @PostgrestFilterDSL
     inline fun and(negate: Boolean = false, referencedTable: String? = null, filter: @PostgrestFilterDSL PostgrestFilterBuilder.() -> Unit) {
-        val prefix = (if (negate) "not." else "") + (if(referencedTable !== null) "$referencedTable." else "")
+        val prefix = buildString {
+            if(negate) append("not.")
+            if(referencedTable !== null) append("$referencedTable.")
+        }
         val joiningFilter = formatJoiningFilter(filter)
-        if(joiningFilter == "()") return
+        if(joiningFilter == "()") return //empty logical expressions return a postgrest error
         _params[prefix + "and"] = listOf(joiningFilter) + if(isInLogicalExpression) _params[prefix + "and"] ?: emptyList() else emptyList()
     }
 

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/filter/PostgrestFilterBuilder.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/filter/PostgrestFilterBuilder.kt
@@ -190,7 +190,7 @@ class PostgrestFilterBuilder(
     inline fun or(negate: Boolean = false, referencedTable: String? = null, filter: @PostgrestFilterDSL PostgrestFilterBuilder.() -> Unit) {
         val prefix = buildString {
             if(negate) append("not.")
-            if(referencedTable !== null) append("$referencedTable.")
+            if(referencedTable != null) append("$referencedTable.")
         }
         val joiningFilter = formatJoiningFilter(filter)
         if(joiningFilter == "()") return //empty logical expressions return a postgrest error
@@ -206,7 +206,7 @@ class PostgrestFilterBuilder(
     inline fun and(negate: Boolean = false, referencedTable: String? = null, filter: @PostgrestFilterDSL PostgrestFilterBuilder.() -> Unit) {
         val prefix = buildString {
             if(negate) append("not.")
-            if(referencedTable !== null) append("$referencedTable.")
+            if(referencedTable != null) append("$referencedTable.")
         }
         val joiningFilter = formatJoiningFilter(filter)
         if(joiningFilter == "()") return //empty logical expressions return a postgrest error

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/filter/PostgrestFilterBuilder.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/filter/PostgrestFilterBuilder.kt
@@ -183,20 +183,28 @@ class PostgrestFilterBuilder(
 
     /**
      * Adds an `or` condition to the query
+     * @param negate Whether to negate the condition
+     * @param referencedTable The table to reference
      */
     @PostgrestFilterDSL
-    inline fun or(negate: Boolean = false, filter: @PostgrestFilterDSL PostgrestFilterBuilder.() -> Unit) {
-        val prefix = if(negate) "not." else ""
-        _params[prefix + "or"] = listOf(formatJoiningFilter(filter)) + if(isInLogicalExpression) _params[prefix + "or"] ?: emptyList() else emptyList()
+    inline fun or(negate: Boolean = false, referencedTable: String? = null, filter: @PostgrestFilterDSL PostgrestFilterBuilder.() -> Unit) {
+        val prefix = (if (negate) "not." else "") + (if(referencedTable !== null) "$referencedTable." else "")
+        val joiningFilter = formatJoiningFilter(filter)
+        if(joiningFilter == "()") return
+        _params[prefix + "or"] = listOf(joiningFilter) + if(isInLogicalExpression) _params[prefix + "or"] ?: emptyList() else emptyList()
     }
 
     /**
      * Adds an `and` condition to the query
+     * @param negate Whether to negate the condition
+     * @param referencedTable The table to reference
      */
     @PostgrestFilterDSL
-    inline fun and(negate: Boolean = false, filter: @PostgrestFilterDSL PostgrestFilterBuilder.() -> Unit) {
-        val prefix = if (negate) "not." else ""
-        _params[prefix + "and"] = listOf(formatJoiningFilter(filter)) + if(isInLogicalExpression) _params[prefix + "and"] ?: emptyList() else emptyList()
+    inline fun and(negate: Boolean = false, referencedTable: String? = null, filter: @PostgrestFilterDSL PostgrestFilterBuilder.() -> Unit) {
+        val prefix = (if (negate) "not." else "") + (if(referencedTable !== null) "$referencedTable." else "")
+        val joiningFilter = formatJoiningFilter(filter)
+        if(joiningFilter == "()") return
+        _params[prefix + "and"] = listOf(joiningFilter) + if(isInLogicalExpression) _params[prefix + "and"] ?: emptyList() else emptyList()
     }
 
     /**

--- a/Postgrest/src/commonTest/kotlin/PostgrestFilterBuilderTest.kt
+++ b/Postgrest/src/commonTest/kotlin/PostgrestFilterBuilderTest.kt
@@ -152,6 +152,66 @@ class PostgrestFilterBuilderTest {
     }
 
     @Test
+    fun and_referenced_table() {
+        val filter = filterToString {
+            and(referencedTable = "shops") {
+                eq("id", 1)
+                eq("id", 2)
+            }
+        }
+        assertEquals("shops.and=(id.eq.1,id.eq.2)", filter)
+    }
+
+    @Test
+    fun or_referenced_table() {
+        val filter = filterToString {
+            or(referencedTable = "shops") {
+                eq("id", 1)
+                eq("id", 2)
+            }
+        }
+        assertEquals("shops.or=(id.eq.1,id.eq.2)", filter)
+    }
+
+    @Test
+    fun and_negated() {
+        val filter = filterToString {
+            and(negate = true) {
+                eq("id", 1)
+                eq("id", 2)
+            }
+        }
+        assertEquals("not.and=(id.eq.1,id.eq.2)", filter)
+    }
+
+    @Test
+    fun or_negated() {
+        val filter = filterToString {
+            or(negate = true) {
+                eq("id", 1)
+                eq("id", 2)
+            }
+        }
+        assertEquals("not.or=(id.eq.1,id.eq.2)", filter)
+    }
+
+    @Test
+    fun and_empty() {
+        val filter = filterToString {
+            and { }
+        }
+        assertEquals("", filter)
+    }
+
+    @Test
+    fun or_empty() {
+        val filter = filterToString {
+            or { }
+        }
+        assertEquals("", filter)
+    }
+
+    @Test
     fun sl() {
         val filter = filterToString {
             sl("id", 1L to 10L)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

You cannot query foreign tables within a logical expression.

## What is the new behavior?

This should be possible now, however it seems like nested logical expression cannot use a referenced table.
I also added some more tests.