### PR TITLE
Add AuthUiExperimental annotation

### DIFF
--- a/plugins/ComposeAuthUI/src/commonMain/kotlin/io/github/jan/supabase/compose/auth/ui/AuthState.kt
+++ b/plugins/ComposeAuthUI/src/commonMain/kotlin/io/github/jan/supabase/compose/auth/ui/AuthState.kt
@@ -6,13 +6,13 @@ import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.saveable.mapSaver
 import androidx.compose.runtime.saveable.rememberSaveable
-import io.github.jan.supabase.annotations.SupabaseExperimental
 import io.github.jan.supabase.annotations.SupabaseInternal
+import io.github.jan.supabase.compose.auth.ui.annotations.AuthUiExperimental
 
 /**
  * Represents the state of auth forms.
  */
-@SupabaseExperimental
+@AuthUiExperimental
 class AuthState(
     states: Map<String, Boolean> = emptyMap()
 ) {
@@ -65,6 +65,7 @@ class AuthState(
 /**
  * Local composition for [AuthState]. Use [AuthForm] for automatic saving and restoring.
  */
+@AuthUiExperimental
 val LocalAuthState = compositionLocalOf {
     AuthState() //possibly to throw an error here
 }
@@ -74,6 +75,7 @@ val LocalAuthState = compositionLocalOf {
  * @param state The [AuthState] to provide.
  * @param content The content to provide the [AuthState] to.
  */
+@AuthUiExperimental
 @Composable
 fun AuthForm(
     state: AuthState = rememberSaveable(saver = AuthState.SAVER) { AuthState() },

--- a/plugins/ComposeAuthUI/src/commonMain/kotlin/io/github/jan/supabase/compose/auth/ui/FormComponent.kt
+++ b/plugins/ComposeAuthUI/src/commonMain/kotlin/io/github/jan/supabase/compose/auth/ui/FormComponent.kt
@@ -5,7 +5,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
-import io.github.jan.supabase.annotations.SupabaseExperimental
+import io.github.jan.supabase.compose.auth.ui.annotations.AuthUiExperimental
 
 /**
  * A component that represents a form field.
@@ -14,7 +14,7 @@ import io.github.jan.supabase.annotations.SupabaseExperimental
  * @param mandatory Whether the form field is mandatory or not. If false, will not affect the [AuthState.validForm] value. Default is true.
  * @param content The composable function that defines the content of the form field and receives a mutable state object as a parameter.
  */
-@SupabaseExperimental
+@AuthUiExperimental
 @Composable
 fun FormComponent(key: String, mandatory: Boolean = true, content: @Composable (valid: MutableState<Boolean>) -> Unit) {
     val state = LocalAuthState.current

--- a/plugins/ComposeAuthUI/src/commonMain/kotlin/io/github/jan/supabase/compose/auth/ui/ProviderButton.kt
+++ b/plugins/ComposeAuthUI/src/commonMain/kotlin/io/github/jan/supabase/compose/auth/ui/ProviderButton.kt
@@ -11,7 +11,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
-import io.github.jan.supabase.annotations.SupabaseExperimental
+import io.github.jan.supabase.compose.auth.ui.annotations.AuthUiExperimental
 import io.github.jan.supabase.gotrue.providers.OAuthProvider
 
 internal val DEFAULT_ICON_SIZE = 24.dp //from Material3
@@ -23,7 +23,7 @@ internal val DEFAULT_ICON_SIZE = 24.dp //from Material3
  * @param contentDescription The content description for the icon.
  * @param modifier The modifier to be applied to the icon. Note that the size of the icon is not fixed.
  */
-@SupabaseExperimental
+@AuthUiExperimental
 @Composable
 fun ProviderIcon(provider: OAuthProvider, contentDescription: String?, modifier: Modifier = Modifier) {
     providerPainter(provider, LocalDensity.current)?.let {
@@ -42,7 +42,7 @@ fun ProviderIcon(provider: OAuthProvider, contentDescription: String?, modifier:
  * @param provider The OAuth provider to authenticate with.
  * @param text The text to display in the button. Default value is "Login in with" followed by the capitalized provider name.
  */
-@SupabaseExperimental
+@AuthUiExperimental
 @Composable
 fun RowScope.ProviderButtonContent(provider: OAuthProvider, text: String = "Login with ${provider.name.capitalize()}") {
     ProviderIcon(provider, "Login with ${provider.name}", Modifier.size(DEFAULT_ICON_SIZE))

--- a/plugins/ComposeAuthUI/src/commonMain/kotlin/io/github/jan/supabase/compose/auth/ui/annotations/AuthUiExperimental.kt
+++ b/plugins/ComposeAuthUI/src/commonMain/kotlin/io/github/jan/supabase/compose/auth/ui/annotations/AuthUiExperimental.kt
@@ -1,0 +1,7 @@
+package io.github.jan.supabase.compose.auth.ui.annotations
+
+/**
+ * Used to mark experimental APIs
+ */
+@RequiresOptIn(level = RequiresOptIn.Level.ERROR, message = "This API is experimental and may not be stable yet")
+annotation class AuthUiExperimental

--- a/plugins/ComposeAuthUI/src/commonMain/kotlin/io/github/jan/supabase/compose/auth/ui/email/EmailField.kt
+++ b/plugins/ComposeAuthUI/src/commonMain/kotlin/io/github/jan/supabase/compose/auth/ui/email/EmailField.kt
@@ -20,10 +20,10 @@ import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.TextFieldValue
-import io.github.jan.supabase.annotations.SupabaseExperimental
 import io.github.jan.supabase.compose.auth.ui.AuthIcons
 import io.github.jan.supabase.compose.auth.ui.FormComponent
 import io.github.jan.supabase.compose.auth.ui.FormValidator
+import io.github.jan.supabase.compose.auth.ui.annotations.AuthUiExperimental
 import io.github.jan.supabase.compose.auth.ui.rememberMailIcon
 
 /**
@@ -50,7 +50,7 @@ import io.github.jan.supabase.compose.auth.ui.rememberMailIcon
  * @param mandatory Whether the form field is mandatory or not. If false, will not affect the [AuthState.validForm] value. You can also make this value dynamic and only make the field mandatory, if e.g. the [value] is not empty. Default is true.
  */
 @ExperimentalMaterial3Api
-@SupabaseExperimental
+@AuthUiExperimental
 @Composable
 fun EmailField(
     value: String,
@@ -130,7 +130,7 @@ fun EmailField(
  * @param formKey The key to store the validity of the email field in the AuthState. Defaults to "EMAIL".
  * @param mandatory Whether the form field is mandatory or not. If false, will not affect the [AuthState.validForm] value. You can also make this value dynamic and only make the field mandatory, if e.g. the [value] is not empty. Default is true.
  */
-@SupabaseExperimental
+@AuthUiExperimental
 @ExperimentalMaterial3Api
 @Composable
 fun EmailField(
@@ -211,7 +211,7 @@ fun EmailField(
  * @param formKey The key to store the validity of the email field in the AuthState. Defaults to "EMAIL".
  * @param mandatory Whether the form field is mandatory or not. If false, will not affect the [AuthState.validForm] value. You can also make this value dynamic and only make the field mandatory, if e.g. the [value] is not empty. Default is true.
  */
-@SupabaseExperimental
+@AuthUiExperimental
 @ExperimentalMaterial3Api
 @Composable
 fun OutlinedEmailField(
@@ -292,7 +292,7 @@ fun OutlinedEmailField(
  * @param formKey The key to store the validity of the email field in the AuthState. Defaults to "EMAIL".
  * @param mandatory Whether the form field is mandatory or not. If false, will not affect the [AuthState.validForm] value. You can also make this value dynamic and only make the field mandatory, if e.g. the [value] is not empty. Default is true.
  */
-@SupabaseExperimental
+@AuthUiExperimental
 @ExperimentalMaterial3Api
 @Composable
 fun OutlinedEmailField(

--- a/plugins/ComposeAuthUI/src/commonMain/kotlin/io/github/jan/supabase/compose/auth/ui/password/PasswordField.kt
+++ b/plugins/ComposeAuthUI/src/commonMain/kotlin/io/github/jan/supabase/compose/auth/ui/password/PasswordField.kt
@@ -25,9 +25,9 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.input.VisualTransformation
-import io.github.jan.supabase.annotations.SupabaseExperimental
 import io.github.jan.supabase.compose.auth.ui.AuthIcons
 import io.github.jan.supabase.compose.auth.ui.FormComponent
+import io.github.jan.supabase.compose.auth.ui.annotations.AuthUiExperimental
 import io.github.jan.supabase.compose.auth.ui.rememberLockIcon
 import io.github.jan.supabase.compose.auth.ui.rememberVisibilityIcon
 import io.github.jan.supabase.compose.auth.ui.rememberVisibilityOffIcon
@@ -55,7 +55,7 @@ import io.github.jan.supabase.compose.auth.ui.rememberVisibilityOffIcon
  * @param formKey The key to store the validity of the password field in the AuthState. Defaults to "EMAIL".
  * @param mandatory Whether the form field is mandatory or not. If false, will not affect the [AuthState.validForm] value. You can also make this value dynamic and only make the field mandatory, if e.g. the [value] is not empty. Default is true.
  */
-@SupabaseExperimental
+@AuthUiExperimental
 @ExperimentalMaterial3Api
 @Composable
 fun PasswordField(
@@ -141,7 +141,7 @@ fun PasswordField(
  * @param formKey The key to store the validity of the password field in the AuthState. Defaults to "EMAIL".
  * @param mandatory Whether the form field is mandatory or not. If false, will not affect the [AuthState.validForm] value. You can also make this value dynamic and only make the field mandatory, if e.g. the [value] is not empty. Default is true.
  */
-@SupabaseExperimental
+@AuthUiExperimental
 @ExperimentalMaterial3Api
 @Composable
 fun PasswordField(
@@ -228,7 +228,7 @@ fun PasswordField(
  * @param formKey The key to store the validity of the password field in the AuthState. Defaults to "EMAIL".
  * @param mandatory Whether the form field is mandatory or not. If false, will not affect the [AuthState.validForm] value. You can also make this value dynamic and only make the field mandatory, if e.g. the [value] is not empty. Default is true.
  */
-@SupabaseExperimental
+@AuthUiExperimental
 @ExperimentalMaterial3Api
 @Composable
 fun OutlinedPasswordField(
@@ -314,7 +314,7 @@ fun OutlinedPasswordField(
  * @param formKey The key to store the validity of the password field in the AuthState. Defaults to "EMAIL".
  * @param mandatory Whether the form field is mandatory or not. If false, will not affect the [AuthState.validForm] value. You can also make this value dynamic and only make the field mandatory, if e.g. the [value] is not empty. Default is true.
  */
-@SupabaseExperimental
+@AuthUiExperimental
 @ExperimentalMaterial3Api
 @Composable
 fun OutlinedPasswordField(

--- a/plugins/ComposeAuthUI/src/commonMain/kotlin/io/github/jan/supabase/compose/auth/ui/phone/PhoneField.kt
+++ b/plugins/ComposeAuthUI/src/commonMain/kotlin/io/github/jan/supabase/compose/auth/ui/phone/PhoneField.kt
@@ -20,10 +20,10 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.input.VisualTransformation
-import io.github.jan.supabase.annotations.SupabaseExperimental
 import io.github.jan.supabase.compose.auth.ui.AuthIcons
 import io.github.jan.supabase.compose.auth.ui.FormComponent
 import io.github.jan.supabase.compose.auth.ui.FormValidator
+import io.github.jan.supabase.compose.auth.ui.annotations.AuthUiExperimental
 import io.github.jan.supabase.compose.auth.ui.rememberCallIcon
 
 private const val DEFAULT_MASK = "+## ### #########"
@@ -54,7 +54,7 @@ private const val DEFAULT_MASK_CHAR = '#'
  * @param formKey The key to store the validity of the phone field in the AuthState. Defaults to "EMAIL".
  * @param mandatory Whether the form field is mandatory or not. If false, will not affect the [AuthState.validForm] value. You can also make this value dynamic and only make the field mandatory, if e.g. the [value] is not empty. Default is true.
  */
-@SupabaseExperimental
+@AuthUiExperimental
 @Composable
 fun PhoneField(
     value: String,
@@ -143,7 +143,7 @@ fun PhoneField(
  * @param formKey The key to store the validity of the phone field in the AuthState. Defaults to "EMAIL".
  * @param mandatory Whether the form field is mandatory or not. If false, will not affect the [AuthState.validForm] value. You can also make this value dynamic and only make the field mandatory, if e.g. the [value] is not empty. Default is true.
  */
-@SupabaseExperimental
+@AuthUiExperimental
 @Composable
 fun PhoneField(
     value: TextFieldValue,
@@ -232,7 +232,7 @@ fun PhoneField(
  * @param formKey The key to store the validity of the phone field in the AuthState. Defaults to "EMAIL".
  * @param mandatory Whether the form field is mandatory or not. If false, will not affect the [AuthState.validForm] value. You can also make this value dynamic and only make the field mandatory, if e.g. the [value] is not empty. Default is true.
  */
-@SupabaseExperimental
+@AuthUiExperimental
 @Composable
 fun OutlinedPhoneField(
     value: TextFieldValue,
@@ -321,7 +321,7 @@ fun OutlinedPhoneField(
  * @param formKey The key to store the validity of the phone field in the AuthState. Defaults to "EMAIL".
  * @param mandatory Whether the form field is mandatory or not. If false, will not affect the [AuthState.validForm] value. You can also make this value dynamic and only make the field mandatory, if e.g. the [value] is not empty. Default is true.
  */
-@SupabaseExperimental
+@AuthUiExperimental
 @Composable
 fun OutlinedPhoneField(
     value: String,

--- a/plugins/ComposeAuthUI/src/commonMain/kotlin/io/github/jan/supabase/compose/auth/ui/phone/PhoneVisualTransformation.kt
+++ b/plugins/ComposeAuthUI/src/commonMain/kotlin/io/github/jan/supabase/compose/auth/ui/phone/PhoneVisualTransformation.kt
@@ -5,7 +5,7 @@ import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.input.OffsetMapping
 import androidx.compose.ui.text.input.TransformedText
 import androidx.compose.ui.text.input.VisualTransformation
-import io.github.jan.supabase.annotations.SupabaseExperimental
+import io.github.jan.supabase.compose.auth.ui.annotations.AuthUiExperimental
 
 /**
  * Represents a phone number visual transformation.
@@ -14,7 +14,7 @@ import io.github.jan.supabase.annotations.SupabaseExperimental
  * @param maskNumber The character used in the mask to represent a digit.
  *
  */
-@SupabaseExperimental
+@AuthUiExperimental
 class PhoneVisualTransformation(val mask: String, val maskNumber: Char) : VisualTransformation {
 
     private val maxLength = mask.count { it == maskNumber }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes #599 

## What is the current behavior?

UI modules have to depend on another supabase module to be able to opt in experimental features.

## What is the new behavior?

There's now an specific annotation for Auth UI module so experimental features can be opted-in w/o any other dependency.
