### PR TITLE
Avoid empty file created on Dashboard by early checking for empty data

### DIFF
--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/BucketApi.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/BucketApi.kt
@@ -70,12 +70,7 @@ sealed interface BucketApi {
     suspend fun uploadToSignedUrl(path: String, token: String, data: ByteArray, upsert: Boolean = false
     ): String {
         require(data.isNotEmpty()) { "The data to upload should not be empty" }
-        return uploadToSignedUrl(
-            path,
-            token,
-            UploadData(ByteReadChannel(data), data.size.toLong()),
-            upsert
-        )
+        return uploadToSignedUrl(path, token, UploadData(ByteReadChannel(data), data.size.toLong()), upsert)
     }
 
     /**

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/BucketApi.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/BucketApi.kt
@@ -65,6 +65,7 @@ sealed interface BucketApi {
      * @param data The data to upload
      * @param upsert Whether to overwrite an existing file
      * @return the key of the uploaded file
+     * @throws IllegalArgumentException if data to upload is empty
      */
     suspend fun uploadToSignedUrl(path: String, token: String, data: ByteArray, upsert: Boolean = false
     ): String {
@@ -102,6 +103,7 @@ sealed interface BucketApi {
      * @param data The new data
      * @param upsert Whether to overwrite an existing file
      * @return the key to the updated file
+     * @throws IllegalArgumentException if data to upload is empty
      * @throws RestException or one of its subclasses if receiving an error response
      * @throws HttpRequestTimeoutException if the request timed out
      * @throws HttpRequestException on network related issues

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/BucketApi.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/BucketApi.kt
@@ -90,12 +90,7 @@ sealed interface BucketApi {
      * @throws HttpRequestException on network related issues
      * @throws HttpRequestException on network related issues
      */
-    suspend fun uploadToSignedUrl(
-        path: String,
-        token: String,
-        data: UploadData,
-        upsert: Boolean = false
-    ): String
+    suspend fun uploadToSignedUrl(path: String, token: String, data: UploadData, upsert: Boolean = false): String
 
     /**
      * Updates a file in [bucketId] under [path]
@@ -204,8 +199,7 @@ sealed interface BucketApi {
      * @throws HttpRequestTimeoutException if the request timed out
      * @throws HttpRequestException on network related issues
      */
-    suspend fun createSignedUrls(expiresIn: Duration, vararg paths: String) =
-        createSignedUrls(expiresIn, paths.toList())
+    suspend fun createSignedUrls(expiresIn: Duration, vararg paths: String) = createSignedUrls(expiresIn, paths.toList())
 
     /**
      * Downloads a file from [bucketId] under [path]
@@ -216,10 +210,7 @@ sealed interface BucketApi {
      * @throws HttpRequestTimeoutException if the request timed out
      * @throws HttpRequestException on network related issues
      */
-    suspend fun downloadAuthenticated(
-        path: String,
-        transform: ImageTransformation.() -> Unit = {}
-    ): ByteArray
+    suspend fun downloadAuthenticated(path: String, transform: ImageTransformation.() -> Unit = {}): ByteArray
 
     /**
      * Downloads a file from [bucketId] under [path]
@@ -230,11 +221,7 @@ sealed interface BucketApi {
      * @throws HttpRequestTimeoutException if the request timed out
      * @throws HttpRequestException on network related issues
      */
-    suspend fun downloadAuthenticated(
-        path: String,
-        channel: ByteWriteChannel,
-        transform: ImageTransformation.() -> Unit = {}
-    )
+    suspend fun downloadAuthenticated(path: String, channel: ByteWriteChannel, transform: ImageTransformation.() -> Unit = {})
 
     /**
      * Downloads a file from [bucketId] under [path] using the public url
@@ -245,10 +232,7 @@ sealed interface BucketApi {
      * @throws HttpRequestTimeoutException if the request timed out
      * @throws HttpRequestException on network related issues
      */
-    suspend fun downloadPublic(
-        path: String,
-        transform: ImageTransformation.() -> Unit = {}
-    ): ByteArray
+    suspend fun downloadPublic(path: String, transform: ImageTransformation.() -> Unit = {}): ByteArray
 
     /**
      * Downloads a file from [bucketId] under [path] using the public url
@@ -259,11 +243,7 @@ sealed interface BucketApi {
      * @throws HttpRequestTimeoutException if the request timed out
      * @throws HttpRequestException on network related issues
      */
-    suspend fun downloadPublic(
-        path: String,
-        channel: ByteWriteChannel,
-        transform: ImageTransformation.() -> Unit = {}
-    )
+    suspend fun downloadPublic(path: String, channel: ByteWriteChannel, transform: ImageTransformation.() -> Unit = {})
 
 
     /**
@@ -341,8 +321,6 @@ sealed interface BucketApi {
  */
 fun BucketApi.authenticatedRequest(path: String): Pair<String, String> {
     val url = authenticatedUrl(path)
-    val token =
-        supabaseClient.storage.config.jwtToken ?: supabaseClient.pluginManager.getPluginOrNull(Auth)
-            ?.currentAccessTokenOrNull() ?: supabaseClient.supabaseKey
+    val token = supabaseClient.storage.config.jwtToken ?: supabaseClient.pluginManager.getPluginOrNull(Auth)?.currentAccessTokenOrNull() ?: supabaseClient.supabaseKey
     return token to url
 }

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/BucketApi.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/BucketApi.kt
@@ -66,17 +66,16 @@ sealed interface BucketApi {
      * @param upsert Whether to overwrite an existing file
      * @return the key of the uploaded file
      */
-    suspend fun uploadToSignedUrl(
-        path: String,
-        token: String,
-        data: ByteArray,
-        upsert: Boolean = false
-    ): String = uploadToSignedUrl(
-        path,
-        token,
-        UploadData(ByteReadChannel(data), data.size.toLong()),
-        upsert
-    )
+    suspend fun uploadToSignedUrl(path: String, token: String, data: ByteArray, upsert: Boolean = false
+    ): String {
+        require(data.isNotEmpty()) { "The data to upload should not be empty" }
+        return uploadToSignedUrl(
+            path,
+            token,
+            UploadData(ByteReadChannel(data), data.size.toLong()),
+            upsert
+        )
+    }
 
     /**
      * Uploads a file in [bucketId] under [path] using a presigned url
@@ -107,8 +106,10 @@ sealed interface BucketApi {
      * @throws HttpRequestTimeoutException if the request timed out
      * @throws HttpRequestException on network related issues
      */
-    suspend fun update(path: String, data: ByteArray, upsert: Boolean = false): String =
-        update(path, UploadData(ByteReadChannel(data), data.size.toLong()), upsert)
+    suspend fun update(path: String, data: ByteArray, upsert: Boolean = false): String {
+        require(data.isNotEmpty()) { "The data to upload should not be empty" }
+        return update(path, UploadData(ByteReadChannel(data), data.size.toLong()), upsert)
+    }
 
     /**
      * Updates a file in [bucketId] under [path]
@@ -179,11 +180,7 @@ sealed interface BucketApi {
      * @throws HttpRequestTimeoutException if the request timed out
      * @throws HttpRequestException on network related issues
      */
-    suspend fun createSignedUrl(
-        path: String,
-        expiresIn: Duration,
-        transform: ImageTransformation.() -> Unit = {}
-    ): String
+    suspend fun createSignedUrl(path: String, expiresIn: Duration, transform: ImageTransformation.() -> Unit = {}): String
 
     /**
      * Creates signed urls for all specified paths. The urls will expire after [expiresIn]


### PR DESCRIPTION
## What kind of change does this PR introduce?
This is to fix https://github.com/supabase-community/supabase-kt/issues/576

## What is the current behavior?
Silently create an empty file as detailed in the issue

## What is the new behavior?
Throw IllegalArgumentException when pass empty data to any upload function requiring data with `ByteArray` type

<img width="1006" alt="Screenshot 2024-04-30 at 20 37 32" src="https://github.com/supabase-community/supabase-kt/assets/43868345/8fe740c7-af45-4046-bb5a-2c41c6a4796f">

