### PR TITLE
fix(auth): fix sign in with Apple in ComposeAuth

### DIFF
--- a/sample/chat-demo-mpp/ios/chatdemoios.xcodeproj/project.pbxproj
+++ b/sample/chat-demo-mpp/ios/chatdemoios.xcodeproj/project.pbxproj
@@ -151,7 +151,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cd \"$SRCROOT/..\"\n./gradlew :common:embedAndSignAppleFrameworkForXcode\n";
+			shellScript = "cd \"${SRCROOT}/../../..\"\n./gradlew :sample:chat-demo-mpp:common:embedAndSignAppleFrameworkForXcode\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix https://github.com/supabase-community/supabase-kt/issues/447

## What is the current behavior?

The current code was trying to decode the identity token as `base64` string, but that isn't true. Because of that, it wasn't getting into the last `let` as the `idToken` was null.

## What is the new behavior?

Decodes identityToken as a UTF-8 string

## Additional context

https://github.com/supabase-community/supabase-kt/assets/5923044/e8df4dc1-0528-4509-9a56-fb23be7a7e03

