### PR TITLE
Add `isError` parameter to Compose Auth Ui fields

### DIFF
--- a/plugins/ComposeAuthUI/src/commonMain/kotlin/io/github/jan/supabase/compose/auth/ui/email/EmailField.kt
+++ b/plugins/ComposeAuthUI/src/commonMain/kotlin/io/github/jan/supabase/compose/auth/ui/email/EmailField.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.TextFieldValue
 import io.github.jan.supabase.compose.auth.ui.AuthIcons
+import io.github.jan.supabase.compose.auth.ui.AuthState
 import io.github.jan.supabase.compose.auth.ui.FormComponent
 import io.github.jan.supabase.compose.auth.ui.FormValidator
 import io.github.jan.supabase.compose.auth.ui.annotations.AuthUiExperimental
@@ -38,6 +39,7 @@ import io.github.jan.supabase.compose.auth.ui.rememberMailIcon
  * @param keyboardActions The keyboard actions for the email field. Defaults to KeyboardActions.Default.
  * @param leadingIcon The leading icon for the email field. Defaults to an email icon.
  * @param singleLine Whether the email field should be a single line or multiline. Defaults to true.
+ * @param isError Whether the email field should display an error state. Defaults to null.
  * @param enabled Whether the email field should be enabled for user interaction. Defaults to true.
  * @param interactionSource The interaction source for the email field. Defaults to MutableInteractionSource.
  * @param textStyle The text style for the email field. Defaults to LocalTextStyle.current.
@@ -70,6 +72,7 @@ fun EmailField(
     },
     singleLine: Boolean = true,
     enabled: Boolean = true,
+    isError: Boolean? = null,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     textStyle: TextStyle = LocalTextStyle.current,
     shape: Shape = TextFieldDefaults.shape,
@@ -94,7 +97,7 @@ fun EmailField(
             keyboardActions = keyboardActions,
             leadingIcon = leadingIcon,
             singleLine = singleLine,
-            isError = !isValidEmail && value.isNotEmpty(),
+            isError = isError ?: (!isValidEmail && value.isNotEmpty()),
             interactionSource = interactionSource,
             textStyle = textStyle,
             shape = shape,
@@ -119,6 +122,7 @@ fun EmailField(
  * @param keyboardActions The keyboard actions for the email field. Defaults to KeyboardActions.Default.
  * @param leadingIcon The leading icon for the email field. Defaults to an email icon.
  * @param singleLine Whether the email field should be a single line or multiline. Defaults to true.
+ * @param isError Whether the email field should display an error state. Defaults to null.
  * @param enabled Whether the email field should be enabled for user interaction. Defaults to true.
  * @param interactionSource The interaction source for the email field. Defaults to MutableInteractionSource.
  * @param textStyle The text style for the email field. Defaults to LocalTextStyle.current.
@@ -151,6 +155,7 @@ fun EmailField(
     },
     singleLine: Boolean = true,
     enabled: Boolean = true,
+    isError: Boolean? = null,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     textStyle: TextStyle = LocalTextStyle.current,
     shape: Shape = TextFieldDefaults.shape,
@@ -175,7 +180,7 @@ fun EmailField(
             keyboardActions = keyboardActions,
             leadingIcon = leadingIcon,
             singleLine = singleLine,
-            isError = !isValidEmail && value.text.isNotEmpty(),
+            isError = isError ?: (!isValidEmail && value.text.isNotEmpty()),
             interactionSource = interactionSource,
             textStyle = textStyle,
             shape = shape,
@@ -201,6 +206,7 @@ fun EmailField(
  * @param leadingIcon The leading icon for the email field. Defaults to an email icon.
  * @param singleLine Whether the email field should be a single line or multiline. Defaults to true.
  * @param enabled Whether the email field should be enabled for user interaction. Defaults to true.
+ * @param isError Whether the email field should display an error state. Defaults to null.
  * @param interactionSource The interaction source for the email field. Defaults to MutableInteractionSource.
  * @param textStyle The text style for the email field. Defaults to LocalTextStyle.current.
  * @param shape The shape of the email field. Defaults to TextFieldDefaults.shape.
@@ -232,6 +238,7 @@ fun OutlinedEmailField(
     },
     singleLine: Boolean = true,
     enabled: Boolean = true,
+    isError: Boolean? = null,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     textStyle: TextStyle = LocalTextStyle.current,
     shape: Shape = OutlinedTextFieldDefaults.shape,
@@ -256,7 +263,7 @@ fun OutlinedEmailField(
             keyboardActions = keyboardActions,
             leadingIcon = leadingIcon,
             singleLine = singleLine,
-            isError = !isValidEmail && value.isNotEmpty(),
+            isError = isError ?: (!isValidEmail && value.isNotEmpty()),
             interactionSource = interactionSource,
             textStyle = textStyle,
             shape = shape,
@@ -282,6 +289,7 @@ fun OutlinedEmailField(
  * @param leadingIcon The leading icon for the email field. Defaults to an email icon.
  * @param singleLine Whether the email field should be a single line or multiline. Defaults to true.
  * @param enabled Whether the email field should be enabled for user interaction. Defaults to true.
+ * @param isError Whether the email field should display an error state. Defaults to null.
  * @param interactionSource The interaction source for the email field. Defaults to MutableInteractionSource.
  * @param textStyle The text style for the email field. Defaults to LocalTextStyle.current.
  * @param shape The shape of the email field. Defaults to TextFieldDefaults.shape.
@@ -313,6 +321,7 @@ fun OutlinedEmailField(
     },
     singleLine: Boolean = true,
     enabled: Boolean = true,
+    isError: Boolean? = null,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     textStyle: TextStyle = LocalTextStyle.current,
     shape: Shape = OutlinedTextFieldDefaults.shape,
@@ -337,7 +346,7 @@ fun OutlinedEmailField(
             keyboardActions = keyboardActions,
             leadingIcon = leadingIcon,
             singleLine = singleLine,
-            isError = !isValidEmail && value.text.isNotEmpty(),
+            isError = isError ?: (!isValidEmail && value.text.isNotEmpty()),
             interactionSource = interactionSource,
             textStyle = textStyle,
             shape = shape,

--- a/plugins/ComposeAuthUI/src/commonMain/kotlin/io/github/jan/supabase/compose/auth/ui/email/EmailField.kt
+++ b/plugins/ComposeAuthUI/src/commonMain/kotlin/io/github/jan/supabase/compose/auth/ui/email/EmailField.kt
@@ -39,7 +39,7 @@ import io.github.jan.supabase.compose.auth.ui.rememberMailIcon
  * @param keyboardActions The keyboard actions for the email field. Defaults to KeyboardActions.Default.
  * @param leadingIcon The leading icon for the email field. Defaults to an email icon.
  * @param singleLine Whether the email field should be a single line or multiline. Defaults to true.
- * @param isError Whether the email field should display an error state. Defaults to null.
+ * @param isError Whether the email field should display an error state. Defaults to null (handled automatically).
  * @param enabled Whether the email field should be enabled for user interaction. Defaults to true.
  * @param interactionSource The interaction source for the email field. Defaults to MutableInteractionSource.
  * @param textStyle The text style for the email field. Defaults to LocalTextStyle.current.
@@ -122,7 +122,7 @@ fun EmailField(
  * @param keyboardActions The keyboard actions for the email field. Defaults to KeyboardActions.Default.
  * @param leadingIcon The leading icon for the email field. Defaults to an email icon.
  * @param singleLine Whether the email field should be a single line or multiline. Defaults to true.
- * @param isError Whether the email field should display an error state. Defaults to null.
+ * @param isError Whether the email field should display an error state. Defaults to null (handled automatically).
  * @param enabled Whether the email field should be enabled for user interaction. Defaults to true.
  * @param interactionSource The interaction source for the email field. Defaults to MutableInteractionSource.
  * @param textStyle The text style for the email field. Defaults to LocalTextStyle.current.
@@ -206,7 +206,7 @@ fun EmailField(
  * @param leadingIcon The leading icon for the email field. Defaults to an email icon.
  * @param singleLine Whether the email field should be a single line or multiline. Defaults to true.
  * @param enabled Whether the email field should be enabled for user interaction. Defaults to true.
- * @param isError Whether the email field should display an error state. Defaults to null.
+ * @param isError Whether the email field should display an error state. Defaults to null (handled automatically).
  * @param interactionSource The interaction source for the email field. Defaults to MutableInteractionSource.
  * @param textStyle The text style for the email field. Defaults to LocalTextStyle.current.
  * @param shape The shape of the email field. Defaults to TextFieldDefaults.shape.
@@ -289,7 +289,7 @@ fun OutlinedEmailField(
  * @param leadingIcon The leading icon for the email field. Defaults to an email icon.
  * @param singleLine Whether the email field should be a single line or multiline. Defaults to true.
  * @param enabled Whether the email field should be enabled for user interaction. Defaults to true.
- * @param isError Whether the email field should display an error state. Defaults to null.
+ * @param isError Whether the email field should display an error state. Defaults to null (handled automatically).
  * @param interactionSource The interaction source for the email field. Defaults to MutableInteractionSource.
  * @param textStyle The text style for the email field. Defaults to LocalTextStyle.current.
  * @param shape The shape of the email field. Defaults to TextFieldDefaults.shape.

--- a/plugins/ComposeAuthUI/src/commonMain/kotlin/io/github/jan/supabase/compose/auth/ui/password/PasswordField.kt
+++ b/plugins/ComposeAuthUI/src/commonMain/kotlin/io/github/jan/supabase/compose/auth/ui/password/PasswordField.kt
@@ -45,6 +45,7 @@ import io.github.jan.supabase.compose.auth.ui.rememberVisibilityOffIcon
  * @param leadingIcon The leading icon for the password field. Defaults to an email icon.
  * @param singleLine Whether the password field should be a single line or multiline. Defaults to true.
  * @param enabled Whether the password field should be enabled for user interaction. Defaults to true.
+ * @param isError Whether the password field should display an error state. Defaults to null.
  * @param interactionSource The interaction source for the password field. Defaults to MutableInteractionSource.
  * @param textStyle The text style for the password field. Defaults to LocalTextStyle.current.
  * @param shape The shape of the password field. Defaults to TextFieldDefaults.shape.
@@ -69,6 +70,7 @@ fun PasswordField(
     readOnly: Boolean = false,
     enabled: Boolean = true,
     singleLine: Boolean = true,
+    isError: Boolean? = null,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     textStyle: TextStyle = LocalTextStyle.current,
     shape: Shape = TextFieldDefaults.shape,
@@ -102,7 +104,7 @@ fun PasswordField(
             keyboardOptions = keyboardOptions,
             keyboardActions = keyboardActions,
             singleLine = singleLine,
-            isError = ruleResults.firstUnfulfilled() != null && value.isNotEmpty(),
+            isError = isError ?: (ruleResults.firstUnfulfilled() != null && value.isNotEmpty()),
             modifier = modifier,
             leadingIcon = leadingIcon,
             trailingIcon = { trailingIcon?.invoke(showPassword) },
@@ -131,6 +133,7 @@ fun PasswordField(
  * @param leadingIcon The leading icon for the password field. Defaults to an email icon.
  * @param singleLine Whether the password field should be a single line or multiline. Defaults to true.
  * @param enabled Whether the password field should be enabled for user interaction. Defaults to true.
+ * @param isError Whether the password field should display an error state. Defaults to null.
  * @param interactionSource The interaction source for the password field. Defaults to MutableInteractionSource.
  * @param textStyle The text style for the password field. Defaults to LocalTextStyle.current.
  * @param shape The shape of the password field. Defaults to TextFieldDefaults.shape.
@@ -155,6 +158,7 @@ fun PasswordField(
     readOnly: Boolean = false,
     enabled: Boolean = true,
     singleLine: Boolean = true,
+    isError: Boolean? = null,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     textStyle: TextStyle = LocalTextStyle.current,
     shape: Shape = TextFieldDefaults.shape,
@@ -189,7 +193,7 @@ fun PasswordField(
             keyboardOptions = keyboardOptions,
             keyboardActions = keyboardActions,
             singleLine = singleLine,
-            isError = ruleResults.firstUnfulfilled() != null && value.text.isNotEmpty(),
+            isError = isError ?: (ruleResults.firstUnfulfilled() != null && value.text.isNotEmpty()),
             modifier = modifier,
             leadingIcon = leadingIcon,
             trailingIcon = { trailingIcon?.invoke(showPassword) },
@@ -218,6 +222,7 @@ fun PasswordField(
  * @param leadingIcon The leading icon for the password field. Defaults to an email icon.
  * @param singleLine Whether the password field should be a single line or multiline. Defaults to true.
  * @param enabled Whether the password field should be enabled for user interaction. Defaults to true.
+ * @param isError Whether the password field should display an error state. Defaults to null.
  * @param interactionSource The interaction source for the password field. Defaults to MutableInteractionSource.
  * @param textStyle The text style for the password field. Defaults to LocalTextStyle.current.
  * @param shape The shape of the password field. Defaults to TextFieldDefaults.shape.
@@ -242,6 +247,7 @@ fun OutlinedPasswordField(
     readOnly: Boolean = false,
     enabled: Boolean = true,
     singleLine: Boolean = true,
+    isError: Boolean? = null,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     textStyle: TextStyle = LocalTextStyle.current,
     shape: Shape = OutlinedTextFieldDefaults.shape,
@@ -275,7 +281,7 @@ fun OutlinedPasswordField(
             keyboardOptions = keyboardOptions,
             keyboardActions = keyboardActions,
             singleLine = singleLine,
-            isError = ruleResults.firstUnfulfilled() != null && value.isNotEmpty(),
+            isError = isError ?: (ruleResults.firstUnfulfilled() != null && value.isNotEmpty()),
             modifier = modifier,
             leadingIcon = leadingIcon,
             trailingIcon = { trailingIcon?.invoke(showPassword) },
@@ -304,6 +310,7 @@ fun OutlinedPasswordField(
  * @param leadingIcon The leading icon for the password field. Defaults to an email icon.
  * @param singleLine Whether the password field should be a single line or multiline. Defaults to true.
  * @param enabled Whether the password field should be enabled for user interaction. Defaults to true.
+ * @param isError Whether the password field should display an error state. Defaults to null.
  * @param interactionSource The interaction source for the password field. Defaults to MutableInteractionSource.
  * @param textStyle The text style for the password field. Defaults to LocalTextStyle.current.
  * @param shape The shape of the password field. Defaults to TextFieldDefaults.shape.
@@ -327,6 +334,7 @@ fun OutlinedPasswordField(
     keyboardOptions: KeyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
     readOnly: Boolean = false,
     enabled: Boolean = true,
+    isError: Boolean? = null,
     singleLine: Boolean = true,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     textStyle: TextStyle = LocalTextStyle.current,
@@ -361,7 +369,7 @@ fun OutlinedPasswordField(
             keyboardOptions = keyboardOptions,
             keyboardActions = keyboardActions,
             singleLine = singleLine,
-            isError = ruleResults.firstUnfulfilled() != null && value.text.isNotEmpty(),
+            isError = isError ?: (ruleResults.firstUnfulfilled() != null && value.text.isNotEmpty()),
             modifier = modifier,
             leadingIcon = leadingIcon,
             trailingIcon = { trailingIcon?.invoke(showPassword) },

--- a/plugins/ComposeAuthUI/src/commonMain/kotlin/io/github/jan/supabase/compose/auth/ui/password/PasswordField.kt
+++ b/plugins/ComposeAuthUI/src/commonMain/kotlin/io/github/jan/supabase/compose/auth/ui/password/PasswordField.kt
@@ -45,7 +45,7 @@ import io.github.jan.supabase.compose.auth.ui.rememberVisibilityOffIcon
  * @param leadingIcon The leading icon for the password field. Defaults to an email icon.
  * @param singleLine Whether the password field should be a single line or multiline. Defaults to true.
  * @param enabled Whether the password field should be enabled for user interaction. Defaults to true.
- * @param isError Whether the password field should display an error state. Defaults to null.
+ * @param isError Whether the password field should display an error state. Defaults to null (handled automatically).
  * @param interactionSource The interaction source for the password field. Defaults to MutableInteractionSource.
  * @param textStyle The text style for the password field. Defaults to LocalTextStyle.current.
  * @param shape The shape of the password field. Defaults to TextFieldDefaults.shape.
@@ -133,7 +133,7 @@ fun PasswordField(
  * @param leadingIcon The leading icon for the password field. Defaults to an email icon.
  * @param singleLine Whether the password field should be a single line or multiline. Defaults to true.
  * @param enabled Whether the password field should be enabled for user interaction. Defaults to true.
- * @param isError Whether the password field should display an error state. Defaults to null.
+ * @param isError Whether the password field should display an error state. Defaults to null (handled automatically).
  * @param interactionSource The interaction source for the password field. Defaults to MutableInteractionSource.
  * @param textStyle The text style for the password field. Defaults to LocalTextStyle.current.
  * @param shape The shape of the password field. Defaults to TextFieldDefaults.shape.
@@ -222,7 +222,7 @@ fun PasswordField(
  * @param leadingIcon The leading icon for the password field. Defaults to an email icon.
  * @param singleLine Whether the password field should be a single line or multiline. Defaults to true.
  * @param enabled Whether the password field should be enabled for user interaction. Defaults to true.
- * @param isError Whether the password field should display an error state. Defaults to null.
+ * @param isError Whether the password field should display an error state. Defaults to null (handled automatically).
  * @param interactionSource The interaction source for the password field. Defaults to MutableInteractionSource.
  * @param textStyle The text style for the password field. Defaults to LocalTextStyle.current.
  * @param shape The shape of the password field. Defaults to TextFieldDefaults.shape.
@@ -310,7 +310,7 @@ fun OutlinedPasswordField(
  * @param leadingIcon The leading icon for the password field. Defaults to an email icon.
  * @param singleLine Whether the password field should be a single line or multiline. Defaults to true.
  * @param enabled Whether the password field should be enabled for user interaction. Defaults to true.
- * @param isError Whether the password field should display an error state. Defaults to null.
+ * @param isError Whether the password field should display an error state. Defaults to null (handled automatically).
  * @param interactionSource The interaction source for the password field. Defaults to MutableInteractionSource.
  * @param textStyle The text style for the password field. Defaults to LocalTextStyle.current.
  * @param shape The shape of the password field. Defaults to TextFieldDefaults.shape.

--- a/plugins/ComposeAuthUI/src/commonMain/kotlin/io/github/jan/supabase/compose/auth/ui/phone/PhoneField.kt
+++ b/plugins/ComposeAuthUI/src/commonMain/kotlin/io/github/jan/supabase/compose/auth/ui/phone/PhoneField.kt
@@ -44,6 +44,7 @@ private const val DEFAULT_MASK_CHAR = '#'
  * @param leadingIcon The leading icon for the phone field. Defaults to an email icon.
  * @param singleLine Whether the phone field should be a single line or multiline. Defaults to true.
  * @param enabled Whether the phone field should be enabled for user interaction. Defaults to true.
+ * @param isError Whether the phone field should display an error state. Defaults to null.
  * @param interactionSource The interaction source for the phone field. Defaults to MutableInteractionSource.
  * @param textStyle The text style for the phone field. Defaults to LocalTextStyle.current.
  * @param shape The shape of the phone field. Defaults to TextFieldDefaults.shape.
@@ -76,6 +77,7 @@ fun PhoneField(
     },
     singleLine: Boolean = true,
     enabled: Boolean = true,
+    isError: Boolean? = null,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     textStyle: TextStyle = LocalTextStyle.current,
     shape: Shape = TextFieldDefaults.shape,
@@ -104,7 +106,7 @@ fun PhoneField(
             keyboardActions = keyboardActions,
             leadingIcon = leadingIcon,
             singleLine = singleLine,
-            isError = !isValidPhone && value.isNotEmpty(),
+            isError = isError ?: (!isValidPhone && value.isNotEmpty()),
             interactionSource = interactionSource,
             textStyle = textStyle,
             shape = shape,
@@ -132,6 +134,7 @@ fun PhoneField(
  * @param keyboardActions The keyboard actions for the phone field. Defaults to KeyboardActions.Default.
  * @param leadingIcon The leading icon for the phone field. Defaults to an email icon.
  * @param singleLine Whether the phone field should be a single line or multiline. Defaults to true.
+ * @param isError Whether the phone field should display an error state. Defaults to null.
  * @param enabled Whether the phone field should be enabled for user interaction. Defaults to true.
  * @param interactionSource The interaction source for the phone field. Defaults to MutableInteractionSource.
  * @param textStyle The text style for the phone field. Defaults to LocalTextStyle.current.
@@ -165,6 +168,7 @@ fun PhoneField(
     },
     singleLine: Boolean = true,
     enabled: Boolean = true,
+    isError: Boolean? = null,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     textStyle: TextStyle = LocalTextStyle.current,
     shape: Shape = TextFieldDefaults.shape,
@@ -193,7 +197,7 @@ fun PhoneField(
             keyboardActions = keyboardActions,
             leadingIcon = leadingIcon,
             singleLine = singleLine,
-            isError = !isValidPhone && value.text.isNotEmpty(),
+            isError = isError ?: (!isValidPhone && value.text.isNotEmpty()),
             interactionSource = interactionSource,
             textStyle = textStyle,
             shape = shape,
@@ -222,6 +226,7 @@ fun PhoneField(
  * @param leadingIcon The leading icon for the phone field. Defaults to an email icon.
  * @param singleLine Whether the phone field should be a single line or multiline. Defaults to true.
  * @param enabled Whether the phone field should be enabled for user interaction. Defaults to true.
+ * @param isError Whether the phone field should display an error state. Defaults to null.
  * @param interactionSource The interaction source for the phone field. Defaults to MutableInteractionSource.
  * @param textStyle The text style for the phone field. Defaults to LocalTextStyle.current.
  * @param shape The shape of the phone field. Defaults to TextFieldDefaults.shape.
@@ -254,6 +259,7 @@ fun OutlinedPhoneField(
     },
     singleLine: Boolean = true,
     enabled: Boolean = true,
+    isError: Boolean? = null,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     textStyle: TextStyle = LocalTextStyle.current,
     shape: Shape = OutlinedTextFieldDefaults.shape,
@@ -282,7 +288,7 @@ fun OutlinedPhoneField(
             keyboardActions = keyboardActions,
             leadingIcon = leadingIcon,
             singleLine = singleLine,
-            isError = !isValidPhone && value.text.isNotEmpty(),
+            isError = isError ?: (!isValidPhone && value.text.isNotEmpty()),
             interactionSource = interactionSource,
             textStyle = textStyle,
             shape = shape,
@@ -311,6 +317,7 @@ fun OutlinedPhoneField(
  * @param leadingIcon The leading icon for the phone field. Defaults to an email icon.
  * @param singleLine Whether the phone field should be a single line or multiline. Defaults to true.
  * @param enabled Whether the phone field should be enabled for user interaction. Defaults to true.
+ * @param isError Whether the phone field should display an error state. Defaults to null.
  * @param interactionSource The interaction source for the phone field. Defaults to MutableInteractionSource.
  * @param textStyle The text style for the phone field. Defaults to LocalTextStyle.current.
  * @param shape The shape of the phone field. Defaults to TextFieldDefaults.shape.
@@ -343,6 +350,7 @@ fun OutlinedPhoneField(
     },
     singleLine: Boolean = true,
     enabled: Boolean = true,
+    isError: Boolean? = null,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     textStyle: TextStyle = LocalTextStyle.current,
     shape: Shape = OutlinedTextFieldDefaults.shape,
@@ -368,7 +376,7 @@ fun OutlinedPhoneField(
             keyboardActions = keyboardActions,
             leadingIcon = leadingIcon,
             singleLine = singleLine,
-            isError = !isValidPhone && value.isNotEmpty(),
+            isError = isError ?: (!isValidPhone && value.isNotEmpty()),
             interactionSource = interactionSource,
             textStyle = textStyle,
             shape = shape,

--- a/plugins/ComposeAuthUI/src/commonMain/kotlin/io/github/jan/supabase/compose/auth/ui/phone/PhoneField.kt
+++ b/plugins/ComposeAuthUI/src/commonMain/kotlin/io/github/jan/supabase/compose/auth/ui/phone/PhoneField.kt
@@ -44,7 +44,7 @@ private const val DEFAULT_MASK_CHAR = '#'
  * @param leadingIcon The leading icon for the phone field. Defaults to an email icon.
  * @param singleLine Whether the phone field should be a single line or multiline. Defaults to true.
  * @param enabled Whether the phone field should be enabled for user interaction. Defaults to true.
- * @param isError Whether the phone field should display an error state. Defaults to null.
+ * @param isError Whether the phone field should display an error state. Defaults to null (handled automatically).
  * @param interactionSource The interaction source for the phone field. Defaults to MutableInteractionSource.
  * @param textStyle The text style for the phone field. Defaults to LocalTextStyle.current.
  * @param shape The shape of the phone field. Defaults to TextFieldDefaults.shape.
@@ -134,7 +134,7 @@ fun PhoneField(
  * @param keyboardActions The keyboard actions for the phone field. Defaults to KeyboardActions.Default.
  * @param leadingIcon The leading icon for the phone field. Defaults to an email icon.
  * @param singleLine Whether the phone field should be a single line or multiline. Defaults to true.
- * @param isError Whether the phone field should display an error state. Defaults to null.
+ * @param isError Whether the phone field should display an error state. Defaults to null (handled automatically).
  * @param enabled Whether the phone field should be enabled for user interaction. Defaults to true.
  * @param interactionSource The interaction source for the phone field. Defaults to MutableInteractionSource.
  * @param textStyle The text style for the phone field. Defaults to LocalTextStyle.current.
@@ -226,7 +226,7 @@ fun PhoneField(
  * @param leadingIcon The leading icon for the phone field. Defaults to an email icon.
  * @param singleLine Whether the phone field should be a single line or multiline. Defaults to true.
  * @param enabled Whether the phone field should be enabled for user interaction. Defaults to true.
- * @param isError Whether the phone field should display an error state. Defaults to null.
+ * @param isError Whether the phone field should display an error state. Defaults to null (handled automatically).
  * @param interactionSource The interaction source for the phone field. Defaults to MutableInteractionSource.
  * @param textStyle The text style for the phone field. Defaults to LocalTextStyle.current.
  * @param shape The shape of the phone field. Defaults to TextFieldDefaults.shape.
@@ -317,7 +317,7 @@ fun OutlinedPhoneField(
  * @param leadingIcon The leading icon for the phone field. Defaults to an email icon.
  * @param singleLine Whether the phone field should be a single line or multiline. Defaults to true.
  * @param enabled Whether the phone field should be enabled for user interaction. Defaults to true.
- * @param isError Whether the phone field should display an error state. Defaults to null.
+ * @param isError Whether the phone field should display an error state. Defaults to null (handled automatically).
  * @param interactionSource The interaction source for the phone field. Defaults to MutableInteractionSource.
  * @param textStyle The text style for the phone field. Defaults to LocalTextStyle.current.
  * @param shape The shape of the phone field. Defaults to TextFieldDefaults.shape.


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature (closes #604)

## What is the current behavior?

You cannot set an error state yourself.

## What is the new behavior?

There is now a new `isError` parameter for all fields, which defaults to null (handled by the field)

