### PR TITLE
Add support for verifying a token hash

### DIFF
--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/Auth.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/Auth.kt
@@ -269,6 +269,16 @@ sealed interface Auth : MainPlugin<AuthConfig>, CustomSerializationPlugin {
     suspend fun verifyEmailOtp(type: OtpType.Email, email: String, token: String, captchaToken: String? = null)
 
     /**
+     * Verifies a email otp token hash received via email
+     * @param type The type of the verification
+     * @param tokenHash The token hash used to verify
+     * @throws RestException or one of its subclasses if receiving an error response. If the error response contains a error code, an [AuthRestException] will be thrown which can be used to easier identify the problem.
+     * @throws HttpRequestTimeoutException if the request timed out
+     * @throws HttpRequestException on network related issues
+     */
+    suspend fun verifyEmailOtp(type: OtpType.Email, tokenHash: String, captchaToken: String? = null)
+
+    /**
      * Verifies a phone/sms otp
      * @param type The type of the verification
      * @param token The otp to verify

--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/AuthImpl.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/AuthImpl.kt
@@ -295,13 +295,13 @@ internal class AuthImpl(
 
     private suspend fun verify(
         type: String,
-        token: String,
+        token: String?,
         captchaToken: String?,
         additionalData: JsonObjectBuilder.() -> Unit
     ) {
         val body = buildJsonObject {
             put("type", type)
-            put("token", token)
+            token?.let { put("token", it) }
             captchaToken?.let(::putCaptchaToken)
             additionalData()
         }
@@ -317,6 +317,14 @@ internal class AuthImpl(
         captchaToken: String?
     ) = verify(type.type, token, captchaToken) {
         put("email", email)
+    }
+
+    override suspend fun verifyEmailOtp(
+        type: OtpType.Email,
+        tokenHash: String,
+        captchaToken: String?
+    ) = verify(type.type, null, captchaToken) {
+        put("token_hash", tokenHash)
     }
 
     override suspend fun verifyPhoneOtp(

--- a/GoTrue/src/commonTest/kotlin/AuthApiTest.kt
+++ b/GoTrue/src/commonTest/kotlin/AuthApiTest.kt
@@ -561,6 +561,31 @@ class AuthRequestTest {
     }
 
     @Test
+    fun testVerifyEmailOtpWithTokenHash() {
+        runTest {
+            val expectedType = OtpType.Email.EMAIL
+            val expectedTokenHash = "hash"
+            val expectedCaptchaToken = "captchaToken"
+            val client = createMockedSupabaseClient(configuration = configuration) {
+                assertMethodIs(HttpMethod.Post, it.method)
+                assertPathIs("/verify", it.url.pathAfterVersion())
+                val body = it.body.toJsonElement().jsonObject
+                val metaSecurity = body["gotrue_meta_security"]!!.jsonObject
+                assertEquals(
+                    expectedCaptchaToken,
+                    metaSecurity["captcha_token"]?.jsonPrimitive?.content
+                )
+                assertEquals(expectedTokenHash, body["token_hash"]?.jsonPrimitive?.content)
+                assertEquals(expectedType.name.lowercase(), body["type"]?.jsonPrimitive?.content)
+                respondJson(
+                    sampleUserSession()
+                )
+            }
+            client.auth.verifyEmailOtp(expectedType, tokenHash = expectedTokenHash, captchaToken = expectedCaptchaToken)
+        }
+    }
+
+    @Test
     fun testVerifyPhoneOtp() {
         runTest {
             val expectedType = OtpType.Phone.SMS


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature (closes #655)

## What is the current behavior?

You cannot sign in via verifying a token hash received from an email

## What is the new behavior?

There is now a new overload providing support for this feature.
