### PR TITLE
Fix Google sign in prompt in composeAuth

### DIFF
--- a/plugins/ComposeAuth/src/androidMain/kotlin/io/github/jan/supabase/compose/auth/Utils.kt
+++ b/plugins/ComposeAuth/src/androidMain/kotlin/io/github/jan/supabase/compose/auth/Utils.kt
@@ -9,7 +9,7 @@ internal fun getSignInWithGoogleOptions(
     config: GoogleLoginConfig?,
     nonce: String? = null
 ): GetSignInWithGoogleOption {
-    val signInWithGoogleOption = GetSignInWithGoogleOption.Builder(config!!.serverClientId)
+    val signInWithGoogleOption = GetSignInWithGoogleOption.Builder(config?.serverClientId ?: error("Trying to use Google Auth without setting the serverClientId"))
     signInWithGoogleOption.setNonce(nonce)
     return signInWithGoogleOption.build()
 }

--- a/plugins/ComposeAuth/src/androidMain/kotlin/io/github/jan/supabase/compose/auth/Utils.kt
+++ b/plugins/ComposeAuth/src/androidMain/kotlin/io/github/jan/supabase/compose/auth/Utils.kt
@@ -3,24 +3,15 @@ package io.github.jan.supabase.compose.auth
 import android.app.Activity
 import android.content.Context
 import android.content.ContextWrapper
-import com.google.android.libraries.identity.googleid.GetGoogleIdOption
+import com.google.android.libraries.identity.googleid.GetSignInWithGoogleOption
 
-internal fun getGoogleIDOptions(
+internal fun getSignInWithGoogleOptions(
     config: GoogleLoginConfig?,
-    filterByAuthorizedAccounts: Boolean,
     nonce: String? = null
-): GetGoogleIdOption {
-    val googleIdOption = GetGoogleIdOption.Builder()
-    config?.let { options ->
-        googleIdOption.setServerClientId(options.serverClientId)
-        googleIdOption.setFilterByAuthorizedAccounts(filterByAuthorizedAccounts)
-        googleIdOption.setNonce(nonce)
-
-        options.associateLinkedAccounts?.let {
-            googleIdOption.associateLinkedAccounts(it.first, it.second)
-        }
-    }
-    return googleIdOption.build()
+): GetSignInWithGoogleOption {
+    val signInWithGoogleOption = GetSignInWithGoogleOption.Builder(config!!.serverClientId)
+    signInWithGoogleOption.setNonce(nonce)
+    return signInWithGoogleOption.build()
 }
 
 internal fun Context.getActivity(): Activity? = when (this) {

--- a/plugins/ComposeAuth/src/androidMain/kotlin/io/github/jan/supabase/compose/auth/composable/GoogleAuth.kt
+++ b/plugins/ComposeAuth/src/androidMain/kotlin/io/github/jan/supabase/compose/auth/composable/GoogleAuth.kt
@@ -17,7 +17,7 @@ import com.google.android.libraries.identity.googleid.GoogleIdTokenParsingExcept
 import io.github.jan.supabase.compose.auth.ComposeAuth
 import io.github.jan.supabase.compose.auth.applicationContext
 import io.github.jan.supabase.compose.auth.getActivity
-import io.github.jan.supabase.compose.auth.getGoogleIDOptions
+import io.github.jan.supabase.compose.auth.getSignInWithGoogleOptions
 import io.github.jan.supabase.compose.auth.hash
 import io.github.jan.supabase.compose.auth.signInWithGoogle
 import io.github.jan.supabase.logging.d
@@ -139,11 +139,10 @@ private suspend fun tryRequest(
     context: android.content.Context,
     activity: android.app.Activity,
     config: ComposeAuth.Config,
-    nonce: String?,
-    withFilter: Boolean
+    nonce: String?
 ): GetCredentialResponse {
     val request = GetCredentialRequest.Builder()
-        .addCredentialOption(getGoogleIDOptions(config.googleLoginConfig, withFilter, nonce))
+        .addCredentialOption(getSignInWithGoogleOptions(config.googleLoginConfig, nonce))
         .build()
     return CredentialManager.create(context).getCredential(activity, request)
 }
@@ -155,12 +154,9 @@ private suspend fun makeRequest(
     nonce: String?
 ): GetCredentialResponse? {
     return try {
-        ComposeAuth.logger.d { "Trying to get Google ID Token Credential with only authorized accounts" }
-        tryRequest(context, activity, config, nonce, true)
+        ComposeAuth.logger.d { "Trying to get Google ID Token Credential" }
+        tryRequest(context, activity, config, nonce)
     } catch(e: GetCredentialCancellationException) {
         return null
-    } catch(e: GetCredentialException) {
-        ComposeAuth.logger.d { "Error while trying to get Google ID Token Credential. Retrying without only authorized accounts" }
-        tryRequest(context, activity, config, nonce, false)
     }
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix #643

## What is the current behavior?

The google sign in prompt doesn't show at all if "sign in prompts" setting is disabled in the user's google account/device.

## What is the new behavior?

Sign in prompt (dialog) now shows irrespective of the "sign in prompts" setting is enabled or not.