### PR TITLE
Add missing destinationBucket to move & copy methods in BucketApi

### DIFF
--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/BucketApi.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/BucketApi.kt
@@ -124,7 +124,7 @@ sealed interface BucketApi {
      * @throws HttpRequestTimeoutException if the request timed out
      * @throws HttpRequestException on network related issues
      */
-    suspend fun move(from: String, to: String)
+    suspend fun move(from: String, to: String, destinationBucket: String? = null)
 
     /**
      * Copies a file under [from] to [to]
@@ -132,7 +132,7 @@ sealed interface BucketApi {
      * @throws HttpRequestTimeoutException if the request timed out
      * @throws HttpRequestException on network related issues
      */
-    suspend fun copy(from: String, to: String)
+    suspend fun copy(from: String, to: String, destinationBucket: String? = null)
 
     /**
      * Creates a signed url to upload without authentication.

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/BucketApi.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/BucketApi.kt
@@ -104,6 +104,7 @@ sealed interface BucketApi {
 
     /**
      * Deletes all files in [bucketId] with in [paths]
+     * @param paths The paths to delete
      * @throws RestException or one of its subclasses if receiving an error response
      * @throws HttpRequestTimeoutException if the request timed out
      * @throws HttpRequestException on network related issues
@@ -112,6 +113,7 @@ sealed interface BucketApi {
 
     /**
      * Deletes all files in [bucketId] with in [paths]
+     * @param paths The paths to delete
      * @throws RestException or one of its subclasses if receiving an error response
      * @throws HttpRequestTimeoutException if the request timed out
      * @throws HttpRequestException on network related issues
@@ -120,6 +122,9 @@ sealed interface BucketApi {
 
     /**
      * Moves a file under [from] to [to]
+     * @param from The path to move from
+     * @param to The path to move to
+     * @param destinationBucket The bucket to move the file to. If null, the file will be moved within the same bucket
      * @throws RestException or one of its subclasses if receiving an error response
      * @throws HttpRequestTimeoutException if the request timed out
      * @throws HttpRequestException on network related issues
@@ -128,6 +133,9 @@ sealed interface BucketApi {
 
     /**
      * Copies a file under [from] to [to]
+     * @param from The path to copy from
+     * @param to The path to copy to
+     * @param destinationBucket The destination bucket to copy to. If null, the current bucket is used
      * @throws RestException or one of its subclasses if receiving an error response
      * @throws HttpRequestTimeoutException if the request timed out
      * @throws HttpRequestException on network related issues

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/BucketApiImpl.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/BucketApiImpl.kt
@@ -74,19 +74,21 @@ internal class BucketApiImpl(override val bucketId: String, val storage: Storage
         })
     }
 
-    override suspend fun move(from: String, to: String) {
+    override suspend fun move(from: String, to: String, destinationBucket: String?) {
         storage.api.postJson("object/move", buildJsonObject {
             put("bucketId", bucketId)
             put("sourceKey", from)
             put("destinationKey", to)
+            destinationBucket?.let { put("destinationBucket", it) }
         })
     }
 
-    override suspend fun copy(from: String, to: String) {
+    override suspend fun copy(from: String, to: String, destinationBucket: String?) {
         storage.api.postJson("object/copy", buildJsonObject {
             put("bucketId", bucketId)
             put("sourceKey", from)
             put("destinationKey", to)
+            destinationBucket?.let { put("destinationBucket", it) }
         })
     }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

You cannot move or copy files from one bucket to another.

## What is the new behavior?

There is a new method parameter which allows this behavior.
