### PR TITLE
Add region parameter to functions

### DIFF
--- a/Functions/src/commonMain/kotlin/io/github/jan/supabase/functions/FunctionRegion.kt
+++ b/Functions/src/commonMain/kotlin/io/github/jan/supabase/functions/FunctionRegion.kt
@@ -1,0 +1,23 @@
+package io.github.jan.supabase.functions
+
+/**
+ * The region where the function is invoked.
+ * @param value The value of the region
+ */
+enum class FunctionRegion(val value: String) {
+    Any("any"),
+    ApNortheast1("ap-northeast-1"),
+    ApNortheast2("ap-northeast-2"),
+    ApSouth1("ap-south-1"),
+    ApSoutheast1("ap-southeast-1"),
+    ApSoutheast2("ap-southeast-2"),
+    CaCentral1("ca-central-1"),
+    EuCentral1("eu-central-1"),
+    EuWest1("eu-west-1"),
+    EuWest2("eu-west-2"),
+    EuWest3("eu-west-3"),
+    SaEast1("sa-east-1"),
+    UsEast1("us-east-1"),
+    UsWest1("us-west-1"),
+    UsWest2("us-west-2"),
+}

--- a/Functions/src/commonMain/kotlin/io/github/jan/supabase/functions/Functions.kt
+++ b/Functions/src/commonMain/kotlin/io/github/jan/supabase/functions/Functions.kt
@@ -18,6 +18,7 @@ import io.github.jan.supabase.plugins.SupabasePluginProvider
 import io.github.jan.supabase.serializer.KotlinXSerializer
 import io.ktor.client.plugins.HttpRequestTimeoutException
 import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.client.request.header
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsText
@@ -61,12 +62,16 @@ class Functions(override val config: Config, override val supabaseClient: Supaba
      * Invokes a remote edge function. The authorization token is automatically added to the request.
      * @param function The function to invoke
      * @param builder The request builder to configure the request
+     * @param region The region where the function is invoked
      * @throws RestException or one of its subclasses if receiving an error response
      * @throws HttpRequestTimeoutException if the request timed out
      * @throws HttpRequestException on network related issues
      */
-    suspend inline operator fun invoke(function: String, crossinline builder: HttpRequestBuilder.() -> Unit): HttpResponse {
-        return api.post(function, builder)
+    suspend inline operator fun invoke(function: String, region: FunctionRegion = config.defaultRegion, crossinline builder: HttpRequestBuilder.() -> Unit): HttpResponse {
+        return api.post(function) {
+            builder()
+            header("x-region", region.value)
+        }
     }
 
     /**
@@ -75,12 +80,14 @@ class Functions(override val config: Config, override val supabaseClient: Supaba
      * @param function The function to invoke
      * @param body The body of the request
      * @param headers Headers to add to the request
+     * @param region The region where the function is invoked
      * @throws RestException or one of its subclasses if receiving an error response
      * @throws HttpRequestTimeoutException if the request timed out
      * @throws HttpRequestException on network related issues
      */
-    suspend inline operator fun <reified T : Any> invoke(function: String, body: T, headers: Headers = Headers.Empty): HttpResponse = invoke(function) {
+    suspend inline operator fun <reified T : Any> invoke(function: String, body: T, region: FunctionRegion = config.defaultRegion, headers: Headers = Headers.Empty): HttpResponse = invoke(function) {
         this.headers.appendAll(headers)
+        header("x-region", region.value)
         setBody(serializer.encode(body))
     }
 
@@ -88,21 +95,35 @@ class Functions(override val config: Config, override val supabaseClient: Supaba
      * Invokes a remote edge function. The authorization token is automatically added to the request.
      * @param function The function to invoke
      * @param headers Headers to add to the request
+     * @param region The region where the function is invoked
      * @throws RestException or one of its subclasses if receiving an error response
      * @throws HttpRequestTimeoutException if the request timed out
      * @throws HttpRequestException on network related issues
      */
-    suspend inline operator fun invoke(function: String, headers: Headers = Headers.Empty): HttpResponse = invoke(function) {
+    suspend inline operator fun invoke(function: String, region: FunctionRegion = config.defaultRegion, headers: Headers = Headers.Empty): HttpResponse = invoke(function) {
         this.headers.appendAll(headers)
+        header("x-region", region.value)
     }
 
     /**
      * Builds an [EdgeFunction] which can be invoked multiple times
      * @param function The function name
      * @param headers Headers to add to the requests when invoking the function
+     * @param region The region where the function is invoked
      */
     @OptIn(SupabaseInternal::class)
-    fun buildEdgeFunction(function: String, headers: Headers = Headers.Empty) = EdgeFunction(function, headers, supabaseClient)
+    fun buildEdgeFunction(
+        function: String,
+        region: FunctionRegion = config.defaultRegion,
+        headers: Headers = Headers.Empty
+    ) = EdgeFunction(
+        functionName = function,
+        headers = Headers.build {
+            appendAll(headers)
+            append("x-region", region.value)
+        },
+        supabaseClient = supabaseClient
+    )
 
     override suspend fun parseErrorResponse(response: HttpResponse): RestException {
         val error = response.bodyAsText()
@@ -123,6 +144,11 @@ class Functions(override val config: Config, override val supabaseClient: Supaba
     class Config : MainConfig(), CustomSerializationConfig {
 
         override var serializer: SupabaseSerializer? = null
+
+        /**
+         * The default region to use when invoking a function
+         */
+        var defaultRegion: FunctionRegion = FunctionRegion.Any
 
     }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

You can only change the region by setting the required header yourself.

## What is the new behavior?

There is now a new parameter for each invoke function to set the region. This parameter defaults to `Functions.Config#defaultRegion`. 

