### PR TITLE
Remove realtime client side rate-limiting

### DIFF
--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/Realtime.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/Realtime.kt
@@ -101,7 +101,6 @@ sealed interface Realtime : MainPlugin<Realtime.Config>, CustomSerializationPlug
      * @property reconnectDelay The delay between reconnect attempts. Defaults to 7 seconds
      * @property heartbeatInterval The interval between heartbeat messages. Defaults to 15 seconds
      * @property connectOnSubscribe Whether to connect to the websocket when subscribing to a channel. Defaults to true
-     * @property eventsPerSecond The maximum amount of events per second (client-side rate-limiting). Defaults to 10 (100 ms per event). Set to a negative number to disable rate-limiting.
      * @property disconnectOnNoSubscriptions Whether to disconnect from the websocket when there are no more subscriptions. Defaults to true
      * @property serializer A serializer used for serializing/deserializing objects e.g. in [PresenceAction.decodeJoinsAs] or [RealtimeChannel.broadcast]. Defaults to [KotlinXSerializer]
      */
@@ -113,7 +112,6 @@ sealed interface Realtime : MainPlugin<Realtime.Config>, CustomSerializationPlug
         var disconnectOnSessionLoss: Boolean = true,
         var connectOnSubscribe: Boolean = true,
         var disconnectOnNoSubscriptions: Boolean = true,
-        @Deprecated("This property is deprecated and will be removed in a future version.") var eventsPerSecond: Int = 10,
     ): MainConfig(), CustomSerializationConfig {
 
         override var serializer: SupabaseSerializer? = null

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeRateLimitException.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeRateLimitException.kt
@@ -1,7 +1,0 @@
-package io.github.jan.supabase.realtime
-
-/**
- * Exception thrown when the rate limit for sending messages to the realtime websocket is exceeded.
- * @param eventsPerSecond the current rate limit. Can be changed within the realtime config.
- */
-class RealtimeRateLimitException(eventsPerSecond: Int) : Exception("Rate limit exceeded. Your current limit is set to $eventsPerSecond events per second.")


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## Additional context

This feature has been removed in the JS client.
