### PR TITLE
Fix session expiry calculation

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,5 +9,5 @@ org.gradle.parallel=true
 org.jetbrains.compose.experimental.uikit.enabled=true
 org.jetbrains.compose.experimental.jscanvas.enabled=true
 
-supabase-version = 2.4.0-rc-1
+supabase-version = 2.4.0
 base-group = io.github.jan-tennert.supabase


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The current behavior calculates the delay before session expiry based on the time between the current system time and the expirationAt time. This delayBeforeExpiry time will change depending on the current system time.

## What is the new behavior?

The new behavior calculates the delay before session expiry based on the time between the beginning of the session and the expirationAt time. This makes it so that the delayBeforeExpiry is static and will always be 80% of the way from the beginning of the session to the expiresAt time.

## Additional context

I'm having some issues with expired tokens being used with my backend from the kotlin client, I'm hoping this helps alleviate some of that 
