### PR TITLE
Add the possibility to have a multi-column PK in realtime

### DIFF
--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/PostgrestExtensions.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/PostgrestExtensions.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.onCompletion
+import kotlin.jvm.JvmName
 import kotlin.reflect.KProperty1
 
 /**
@@ -123,6 +124,7 @@ inline fun <reified Data : Any, Value> PostgrestQueryBuilder.selectAsFlow(
  * @param channelName the name of the channel to use for the realtime updates. If null, a channel name following the format "schema:table:id" will be used
  */
 @SupabaseExperimental
+@JvmName("selectAsFlowMultiplePks")
 inline fun <reified Data : Any, Value> PostgrestQueryBuilder.selectAsFlow(
     primaryKeys: List<KProperty1<Data, Value>>,
     channelName: String? = null,

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/PostgrestExtensions.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/PostgrestExtensions.kt
@@ -22,20 +22,6 @@ inline fun <reified Data : Any> PostgrestQueryBuilder.selectSingleValueAsFlow(
     primaryKey: PrimaryKey<Data>,
     channelName: String? = null,
     crossinline filter: PostgrestFilterBuilder.() -> Unit
-): Flow<Data> = selectSingleValueAsFlow(listOf(primaryKey), channelName, filter)
-
-/**
- * Executes vertical filtering with select on [PostgrestQueryBuilder.table] and [PostgrestQueryBuilder.schema] and returns a [Flow] of a single value matching the [filter].
- * This function listens for changes in the table and emits the new value whenever a change occurs.
- * @param primaryKeys the list of primary key of the [Data] type
- * @param filter the filter to apply to the select query
- * @param channelName the name of the channel to use for the realtime updates. If null, a channel name following the format "schema:table:id" will be used
- */
-@SupabaseExperimental
-inline fun <reified Data : Any> PostgrestQueryBuilder.selectSingleValueAsFlow(
-    primaryKeys: List<PrimaryKey<Data>>,
-    channelName: String? = null,
-    crossinline filter: PostgrestFilterBuilder.() -> Unit
 ): Flow<Data> {
     val realtime = postgrest.supabaseClient.realtime as RealtimeImpl
     val channel = realtime.channel(channelName ?: defaultChannelName(schema, table, realtime))
@@ -43,7 +29,7 @@ inline fun <reified Data : Any> PostgrestQueryBuilder.selectSingleValueAsFlow(
         val dataFlow = channel.postgresSingleDataFlow(
             schema = this@selectSingleValueAsFlow.schema,
             table = this@selectSingleValueAsFlow.table,
-            primaryKeys = primaryKeys,
+            primaryKey = primaryKey,
             filter = filter
         )
         channel.subscribe()
@@ -65,7 +51,11 @@ inline fun <reified Data : Any, Value> PostgrestQueryBuilder.selectSingleValueAs
     primaryKey: KProperty1<Data, Value>,
     channelName: String? = null,
     crossinline filter: PostgrestFilterBuilder.() -> Unit
-): Flow<Data> = selectSingleValueAsFlow(PrimaryKey(primaryKey.name) { primaryKey.get(it).toString() }, channelName, filter)
+): Flow<Data> = selectSingleValueAsFlow(
+    PrimaryKey(primaryKey.name) { primaryKey.get(it).toString() },
+    channelName,
+    filter
+)
 
 /**
  * Executes vertical filtering with select on [PostgrestQueryBuilder.table] and [PostgrestQueryBuilder.schema] and returns a [Flow] of a list of values matching the [filter].
@@ -80,6 +70,7 @@ inline fun <reified Data : Any> PostgrestQueryBuilder.selectAsFlow(
     channelName: String? = null,
     filter: FilterOperation? = null,
 ): Flow<List<Data>> = selectAsFlow(listOf(primaryKey), channelName, filter)
+
 /**
  * Executes vertical filtering with select on [PostgrestQueryBuilder.table] and [PostgrestQueryBuilder.schema] and returns a [Flow] of a list of values matching the [filter].
  * This function listens for changes in the table and emits the new list whenever a change occurs.
@@ -121,7 +112,9 @@ inline fun <reified Data : Any, Value> PostgrestQueryBuilder.selectAsFlow(
     primaryKey: KProperty1<Data, Value>,
     channelName: String? = null,
     filter: FilterOperation? = null,
-): Flow<List<Data>> = selectAsFlow(PrimaryKey(primaryKey.name) { primaryKey.get(it).toString() }, channelName, filter)
+): Flow<List<Data>> =
+    selectAsFlow(PrimaryKey(primaryKey.name) { primaryKey.get(it).toString() }, channelName, filter)
 
 @PublishedApi
-internal fun defaultChannelName(schema: String, table: String, realtimeImpl: RealtimeImpl) = "$schema:$table:${realtimeImpl.nextIncrementId()}"
+internal fun defaultChannelName(schema: String, table: String, realtimeImpl: RealtimeImpl) =
+    "$schema:$table:${realtimeImpl.nextIncrementId()}"

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/PostgrestExtensions.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/PostgrestExtensions.kt
@@ -113,7 +113,25 @@ inline fun <reified Data : Any, Value> PostgrestQueryBuilder.selectAsFlow(
     channelName: String? = null,
     filter: FilterOperation? = null,
 ): Flow<List<Data>> =
-    selectAsFlow(PrimaryKey(primaryKey.name) { primaryKey.get(it).toString() }, channelName, filter)
+    selectAsFlow(listOf(primaryKey), channelName, filter)
+
+/**
+ * Executes vertical filtering with select on [PostgrestQueryBuilder.table] and [PostgrestQueryBuilder.schema] and returns a [Flow] of a list of values matching the [filter].
+ * This function listens for changes in the table and emits the new list whenever a change occurs.
+ * @param primaryKeys the list of primary key of the [Data] type
+ * @param filter the filter to apply to the select query
+ * @param channelName the name of the channel to use for the realtime updates. If null, a channel name following the format "schema:table:id" will be used
+ */
+@SupabaseExperimental
+inline fun <reified Data : Any, Value> PostgrestQueryBuilder.selectAsFlow(
+    primaryKeys: List<KProperty1<Data, Value>>,
+    channelName: String? = null,
+    filter: FilterOperation? = null,
+): Flow<List<Data>> =
+    selectAsFlow(primaryKeys.map { primaryKey ->
+        PrimaryKey(primaryKey.name) { primaryKey.get(it).toString() }
+    }, channelName, filter)
+
 
 @PublishedApi
 internal fun defaultChannelName(schema: String, table: String, realtimeImpl: RealtimeImpl) =

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/PostgrestExtensions.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/PostgrestExtensions.kt
@@ -22,6 +22,20 @@ inline fun <reified Data : Any> PostgrestQueryBuilder.selectSingleValueAsFlow(
     primaryKey: PrimaryKey<Data>,
     channelName: String? = null,
     crossinline filter: PostgrestFilterBuilder.() -> Unit
+): Flow<Data> = selectSingleValueAsFlow(listOf(primaryKey), channelName, filter)
+
+/**
+ * Executes vertical filtering with select on [PostgrestQueryBuilder.table] and [PostgrestQueryBuilder.schema] and returns a [Flow] of a single value matching the [filter].
+ * This function listens for changes in the table and emits the new value whenever a change occurs.
+ * @param primaryKeys the list of primary key of the [Data] type
+ * @param filter the filter to apply to the select query
+ * @param channelName the name of the channel to use for the realtime updates. If null, a channel name following the format "schema:table:id" will be used
+ */
+@SupabaseExperimental
+inline fun <reified Data : Any> PostgrestQueryBuilder.selectSingleValueAsFlow(
+    primaryKeys: List<PrimaryKey<Data>>,
+    channelName: String? = null,
+    crossinline filter: PostgrestFilterBuilder.() -> Unit
 ): Flow<Data> {
     val realtime = postgrest.supabaseClient.realtime as RealtimeImpl
     val channel = realtime.channel(channelName ?: defaultChannelName(schema, table, realtime))
@@ -29,7 +43,7 @@ inline fun <reified Data : Any> PostgrestQueryBuilder.selectSingleValueAsFlow(
         val dataFlow = channel.postgresSingleDataFlow(
             schema = this@selectSingleValueAsFlow.schema,
             table = this@selectSingleValueAsFlow.table,
-            primaryKey = primaryKey,
+            primaryKeys = primaryKeys,
             filter = filter
         )
         channel.subscribe()
@@ -65,6 +79,19 @@ inline fun <reified Data : Any> PostgrestQueryBuilder.selectAsFlow(
     primaryKey: PrimaryKey<Data>,
     channelName: String? = null,
     filter: FilterOperation? = null,
+): Flow<List<Data>> = selectAsFlow(listOf(primaryKey), channelName, filter)
+/**
+ * Executes vertical filtering with select on [PostgrestQueryBuilder.table] and [PostgrestQueryBuilder.schema] and returns a [Flow] of a list of values matching the [filter].
+ * This function listens for changes in the table and emits the new list whenever a change occurs.
+ * @param primaryKeys the list of primary key of the [Data] type
+ * @param filter the filter to apply to the select query
+ * @param channelName the name of the channel to use for the realtime updates. If null, a channel name following the format "schema:table:id" will be used
+ */
+@SupabaseExperimental
+inline fun <reified Data : Any> PostgrestQueryBuilder.selectAsFlow(
+    primaryKeys: List<PrimaryKey<Data>>,
+    channelName: String? = null,
+    filter: FilterOperation? = null,
 ): Flow<List<Data>> {
     val realtime = postgrest.supabaseClient.realtime as RealtimeImpl
     val channel = realtime.channel(channelName ?: defaultChannelName(schema, table, realtime))
@@ -72,7 +99,7 @@ inline fun <reified Data : Any> PostgrestQueryBuilder.selectAsFlow(
         val dataFlow = channel.postgresListDataFlow(
             schema = this@selectAsFlow.schema,
             table = this@selectAsFlow.table,
-            primaryKey = primaryKey,
+            primaryKeys = primaryKeys,
             filter = filter
         )
         channel.subscribe()

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeExt.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeExt.kt
@@ -1,4 +1,5 @@
 @file:Suppress("MatchingDeclarationName")
+
 package io.github.jan.supabase.realtime
 
 import io.github.jan.supabase.collections.AtomicMutableMap
@@ -21,10 +22,10 @@ import kotlin.reflect.KProperty1
  */
 data class PrimaryKey<Data>(val columnName: String, val producer: (Data) -> String)
 
-fun <Data> List<PrimaryKey<Data>>.producer(data: Data): String =
+private fun <Data> List<PrimaryKey<Data>>.producer(data: Data): String =
     fold("") { value, pk -> value + pk.producer(data) }
 
-val <Data> List<PrimaryKey<Data>>.columnName: String
+private val <Data> List<PrimaryKey<Data>>.columnName: String
     get() = fold("") { value, pk -> value + pk.columnName }
 
 /**
@@ -113,17 +114,20 @@ inline fun <reified Data : Any> RealtimeChannel.postgresListDataFlow(
                     val key = primaryKeys.producer(data)
                     cache[key] = data
                 }
+
                 is PostgresAction.Update -> {
                     val data = it.decodeRecord<Data>()
                     val key = primaryKeys.producer(data)
                     cache[key] = data
                 }
+
                 is PostgresAction.Delete -> {
                     cache.remove(
                         it.oldRecord[primaryKeys.columnName]?.jsonPrimitive?.content
                             ?: error("No primary key found")
                     )
                 }
+
                 else -> {}
             }
             trySend(cache.values.toList())
@@ -152,7 +156,7 @@ inline fun <reified Data : Any, Value> RealtimeChannel.postgresListDataFlow(
     schema = schema,
     primaryKey = PrimaryKey(
         primaryKey.name
-    ){
+    ) {
         primaryKey.get(it).toString()
     }
 )
@@ -213,13 +217,16 @@ suspend inline fun <reified Data : Any> RealtimeChannel.postgresSingleDataFlow(
                     val data = it.decodeRecord<Data>()
                     trySend(data)
                 }
+
                 is PostgresAction.Update -> {
                     val data = it.decodeRecord<Data>()
                     trySend(data)
                 }
+
                 is PostgresAction.Delete -> {
                     close()
                 }
+
                 else -> {}
             }
         }

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeExt.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeExt.kt
@@ -153,14 +153,29 @@ inline fun <reified Data : Any, Value> RealtimeChannel.postgresListDataFlow(
     table: String,
     filter: FilterOperation? = null,
     primaryKey: KProperty1<Data, Value>,
+): Flow<List<Data>> = postgresListDataFlow(schema, table, filter, listOf(primaryKey))
+
+/**
+ * This function retrieves the initial data from the table and then listens for changes. It automatically handles inserts, updates and deletes.
+ *
+ * If you want more control, use the [postgresChangeFlow] function.
+ * @param schema the schema of the table
+ * @param table the table name
+ * @param filter an optional filter to filter the data
+ * @param primaryKeys the list of primary keys of the [Data] type
+ * @return a [Flow] of the current data in a list. This list is updated and emitted whenever a change occurs.
+ */
+inline fun <reified Data : Any, Value> RealtimeChannel.postgresListDataFlow(
+    schema: String = "public",
+    table: String,
+    filter: FilterOperation? = null,
+    primaryKeys: List<KProperty1<Data, Value>>,
 ): Flow<List<Data>> = postgresListDataFlow<Data>(
     filter = filter,
     table = table,
     schema = schema,
-    primaryKey = PrimaryKey(
-        primaryKey.name
-    ) {
-        primaryKey.get(it).toString()
+    primaryKeys = primaryKeys.map { primaryKey ->
+        PrimaryKey(primaryKey.name) { primaryKey.get(it).toString() }
     }
 )
 

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeExt.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeExt.kt
@@ -22,10 +22,12 @@ import kotlin.reflect.KProperty1
  */
 data class PrimaryKey<Data>(val columnName: String, val producer: (Data) -> String)
 
-private fun <Data> List<PrimaryKey<Data>>.producer(data: Data): String =
+@PublishedApi
+internal fun <Data> List<PrimaryKey<Data>>.producer(data: Data): String =
     fold("") { value, pk -> value + pk.producer(data) }
 
-private val <Data> List<PrimaryKey<Data>>.columnName: String
+@PublishedApi
+internal val <Data> List<PrimaryKey<Data>>.columnName: String
     get() = fold("") { value, pk -> value + pk.columnName }
 
 /**

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeExt.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeExt.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.serialization.json.jsonPrimitive
+import kotlin.jvm.JvmName
 import kotlin.reflect.KProperty1
 
 /**
@@ -165,6 +166,7 @@ inline fun <reified Data : Any, Value> RealtimeChannel.postgresListDataFlow(
  * @param primaryKeys the list of primary keys of the [Data] type
  * @return a [Flow] of the current data in a list. This list is updated and emitted whenever a change occurs.
  */
+@JvmName("postgresListDataFlowMultiplePks")
 inline fun <reified Data : Any, Value> RealtimeChannel.postgresListDataFlow(
     schema: String = "public",
     table: String,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

The realtime API doesn't allow to have a multi-column PK.

## What is the new behavior?

The realtime API now works with multi-column PKs.

## Additional context

https://kotlinlang.slack.com/archives/C06QXPC7064/p1716652456870609

I couldn't really test this. What's the usual strategy to test the library?
