### PR TITLE
Rethrow and log CancellationExceptions on network calls

### DIFF
--- a/src/commonMain/kotlin/io/github/jan/supabase/network/KtorSupabaseHttpClient.kt
+++ b/src/commonMain/kotlin/io/github/jan/supabase/network/KtorSupabaseHttpClient.kt
@@ -7,7 +7,6 @@ import io.github.jan.supabase.annotations.SupabaseInternal
 import io.github.jan.supabase.exceptions.HttpRequestException
 import io.github.jan.supabase.logging.d
 import io.github.jan.supabase.logging.e
-import io.github.jan.supabase.logging.w
 import io.github.jan.supabase.supabaseJson
 import io.ktor.client.HttpClient
 import io.ktor.client.HttpClientConfig
@@ -61,7 +60,7 @@ class KtorSupabaseHttpClient @SupabaseInternal constructor(
             SupabaseClient.LOGGER.e { "${request.method.value} request to endpoint $endPoint timed out after $requestTimeout ms" }
             throw e
         } catch(e: CancellationException) {
-            SupabaseClient.LOGGER.w { "${request.method.value} request to endpoint $endPoint was cancelled"}
+            SupabaseClient.LOGGER.e { "${request.method.value} request to endpoint $endPoint was cancelled"}
             throw e
         } catch(e: Exception) {
             SupabaseClient.LOGGER.e { "${request.method.value} request to endpoint $endPoint failed with exception ${e.message}" }
@@ -86,7 +85,7 @@ class KtorSupabaseHttpClient @SupabaseInternal constructor(
             SupabaseClient.LOGGER.e { "Request timed out after $requestTimeout ms on url $url" }
             throw e
         } catch(e: CancellationException) {
-            SupabaseClient.LOGGER.w { "Request was cancelled on url $url" }
+            SupabaseClient.LOGGER.e { "Request was cancelled on url $url" }
             throw e
         } catch(e: Exception) {
             SupabaseClient.LOGGER.e { "Request failed with ${e.message} on url $url" }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Enhancement (fixes #575)

## What is the current behavior?

CancellationExceptions get caught and never rethrown, so there is no way for applications to handle that.

## What is the new behavior?

The exception gets rethrown and logged.
