### PR TITLE
Change return type of file uploads in Storage to match other client libs

### DIFF
--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/BucketApi.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/BucketApi.kt
@@ -41,7 +41,7 @@ sealed interface BucketApi {
      * @throws HttpRequestTimeoutException if the request timed out
      * @throws HttpRequestException on network related issues
      */
-    suspend fun upload(path: String, data: ByteArray, upsert: Boolean = false): String {
+    suspend fun upload(path: String, data: ByteArray, upsert: Boolean = false): FileUploadResponse {
         require(data.isNotEmpty()) { "The data to upload should not be empty" }
         return upload(path, UploadData(ByteReadChannel(data), data.size.toLong()), upsert)
     }
@@ -56,7 +56,7 @@ sealed interface BucketApi {
      * @throws HttpRequestTimeoutException if the request timed out
      * @throws HttpRequestException on network related issues
      */
-    suspend fun upload(path: String, data: UploadData, upsert: Boolean = false): String
+    suspend fun upload(path: String, data: UploadData, upsert: Boolean = false): FileUploadResponse
 
     /**
      * Uploads a file in [bucketId] under [path] using a presigned url
@@ -68,7 +68,7 @@ sealed interface BucketApi {
      * @throws IllegalArgumentException if data to upload is empty
      */
     suspend fun uploadToSignedUrl(path: String, token: String, data: ByteArray, upsert: Boolean = false
-    ): String {
+    ): FileUploadResponse {
         require(data.isNotEmpty()) { "The data to upload should not be empty" }
         return uploadToSignedUrl(path, token, UploadData(ByteReadChannel(data), data.size.toLong()), upsert)
     }
@@ -85,7 +85,7 @@ sealed interface BucketApi {
      * @throws HttpRequestException on network related issues
      * @throws HttpRequestException on network related issues
      */
-    suspend fun uploadToSignedUrl(path: String, token: String, data: UploadData, upsert: Boolean = false): String
+    suspend fun uploadToSignedUrl(path: String, token: String, data: UploadData, upsert: Boolean = false): FileUploadResponse
 
     /**
      * Updates a file in [bucketId] under [path]
@@ -98,7 +98,7 @@ sealed interface BucketApi {
      * @throws HttpRequestTimeoutException if the request timed out
      * @throws HttpRequestException on network related issues
      */
-    suspend fun update(path: String, data: ByteArray, upsert: Boolean = false): String {
+    suspend fun update(path: String, data: ByteArray, upsert: Boolean = false): FileUploadResponse {
         require(data.isNotEmpty()) { "The data to upload should not be empty" }
         return update(path, UploadData(ByteReadChannel(data), data.size.toLong()), upsert)
     }
@@ -113,7 +113,7 @@ sealed interface BucketApi {
      * @throws HttpRequestTimeoutException if the request timed out
      * @throws HttpRequestException on network related issues
      */
-    suspend fun update(path: String, data: UploadData, upsert: Boolean = false): String
+    suspend fun update(path: String, data: UploadData, upsert: Boolean = false): FileUploadResponse
 
     /**
      * Deletes all files in [bucketId] with in [paths]

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/FileUploadResponse.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/FileUploadResponse.kt
@@ -1,7 +1,7 @@
 package io.github.jan.supabase.storage
 
 data class FileUploadResponse(
-    val id: String,
+    val id: String? = null,
     val path: String,
-    val key: String
+    val key: String? = null
 )

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/FileUploadResponse.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/FileUploadResponse.kt
@@ -1,0 +1,7 @@
+package io.github.jan.supabase.storage
+
+data class FileUploadResponse(
+    val id: String,
+    val path: String,
+    val key: String
+)

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/FileUploadResponse.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/FileUploadResponse.kt
@@ -1,5 +1,11 @@
 package io.github.jan.supabase.storage
 
+/**
+ * The response of a file upload
+ * @param id The id of the file
+ * @param path The path to the file. Can be used as is in [BucketApi] uploading methods
+ * @param key The key of the file
+ */
 data class FileUploadResponse(
     val id: String? = null,
     val path: String,

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/NetworkStatus.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/NetworkStatus.kt
@@ -48,6 +48,6 @@ sealed interface UploadStatus {
      * @param key The key of the uploaded file
      */
     @JvmInline
-    value class Success(val key: String) : UploadStatus
+    value class Success(val key: FileUploadResponse) : UploadStatus
 
 }

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/resumable/ResumableUpload.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/resumable/ResumableUpload.kt
@@ -6,6 +6,7 @@ import io.github.jan.supabase.logging.d
 import io.github.jan.supabase.logging.e
 import io.github.jan.supabase.logging.w
 import io.github.jan.supabase.storage.BucketApi
+import io.github.jan.supabase.storage.FileUploadResponse
 import io.github.jan.supabase.storage.Storage
 import io.github.jan.supabase.storage.UploadStatus
 import io.github.jan.supabase.storage.resumable.ResumableClient.Companion.TUS_VERSION
@@ -138,7 +139,7 @@ internal class ResumableUploadImpl(
                 _stateFlow.value = ResumableUploadState(fingerprint, cacheEntry, UploadStatus.Progress(offset, size), paused)
             }
             if(offset != serverOffset) error("Upload offset does not match server offset")
-            _stateFlow.value = ResumableUploadState(fingerprint, cacheEntry, UploadStatus.Success(path), false)
+            _stateFlow.value = ResumableUploadState(fingerprint, cacheEntry, UploadStatus.Success(FileUploadResponse(path = path)), false)
             removeFromCache()
             dataStream.cancel()
         }

--- a/Storage/src/commonTest/kotlin/BucketApiTest.kt
+++ b/Storage/src/commonTest/kotlin/BucketApiTest.kt
@@ -501,7 +501,7 @@ class BucketApiTest {
                     content = """
                     { 
                         "Key": "someBucket/$expectedPath",
-                        "Id": "someId",
+                        "Id": "someId"
                     }
                     """.trimIndent(),
                     headers = headersOf(

--- a/Storage/src/commonTest/kotlin/BucketApiTest.kt
+++ b/Storage/src/commonTest/kotlin/BucketApiTest.kt
@@ -1,6 +1,7 @@
 import io.github.jan.supabase.SupabaseClient
 import io.github.jan.supabase.SupabaseClientBuilder
 import io.github.jan.supabase.storage.BucketApi
+import io.github.jan.supabase.storage.FileUploadResponse
 import io.github.jan.supabase.storage.ImageTransformation
 import io.github.jan.supabase.storage.Storage
 import io.github.jan.supabase.storage.resumable.MemoryResumableCache
@@ -485,7 +486,7 @@ class BucketApiTest {
         urlPath: String,
         expectedPath: String = "data.png",
         extra: suspend MockRequestHandleScope.(HttpRequestData) -> Unit,
-        request: suspend (client: SupabaseClient, expectedPath: String, data: ByteArray) -> String
+        request: suspend (client: SupabaseClient, expectedPath: String, data: ByteArray) -> FileUploadResponse
     ) {
         runTest {
             val expectedData = byteArrayOf(1, 2, 3)
@@ -499,7 +500,8 @@ class BucketApiTest {
                 respond(
                     content = """
                     { 
-                        "Key": "$expectedPath"
+                        "Key": "someBucket/$expectedPath",
+                        "Id": "someId",
                     }
                     """.trimIndent(),
                     headers = headersOf(
@@ -508,8 +510,10 @@ class BucketApiTest {
                     )
                 )
             }
-            val key = request(client, expectedPath, expectedData)
-            assertEquals(expectedPath, key, "Key should be $expectedPath")
+            val response = request(client, expectedPath, expectedData)
+            assertEquals("someBucket/$expectedPath", response.key, "Key should be $expectedPath")
+            assertEquals("someId", response.id, "Id should be someId")
+            assertEquals(expectedPath, response.path, "Path should be $expectedPath")
         }
     }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

Only the `Key` value of the response payload is getting returned in all uploading methods.

## What is the new behavior?

To match other client libs, the `Key`, `Id` and `path` values are now also getting returned in form of a new `FileUploadResponse` data class.
