### PR TITLE
Fix "Login in with" typo

### DIFF
--- a/plugins/ComposeAuthUI/src/commonMain/kotlin/io/github/jan/supabase/compose/auth/ui/ProviderButton.kt
+++ b/plugins/ComposeAuthUI/src/commonMain/kotlin/io/github/jan/supabase/compose/auth/ui/ProviderButton.kt
@@ -44,8 +44,8 @@ fun ProviderIcon(provider: OAuthProvider, contentDescription: String?, modifier:
  */
 @SupabaseExperimental
 @Composable
-fun RowScope.ProviderButtonContent(provider: OAuthProvider, text: String = "Login in with ${provider.name.capitalize()}") {
-    ProviderIcon(provider, "Login in with ${provider.name}", Modifier.size(DEFAULT_ICON_SIZE))
+fun RowScope.ProviderButtonContent(provider: OAuthProvider, text: String = "Login with ${provider.name.capitalize()}") {
+    ProviderIcon(provider, "Login with ${provider.name}", Modifier.size(DEFAULT_ICON_SIZE))
     Spacer(Modifier.width(8.dp))
     Text(text)
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Typo fix: "Login in with" -> "Login with"

## What is the current behavior?

<img width="429" alt="image" src="https://github.com/supabase-community/supabase-kt/assets/1144450/dbdc5429-994d-4f93-ad66-ce5ec65c1ea9">

## What is the new behavior?

Typo fixed
