### PR TITLE
Introduce new flow extension functions for postgrest

### DIFF
--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/PostgrestExtensions.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/PostgrestExtensions.kt
@@ -14,14 +14,16 @@ import kotlin.reflect.KProperty1
  * This function listens for changes in the table and emits the new value whenever a change occurs.
  * @param primaryKey the primary key of the [Data] type
  * @param filter the filter to apply to the select query
+ * @param channelName the name of the channel to use for the realtime updates. If null, a channel name following the format "schema:table:id" will be generated
  */
 inline fun <reified Data : Any> PostgrestQueryBuilder.selectSingleValueAsFlow(
     primaryKey: PrimaryKey<Data>,
+    channelName: String? = null,
     crossinline filter: PostgrestFilterBuilder.() -> Unit
 ): Flow<Data> {
     val realtime = postgrest.supabaseClient.realtime as RealtimeImpl
     val id = realtime.nextIncrementId()
-    val channel = realtime.channel("$schema:$table:$id")
+    val channel = realtime.channel(channelName ?: "$schema:$table:$id")
     return flow {
         val dataFlow = channel.postgresSingleDataFlow(
             schema = this@selectSingleValueAsFlow.schema,
@@ -41,25 +43,29 @@ inline fun <reified Data : Any> PostgrestQueryBuilder.selectSingleValueAsFlow(
  * This function listens for changes in the table and emits the new value whenever a change occurs.
  * @param primaryKey the primary key of the [Data] type
  * @param filter the filter to apply to the select query
+ * @param channelName the name of the channel to use for the realtime updates. If null, a channel name following the format "schema:table:id" will be generated
  */
 inline fun <reified Data : Any, Value> PostgrestQueryBuilder.selectSingleValueAsFlow(
     primaryKey: KProperty1<Data, Value>,
+    channelName: String? = null,
     crossinline filter: PostgrestFilterBuilder.() -> Unit
-): Flow<Data> = selectSingleValueAsFlow(PrimaryKey(primaryKey.name) { primaryKey.get(it).toString() }, filter)
+): Flow<Data> = selectSingleValueAsFlow(PrimaryKey(primaryKey.name) { primaryKey.get(it).toString() }, channelName, filter)
 
 /**
  * Executes vertical filtering with select on [PostgrestQueryBuilder.table] and [PostgrestQueryBuilder.schema] and returns a [Flow] of a list of values matching the [filter].
  * This function listens for changes in the table and emits the new list whenever a change occurs.
  * @param primaryKey the primary key of the [Data] type
  * @param filter the filter to apply to the select query
+ * @param channelName the name of the channel to use for the realtime updates. If null, a channel name following the format "schema:table:id" will be generated
  */
 inline fun <reified Data : Any> PostgrestQueryBuilder.selectAsFlow(
     primaryKey: PrimaryKey<Data>,
+    channelName: String? = null,
     filter: FilterOperation? = null,
 ): Flow<List<Data>> {
     val realtime = postgrest.supabaseClient.realtime as RealtimeImpl
     val id = realtime.nextIncrementId()
-    val channel = realtime.channel("$schema:$table:$id")
+    val channel = realtime.channel(channelName ?: "$schema:$table:$id")
     return flow {
         val dataFlow = channel.postgresListDataFlow(
             schema = this@selectAsFlow.schema,
@@ -79,8 +85,10 @@ inline fun <reified Data : Any> PostgrestQueryBuilder.selectAsFlow(
  * This function listens for changes in the table and emits the new list whenever a change occurs.
  * @param primaryKey the primary key of the [Data] type
  * @param filter the filter to apply to the select query
+ * @param channelName the name of the channel to use for the realtime updates. If null, a channel name following the format "schema:table:id" will be generated
  */
 inline fun <reified Data : Any, Value> PostgrestQueryBuilder.selectAsFlow(
     primaryKey: KProperty1<Data, Value>,
+    channelName: String? = null,
     filter: FilterOperation? = null,
-): Flow<List<Data>> = selectAsFlow(PrimaryKey(primaryKey.name) { primaryKey.get(it).toString() }, filter)
+): Flow<List<Data>> = selectAsFlow(PrimaryKey(primaryKey.name) { primaryKey.get(it).toString() }, channelName, filter)

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/PostgrestExtensions.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/PostgrestExtensions.kt
@@ -53,7 +53,7 @@ inline fun <reified Data : Any, Value> PostgrestQueryBuilder.selectSingleValueAs
  * @param primaryKey the primary key of the [Data] type
  * @param filter the filter to apply to the select query
  */
-inline fun <reified Data : Any> PostgrestQueryBuilder.selectListAsFlow(
+inline fun <reified Data : Any> PostgrestQueryBuilder.selectAsFlow(
     primaryKey: PrimaryKey<Data>,
     filter: FilterOperation? = null,
 ): Flow<List<Data>> {
@@ -62,8 +62,8 @@ inline fun <reified Data : Any> PostgrestQueryBuilder.selectListAsFlow(
     val channel = realtime.channel("$schema:$table:$id")
     return flow {
         val dataFlow = channel.postgresListDataFlow(
-            schema = this@selectListAsFlow.schema,
-            table = this@selectListAsFlow.table,
+            schema = this@selectAsFlow.schema,
+            table = this@selectAsFlow.table,
             primaryKey = primaryKey,
             filter = filter
         )
@@ -80,7 +80,7 @@ inline fun <reified Data : Any> PostgrestQueryBuilder.selectListAsFlow(
  * @param primaryKey the primary key of the [Data] type
  * @param filter the filter to apply to the select query
  */
-inline fun <reified Data : Any, Value> PostgrestQueryBuilder.selectListAsFlow(
+inline fun <reified Data : Any, Value> PostgrestQueryBuilder.selectAsFlow(
     primaryKey: KProperty1<Data, Value>,
     filter: FilterOperation? = null,
-): Flow<List<Data>> = selectListAsFlow(PrimaryKey(primaryKey.name) { primaryKey.get(it).toString() }, filter)
+): Flow<List<Data>> = selectAsFlow(PrimaryKey(primaryKey.name) { primaryKey.get(it).toString() }, filter)

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/PostgrestExtensions.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/PostgrestExtensions.kt
@@ -14,7 +14,7 @@ import kotlin.reflect.KProperty1
  * This function listens for changes in the table and emits the new value whenever a change occurs.
  * @param primaryKey the primary key of the [Data] type
  * @param filter the filter to apply to the select query
- * @param channelName the name of the channel to use for the realtime updates. If null, a channel name following the format "schema:table:id" will be generated
+ * @param channelName the name of the channel to use for the realtime updates. If null, a channel name following the format "schema:table:id" will be used
  */
 inline fun <reified Data : Any> PostgrestQueryBuilder.selectSingleValueAsFlow(
     primaryKey: PrimaryKey<Data>,
@@ -43,7 +43,7 @@ inline fun <reified Data : Any> PostgrestQueryBuilder.selectSingleValueAsFlow(
  * This function listens for changes in the table and emits the new value whenever a change occurs.
  * @param primaryKey the primary key of the [Data] type
  * @param filter the filter to apply to the select query
- * @param channelName the name of the channel to use for the realtime updates. If null, a channel name following the format "schema:table:id" will be generated
+ * @param channelName the name of the channel to use for the realtime updates. If null, a channel name following the format "schema:table:id" will be used
  */
 inline fun <reified Data : Any, Value> PostgrestQueryBuilder.selectSingleValueAsFlow(
     primaryKey: KProperty1<Data, Value>,
@@ -56,7 +56,7 @@ inline fun <reified Data : Any, Value> PostgrestQueryBuilder.selectSingleValueAs
  * This function listens for changes in the table and emits the new list whenever a change occurs.
  * @param primaryKey the primary key of the [Data] type
  * @param filter the filter to apply to the select query
- * @param channelName the name of the channel to use for the realtime updates. If null, a channel name following the format "schema:table:id" will be generated
+ * @param channelName the name of the channel to use for the realtime updates. If null, a channel name following the format "schema:table:id" will be used
  */
 inline fun <reified Data : Any> PostgrestQueryBuilder.selectAsFlow(
     primaryKey: PrimaryKey<Data>,
@@ -85,7 +85,7 @@ inline fun <reified Data : Any> PostgrestQueryBuilder.selectAsFlow(
  * This function listens for changes in the table and emits the new list whenever a change occurs.
  * @param primaryKey the primary key of the [Data] type
  * @param filter the filter to apply to the select query
- * @param channelName the name of the channel to use for the realtime updates. If null, a channel name following the format "schema:table:id" will be generated
+ * @param channelName the name of the channel to use for the realtime updates. If null, a channel name following the format "schema:table:id" will be used
  */
 inline fun <reified Data : Any, Value> PostgrestQueryBuilder.selectAsFlow(
     primaryKey: KProperty1<Data, Value>,

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/PostgrestExtensions.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/PostgrestExtensions.kt
@@ -1,0 +1,86 @@
+package io.github.jan.supabase.realtime
+
+import io.github.jan.supabase.postgrest.query.PostgrestQueryBuilder
+import io.github.jan.supabase.postgrest.query.filter.FilterOperation
+import io.github.jan.supabase.postgrest.query.filter.PostgrestFilterBuilder
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.onCompletion
+import kotlin.reflect.KProperty1
+
+/**
+ * Executes vertical filtering with select on [PostgrestQueryBuilder.table] and [PostgrestQueryBuilder.schema] and returns a [Flow] of a single value matching the [filter].
+ * This function listens for changes in the table and emits the new value whenever a change occurs.
+ * @param primaryKey the primary key of the [Data] type
+ * @param filter the filter to apply to the select query
+ */
+inline fun <reified Data : Any> PostgrestQueryBuilder.selectSingleValueAsFlow(
+    primaryKey: PrimaryKey<Data>,
+    crossinline filter: PostgrestFilterBuilder.() -> Unit
+): Flow<Data> {
+    val realtime = postgrest.supabaseClient.realtime as RealtimeImpl
+    val id = realtime.nextIncrementId()
+    val channel = realtime.channel("$schema:$table:$id")
+    return flow {
+        val dataFlow = channel.postgresSingleDataFlow(
+            schema = this@selectSingleValueAsFlow.schema,
+            table = this@selectSingleValueAsFlow.table,
+            primaryKey = primaryKey,
+            filter = filter
+        )
+        channel.subscribe()
+        emitAll(dataFlow)
+    }.onCompletion {
+        realtime.removeChannel(channel)
+    }
+}
+
+/**
+ * Executes vertical filtering with select on [PostgrestQueryBuilder.table] and [PostgrestQueryBuilder.schema] and returns a [Flow] of a single value matching the [filter].
+ * This function listens for changes in the table and emits the new value whenever a change occurs.
+ * @param primaryKey the primary key of the [Data] type
+ * @param filter the filter to apply to the select query
+ */
+inline fun <reified Data : Any, Value> PostgrestQueryBuilder.selectSingleValueAsFlow(
+    primaryKey: KProperty1<Data, Value>,
+    crossinline filter: PostgrestFilterBuilder.() -> Unit
+): Flow<Data> = selectSingleValueAsFlow(PrimaryKey(primaryKey.name) { primaryKey.get(it).toString() }, filter)
+
+/**
+ * Executes vertical filtering with select on [PostgrestQueryBuilder.table] and [PostgrestQueryBuilder.schema] and returns a [Flow] of a list of values matching the [filter].
+ * This function listens for changes in the table and emits the new list whenever a change occurs.
+ * @param primaryKey the primary key of the [Data] type
+ * @param filter the filter to apply to the select query
+ */
+inline fun <reified Data : Any> PostgrestQueryBuilder.selectListAsFlow(
+    primaryKey: PrimaryKey<Data>,
+    filter: FilterOperation? = null,
+): Flow<List<Data>> {
+    val realtime = postgrest.supabaseClient.realtime as RealtimeImpl
+    val id = realtime.nextIncrementId()
+    val channel = realtime.channel("$schema:$table:$id")
+    return flow {
+        val dataFlow = channel.postgresListDataFlow(
+            schema = this@selectListAsFlow.schema,
+            table = this@selectListAsFlow.table,
+            primaryKey = primaryKey,
+            filter = filter
+        )
+        channel.subscribe()
+        emitAll(dataFlow)
+    }.onCompletion {
+        realtime.removeChannel(channel)
+    }
+}
+
+/**
+ * Executes vertical filtering with select on [PostgrestQueryBuilder.table] and [PostgrestQueryBuilder.schema] and returns a [Flow] of a list of values matching the [filter].
+ * This function listens for changes in the table and emits the new list whenever a change occurs.
+ * @param primaryKey the primary key of the [Data] type
+ * @param filter the filter to apply to the select query
+ */
+inline fun <reified Data : Any, Value> PostgrestQueryBuilder.selectListAsFlow(
+    primaryKey: KProperty1<Data, Value>,
+    filter: FilterOperation? = null,
+): Flow<List<Data>> = selectListAsFlow(PrimaryKey(primaryKey.name) { primaryKey.get(it).toString() }, filter)

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/PostgrestExtensions.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/PostgrestExtensions.kt
@@ -22,8 +22,7 @@ inline fun <reified Data : Any> PostgrestQueryBuilder.selectSingleValueAsFlow(
     crossinline filter: PostgrestFilterBuilder.() -> Unit
 ): Flow<Data> {
     val realtime = postgrest.supabaseClient.realtime as RealtimeImpl
-    val id = realtime.nextIncrementId()
-    val channel = realtime.channel(channelName ?: "$schema:$table:$id")
+    val channel = realtime.channel(channelName ?: defaultChannelName(schema, table, realtime))
     return flow {
         val dataFlow = channel.postgresSingleDataFlow(
             schema = this@selectSingleValueAsFlow.schema,
@@ -64,8 +63,7 @@ inline fun <reified Data : Any> PostgrestQueryBuilder.selectAsFlow(
     filter: FilterOperation? = null,
 ): Flow<List<Data>> {
     val realtime = postgrest.supabaseClient.realtime as RealtimeImpl
-    val id = realtime.nextIncrementId()
-    val channel = realtime.channel(channelName ?: "$schema:$table:$id")
+    val channel = realtime.channel(channelName ?: defaultChannelName(schema, table, realtime))
     return flow {
         val dataFlow = channel.postgresListDataFlow(
             schema = this@selectAsFlow.schema,
@@ -92,3 +90,6 @@ inline fun <reified Data : Any, Value> PostgrestQueryBuilder.selectAsFlow(
     channelName: String? = null,
     filter: FilterOperation? = null,
 ): Flow<List<Data>> = selectAsFlow(PrimaryKey(primaryKey.name) { primaryKey.get(it).toString() }, channelName, filter)
+
+@PublishedApi
+internal fun defaultChannelName(schema: String, table: String, realtimeImpl: RealtimeImpl) = "$schema:$table:${realtimeImpl.nextIncrementId()}"

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeImpl.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeImpl.kt
@@ -38,7 +38,7 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.json.buildJsonObject
 import kotlin.time.Duration.Companion.milliseconds
 
-internal class RealtimeImpl(override val supabaseClient: SupabaseClient, override val config: Realtime.Config) : Realtime {
+@PublishedApi internal class RealtimeImpl(override val supabaseClient: SupabaseClient, override val config: Realtime.Config) : Realtime {
 
     private var ws: DefaultClientWebSocketSession? = null
     @Suppress("MagicNumber")
@@ -63,6 +63,7 @@ internal class RealtimeImpl(override val supabaseClient: SupabaseClient, overrid
 
     override var serializer = config.serializer ?: supabaseClient.defaultSerializer
     private val websocketUrl = realtimeWebsocketUrl()
+    private var incrementId by atomic(0)
 
     override suspend fun connect() = connect(false)
 
@@ -282,6 +283,10 @@ internal class RealtimeImpl(override val supabaseClient: SupabaseClient, overrid
             delay(msPerEvent.milliseconds)
             inThrottle = false
         }
+    }
+
+    fun nextIncrementId(): Int {
+        return incrementId++
     }
 
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature (closes #570)

## What is the current behavior?

For receiving realtime updates for your tables, you had to use a realtime channel and handle subscribing/unsubscribing yourself. 

## What is the new behavior?

There are two new methods `PostgrestQueryBuilder#selectSingleValueAsFlow` and `PostgrestQueryBuilder#selectListAsFlow` which handle all that channel management internally. You will just have to call these new methods:
```kotlin
//Not a suspending function, subscribing and unsubscribing is handled internally
supabase.from("products").selectSingleValueAsFlow(Product::id) {
    Product::id eq 2
}.collect {
    println(it)
}
```
```kotlin
supabase.from("products").selectAsFlow(Product::id, filter = FilterOperation("id", FilterOperator.GT, 2)).collect {
    println(it)
}
```
