### PR TITLE
Move `enableLifecycleCallbacks` to common config and add minimalSettings profile

### DIFF
--- a/GoTrue/src/androidMain/kotlin/io/github/jan/supabase/gotrue/AuthConfig.kt
+++ b/GoTrue/src/androidMain/kotlin/io/github/jan/supabase/gotrue/AuthConfig.kt
@@ -12,11 +12,6 @@ import io.github.jan.supabase.plugins.CustomSerializationConfig
 actual class AuthConfig : CustomSerializationConfig, AuthConfigDefaults() {
 
     /**
-     * Whether to stop auto-refresh on focus loss, and resume it on focus again
-     */
-    var enableLifecycleCallbacks: Boolean = true
-
-    /**
      * The action to use for the OAuth flow. Can be overriden per-request in the [ExternalAuthConfig]
      */
     var defaultExternalAuthAction: ExternalAuthAction = ExternalAuthAction.DEFAULT

--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/AuthConfig.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/AuthConfig.kt
@@ -89,6 +89,13 @@ open class AuthConfigDefaults : MainConfig() {
      */
     var defaultRedirectUrl: String? = null
 
+    /**
+     * Whether to stop auto-refresh on focus loss, and resume it on focus again.
+     *
+     * Currently only supported on Android.
+     */
+    var enableLifecycleCallbacks: Boolean = true
+
 }
 
 /**
@@ -129,3 +136,26 @@ val AuthConfig.deepLinkOrNull: String?
         val host = host ?: return null
         return "${scheme}://${host}"
     }
+
+/**
+ * Applies minimal settings to the [AuthConfig]. This is useful for server side applications, where you don't need to store the session or code verifier.
+ * @param alwaysAutoRefresh Whether to always automatically refresh the session, when it expires
+ * @param autoLoadFromStorage Whether to automatically load the session from [sessionManager], when [Auth] is initialized
+ * @param autoSaveToStorage Whether to automatically save the session to [sessionManager], when the session changes
+ * @param sessionManager The session manager used to store/load the session.
+ * @param codeVerifierCache The cache used to store/load the code verifier for the [FlowType.PKCE] flow.
+ * @see AuthConfigDefaults
+ */
+fun AuthConfigDefaults.minimalSettings(
+    alwaysAutoRefresh: Boolean = false,
+    autoLoadFromStorage: Boolean = false,
+    autoSaveToStorage: Boolean = false,
+    sessionManager: SessionManager? = MemorySessionManager(),
+    codeVerifierCache: CodeVerifierCache? = MemoryCodeVerifierCache()
+) {
+    this.alwaysAutoRefresh = alwaysAutoRefresh
+    this.autoLoadFromStorage = autoLoadFromStorage
+    this.autoSaveToStorage = autoSaveToStorage
+    this.sessionManager = sessionManager
+    this.codeVerifierCache = codeVerifierCache
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

The config property `enableLifecycleCallbacks` is only available on Android. 
In addition to that, it is verbose to install a minimal Auth plugin for server-side applications or testing.

## What is the new behavior?

The config property is now available in the common source set (currently only used on Android) and there is a new method `AuthConfig#minimalSettings()`, which, by default, disabling session saving & loading and sets any cache to be memory only.

## Additional context

This is a backport from #558 
