### PR TITLE
Ignore certain status codes when signing out a user

### DIFF
--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/AuthImpl.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/AuthImpl.kt
@@ -277,7 +277,7 @@ internal class AuthImpl(
                     parameter("scope", scope.name.lowercase())
                 }
             } catch(e: RestException) {
-                val errorCode = if(e is AuthRestException) e.statusCode else if(e is UnknownRestException) e.errorCode else -1
+                val errorCode = if(e is AuthRestException) e.statusCode else if(e is UnknownRestException) e.statusCode else -1
                 if(errorCode in listOf(401, 403, 404)) {
                     Auth.logger.d { "Received error code $errorCode while signing out user. This can happen if the user doesn't exist anymore or the JWT is invalid/expired. Proceeding to clean up local data..." }
                 } else throw e
@@ -492,7 +492,7 @@ internal class AuthImpl(
                 response,
                 errorBody.description
             )
-            else -> UnknownRestException(errorBody.error ?: "Unknown Error", response, errorCode = response.status.value)
+            else -> UnknownRestException(errorBody.error ?: "Unknown Error", response, statusCode = response.status.value)
         }
     }
 

--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/AuthImpl.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/AuthImpl.kt
@@ -55,6 +55,7 @@ import kotlinx.serialization.json.put
 import kotlin.time.Duration.Companion.seconds
 
 private const val SESSION_REFRESH_THRESHOLD = 0.8
+private val SIGNOUT_IGNORE_CODES = listOf(401, 403, 404)
 
 @PublishedApi
 internal class AuthImpl(
@@ -278,7 +279,7 @@ internal class AuthImpl(
                 }
             } catch(e: RestException) {
                 val errorCode = if(e is AuthRestException) e.statusCode else if(e is UnknownRestException) e.statusCode else -1
-                if(errorCode in listOf(401, 403, 404)) {
+                if(errorCode in SIGNOUT_IGNORE_CODES) {
                     Auth.logger.d { "Received error code $errorCode while signing out user. This can happen if the user doesn't exist anymore or the JWT is invalid/expired. Proceeding to clean up local data..." }
                 } else throw e
             }

--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/AuthImpl.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/AuthImpl.kt
@@ -55,6 +55,7 @@ import kotlinx.serialization.json.put
 import kotlin.time.Duration.Companion.seconds
 
 private const val SESSION_REFRESH_THRESHOLD = 0.8
+@Suppress("MagicNumber") // see #631
 private val SIGNOUT_IGNORE_CODES = listOf(401, 403, 404)
 
 @PublishedApi
@@ -279,7 +280,7 @@ internal class AuthImpl(
                 }
             } catch(e: RestException) {
                 val errorCode = if(e is AuthRestException) e.statusCode else if(e is UnknownRestException) e.statusCode else -1
-                if(errorCode in SIGNOUT_IGNORE_CODES) {
+                if(errorCode in SIGNOUT_IGNORE_CODES || e is UnauthorizedRestException) {
                     Auth.logger.d { "Received error code $errorCode while signing out user. This can happen if the user doesn't exist anymore or the JWT is invalid/expired. Proceeding to clean up local data..." }
                 } else throw e
             }

--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/exception/AuthRestException.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/exception/AuthRestException.kt
@@ -5,6 +5,7 @@ import io.github.jan.supabase.exceptions.RestException
 /**
  * Base class for rest exceptions thrown by the Auth API.
  * @property errorCode The error code of the rest exception. This should be a known [AuthErrorCode]. If it is not, use [error] instead.
+ * @property statusCode The HTTP status code of the rest exception.
  * @param message The message of the rest exception.
  */
 open class AuthRestException(errorCode: String, message: String, val statusCode: Int = -1): RestException(

--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/exception/AuthRestException.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/exception/AuthRestException.kt
@@ -7,7 +7,7 @@ import io.github.jan.supabase.exceptions.RestException
  * @property errorCode The error code of the rest exception. This should be a known [AuthErrorCode]. If it is not, use [error] instead.
  * @param message The message of the rest exception.
  */
-open class AuthRestException(errorCode: String, message: String): RestException(
+open class AuthRestException(errorCode: String, message: String, val statusCode: Int = -1): RestException(
     error = errorCode,
     description = "Auth API error: $errorCode",
     message = message

--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/exception/AuthRestException.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/exception/AuthRestException.kt
@@ -5,13 +5,13 @@ import io.github.jan.supabase.exceptions.RestException
 /**
  * Base class for rest exceptions thrown by the Auth API.
  * @property errorCode The error code of the rest exception. This should be a known [AuthErrorCode]. If it is not, use [error] instead.
- * @property statusCode The HTTP status code of the rest exception.
  * @param message The message of the rest exception.
  */
-open class AuthRestException(errorCode: String, message: String, val statusCode: Int = -1): RestException(
+open class AuthRestException(errorCode: String, message: String, statusCode: Int): RestException(
     error = errorCode,
     description = "Auth API error: $errorCode",
-    message = message
+    message = message,
+    statusCode = statusCode
 ) {
 
     /**

--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/exception/AuthSessionMissingException.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/exception/AuthSessionMissingException.kt
@@ -3,8 +3,9 @@ package io.github.jan.supabase.gotrue.exception
 /**
  * Exception thrown when a session is not found.
  */
-class AuthSessionMissingException: AuthRestException(
+class AuthSessionMissingException(statusCode: Int): AuthRestException(
     errorCode = CODE,
+    statusCode = statusCode,
     message = "Session not found. This can happen if the user was logged out or deleted."
 ) {
 

--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/exception/AuthWeakPasswordException.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/exception/AuthWeakPasswordException.kt
@@ -7,10 +7,12 @@ package io.github.jan.supabase.gotrue.exception
  */
 class AuthWeakPasswordException(
     description: String,
+    statusCode: Int,
     val reasons: List<String>
 ) : AuthRestException(
     CODE,
     description,
+    statusCode
 ) {
 
     internal companion object {

--- a/src/commonMain/kotlin/io/github/jan/supabase/exceptions/RestException.kt
+++ b/src/commonMain/kotlin/io/github/jan/supabase/exceptions/RestException.kt
@@ -43,6 +43,5 @@ class NotFoundRestException(error: String, response: HttpResponse, message: Stri
 
 /**
  * Thrown for all other response codes
- * @property statusCode The HTTP status code
  */
 class UnknownRestException(error: String, response: HttpResponse, message: String? = null): RestException(error, response, message)

--- a/src/commonMain/kotlin/io/github/jan/supabase/exceptions/RestException.kt
+++ b/src/commonMain/kotlin/io/github/jan/supabase/exceptions/RestException.kt
@@ -43,4 +43,4 @@ class NotFoundRestException(error: String, response: HttpResponse, message: Stri
 /**
  * Thrown for all other response codes
  */
-class UnknownRestException(error: String, response: HttpResponse, message: String? = null): RestException(error, response, message)
+class UnknownRestException(error: String, response: HttpResponse, message: String? = null, val errorCode: Int = -1): RestException(error, response, message)

--- a/src/commonMain/kotlin/io/github/jan/supabase/exceptions/RestException.kt
+++ b/src/commonMain/kotlin/io/github/jan/supabase/exceptions/RestException.kt
@@ -42,5 +42,6 @@ class NotFoundRestException(error: String, response: HttpResponse, message: Stri
 
 /**
  * Thrown for all other response codes
+ * @property statusCode The HTTP status code
  */
-class UnknownRestException(error: String, response: HttpResponse, message: String? = null, val errorCode: Int = -1): RestException(error, response, message)
+class UnknownRestException(error: String, response: HttpResponse, message: String? = null, val statusCode: Int = -1): RestException(error, response, message)

--- a/src/commonMain/kotlin/io/github/jan/supabase/exceptions/RestException.kt
+++ b/src/commonMain/kotlin/io/github/jan/supabase/exceptions/RestException.kt
@@ -9,14 +9,15 @@ import io.ktor.client.statement.request
  * Plugins may extend this class to provide more specific exceptions
  * @param error The error returned by Supabase
  * @param description The error description returned by Supabase
+ * @param statusCode The HTTP status code of the rest exception.
  * @see UnauthorizedRestException
  * @see BadRequestRestException
  * @see NotFoundRestException
  * @see UnknownRestException
  */
-open class RestException(val error: String, val description: String?, message: String): Exception(message) {
+open class RestException(val error: String, val description: String?, val statusCode: Int, message: String): Exception(message) {
 
-    constructor(error: String, response: HttpResponse, message: String? = null): this(error, message, """
+    constructor(error: String, response: HttpResponse, message: String? = null): this(error, message, response.status.value, """
         $error${message?.let { " ($it)" } ?: ""}
         URL: ${response.request.url}
         Headers: ${response.request.headers.entries()}
@@ -44,4 +45,4 @@ class NotFoundRestException(error: String, response: HttpResponse, message: Stri
  * Thrown for all other response codes
  * @property statusCode The HTTP status code
  */
-class UnknownRestException(error: String, response: HttpResponse, message: String? = null, val statusCode: Int = -1): RestException(error, response, message)
+class UnknownRestException(error: String, response: HttpResponse, message: String? = null): RestException(error, response, message)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (closes #631)

## What is the current behavior?

API errors indicating the user doesn't exist/an invalid or expired JWT was used, throw an exception and therefore the sign-out flow doesn't finish.

## What is the new behavior?

The error codes `401`, `403`, `404` now get ignored and if received, the user will still be logged out.
