### PR TITLE
Remove OtpType deprecation notice and clarify documentation

### DIFF
--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/OtpType.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/OtpType.kt
@@ -19,7 +19,7 @@ sealed interface OtpType {
         /**
          * Magic link OTP type
          *
-         * **Note: If you verify an OTP using [Auth.verifyEmailOtp] you can use [Email.EMAIL] to cover all email OTP types**
+         * **Note: If you verify an OTP using [Auth.verifyEmailOtp] you can use [Email.EMAIL] to cover both the [MAGIC_LINK] and [SIGNUP] OTP types**
          *
          * if you want to resend an OTP, use the according type. In this case [MAGIC_LINK]
          */
@@ -27,7 +27,7 @@ sealed interface OtpType {
         /**
          * OTP type for signing up
          *
-         * **Note: If you verify an OTP using [Auth.verifyEmailOtp] you can use [Email.EMAIL] to cover all email OTP types**
+         * **Note: If you verify an OTP using [Auth.verifyEmailOtp] you can use [Email.EMAIL] to cover both the [MAGIC_LINK] and [SIGNUP] OTP types**
          *
          * if you want to resend an OTP, use the according type. In this case [SIGNUP]
          */

--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/OtpType.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/OtpType.kt
@@ -16,11 +16,37 @@ sealed interface OtpType {
      * Email OTP types
      */
     enum class Email(override val type: String): OtpType {
-        @Deprecated("Use OtpType.Email.EMAIL instead", ReplaceWith("OtpType.Email.EMAIL")) MAGIC_LINK("magiclink"),
-        @Deprecated("Use OtpType.Email.EMAIL instead", ReplaceWith("OtpType.Email.EMAIL")) SIGNUP("signup"),
+        /**
+         * Magic link OTP type
+         *
+         * **Note: If you verify an OTP using [Auth.verifyEmailOtp] you can use [Email.EMAIL] to cover all email OTP types**
+         *
+         * if you want to resend an OTP, use the according type. In this case [MAGIC_LINK]
+         */
+        MAGIC_LINK("magiclink"),
+        /**
+         * OTP type for signing up
+         *
+         * **Note: If you verify an OTP using [Auth.verifyEmailOtp] you can use [Email.EMAIL] to cover all email OTP types**
+         *
+         * if you want to resend an OTP, use the according type. In this case [SIGNUP]
+         */
+        SIGNUP("signup"),
+        /**
+         * OTP type for inviting users
+         */
         INVITE("invite"),
+        /**
+         * OTP type for recovering accounts
+         */
         RECOVERY("recovery"),
+        /**
+         * OTP type for changing email addresses
+         */
         EMAIL_CHANGE("email_change"),
+        /**
+         * OTP type combining all email OTP types
+         */
         EMAIL("email")
     }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix/Improvement (closes #591)

## What is the current behavior?

`OtpType.Email.SIGNUP` and `OtpType.Email.MAGIC_LINK` were deprecated. See #591 

## What is the new behavior?

This deprecation has been removed, and the documentation has been clarified on which you should use when.