### PR TITLE
Add .kotlin to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /test/
 .idea
 local.properties
+.kotlin


### PR DESCRIPTION
With K2 we have a new `.kotlin` directory generated and needs to be added to `.gitignore`.

https://kotlinlang.org/docs/whatsnew-eap.html#new-directory-for-kotlin-data-in-gradle-projects