### PR TITLE
Added caching to Gradle steps in GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,8 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
+      - uses: burrunan/gradle-cache-action@v1
+        name: Cache .gradle
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3.1.0
         with:

--- a/.github/workflows/detekt.yml
+++ b/.github/workflows/detekt.yml
@@ -20,6 +20,8 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
+      - uses: burrunan/gradle-cache-action@v1
+        name: Cache .gradle
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3.1.0
         with:

--- a/.github/workflows/dokka.yml
+++ b/.github/workflows/dokka.yml
@@ -37,6 +37,8 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
+      - uses: burrunan/gradle-cache-action@v1
+        name: Cache .gradle
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3.1.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,8 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
+      - uses: burrunan/gradle-cache-action@v1
+        name: Cache .gradle
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3.1.0
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,8 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
+      - uses: burrunan/gradle-cache-action@v1
+        name: Cache .gradle
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3.1.0
         with:


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature: This PR will add a caching and caching retrieval step to all GitHub Actions steps that involve Gradle.
Caches will make builds faster by not requiring Gradle to download and configure all dependencies for each build.
The cache 'hit' and 'miss' logic is robust and should work well across builds.

## What is the current behavior?

No caching is currently implemented in the GitHub Actions steps where Gradle is involved.

## What is the new behavior?

Caches will automatically be created in the GitHub Actions 'caches' section, that will be attempted reused during builds.

## Additional context

Link to GitHub Actions repo:
[Gradle-cache-action](https://github.com/burrunan/gradle-cache-action)

Additionally, there are a lot of settings that can be configurated if and when needed.
