### PR TITLE
Split tests from master build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,9 @@
-name: Build and test project
+name: Build project
 
 on:
   push:
     branches:
       - 'master'
-      - 'development'
 
 concurrency:
   group: environment-${{ github.ref }}
@@ -26,5 +25,5 @@ jobs:
         with:
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
           cache-read-only: false
-      - name: Test supabase-kt
-        run: ./gradlew -DLibrariesOnly=true build test --stacktrace --configuration-cache --scan
+      - name: Build supabase-kt
+        run: ./gradlew -DLibrariesOnly=true build --stacktrace --configuration-cache --scan

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,6 @@ jobs:
         uses: gradle/actions/setup-gradle@v3.1.0
         with:
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
-          cache-read-only: true
+          cache-read-only: github.ref != 'refs/heads/master'
       - name: Test supabase-kt
         run: ./gradlew -DLibrariesOnly=true ${{ matrix.command }} --stacktrace --configuration-cache


### PR DESCRIPTION
## What kind of change does this PR introduce?

Workflow update

## What is the current behavior?

Build & tests are in one single workflow task. This increases the time the action takes and prevents configuration caches for the pull request test workflow.

## What is the new behavior?

The pull request workflow testing the project now also gets used on a push to `master` and the `build.yml` workflow now only builds the project.
