### PR TITLE
Remove suspend modifier on `postgrestListDataFlow` and clean the join payload on flow cancellation

### DIFF
--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeChannel.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeChannel.kt
@@ -73,6 +73,9 @@ sealed interface RealtimeChannel {
     @SupabaseInternal
     fun RealtimeChannel.addPostgresChange(data: PostgresJoinConfig)
 
+    @SupabaseInternal
+    fun RealtimeChannel.removePostgresChange(data: PostgresJoinConfig)
+
     /**
      * Represents the status of a channel
      */
@@ -163,7 +166,10 @@ inline fun <reified T : PostgresAction> RealtimeChannel.postgresChangeFlow(schem
         }
 
         val id = callbackManager.addPostgresCallback(config, callback)
-        awaitClose { callbackManager.removeCallbackById(id) }
+        awaitClose {
+            callbackManager.removeCallbackById(id)
+            removePostgresChange(config)
+        }
     }
 }
 

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeChannelImpl.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeChannelImpl.kt
@@ -190,6 +190,11 @@ internal class RealtimeChannelImpl(
         clientChanges.add(data)
     }
 
+    @SupabaseInternal
+    override fun RealtimeChannel.removePostgresChange(data: PostgresJoinConfig) {
+        clientChanges.remove(data)
+    }
+
     override suspend fun track(state: JsonObject) {
         if(status.value != RealtimeChannel.Status.SUBSCRIBED) {
             error("You can only track your presence after subscribing to the channel. Did you forget to call `channel.subscribe()`?")


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix & Feature (as observed in #560)

## What is the current behavior?

`postgrestListDataFlow` is suspending, which doesn't have to be. Also when a postgres flow method is cancelled, the join payload still includes the applied filter.

## What is the new behavior?

The method is no longer suspending and the join payload now gets properly cleaned.
