### PR TITLE
Refactor MFA to add support for the Phone MFA type and add MFA tests

### DIFF
--- a/GoTrue/build.gradle.kts
+++ b/GoTrue/build.gradle.kts
@@ -54,6 +54,7 @@ kotlin {
         val commonTest by getting {
             dependencies {
                 implementation(libs.bundles.testing)
+                implementation(libs.turbine)
                 implementation(project(":test-common"))
             }
         }

--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/mfa/FactorType.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/mfa/FactorType.kt
@@ -5,26 +5,28 @@ import io.github.jan.supabase.supabaseJson
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.decodeFromJsonElement
+import kotlinx.serialization.json.encodeToJsonElement
 import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 
 /**
  * Represents an MFA factor type
  * @param value The name of the factor type
  */
-sealed class FactorType<T>(val value: String) {
+sealed class FactorType<Config, Response>(val value: String) {
 
     @SupabaseInternal
-    abstract suspend fun decodeResponse(json: JsonObject): T
+    abstract suspend fun encodeConfig(config: Config.() -> Unit): JsonObject
+
+    @SupabaseInternal
+    abstract suspend fun decodeResponse(json: JsonObject): Response
 
     /**
      * TOTP (timed one-time password) MFA factor
      */
-    data object TOTP : FactorType<TOTP.Response>("totp") {
-
-        override suspend fun decodeResponse(json: JsonObject): Response {
-            return supabaseJson.decodeFromJsonElement(json["totp"]?.jsonObject ?: error("No 'totp' object found in factor response"))
-        }
+    data object TOTP : FactorType<TOTP.Config, TOTP.Response>("totp") {
 
         /**
          * @param secret The secret used to generate the TOTP code
@@ -38,6 +40,55 @@ sealed class FactorType<T>(val value: String) {
             val qrCode: String,
             val uri: String
         )
+
+        /**
+         * @param issuer Domain which the user is enrolling with
+         */
+        @Serializable
+        data class Config(
+            var issuer: String? = null,
+        )
+
+        override suspend fun decodeResponse(json: JsonObject): Response {
+            return supabaseJson.decodeFromJsonElement(json["totp"]?.jsonObject ?: error("No 'totp' object found in factor response"))
+        }
+
+        override suspend fun encodeConfig(config: Config.() -> Unit): JsonObject {
+            return supabaseJson.encodeToJsonElement(Config().apply(config)).jsonObject
+        }
+
+    }
+
+    /**
+     * TOTP (timed one-time password) MFA factor
+     */
+    data object SMS : FactorType<SMS.Config, SMS.Response>("sms") {
+
+        /**
+
+         */
+        @Serializable
+        data class Response(
+            @SerialName("phone_number")
+            val phone: String
+        )
+
+        /**
+         * @param phone The phone number to send the SMS to
+         */
+        @Serializable
+        data class Config(
+            @SerialName("phone_number")
+            var phone: String? = null,
+        )
+
+        override suspend fun decodeResponse(json: JsonObject): Response {
+            return Response(json["phone_number"]?.jsonPrimitive?.contentOrNull ?: error("No 'phone_number' entry found in factor response"))
+        }
+
+        override suspend fun encodeConfig(config: Config.() -> Unit): JsonObject {
+            return supabaseJson.encodeToJsonElement(Config().apply(config)).jsonObject
+        }
 
     }
 

--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/mfa/FactorType.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/mfa/FactorType.kt
@@ -60,30 +60,28 @@ sealed class FactorType<Config, Response>(val value: String) {
     }
 
     /**
-     * TOTP (timed one-time password) MFA factor
+     * Phone MFA factor
      */
-    data object SMS : FactorType<SMS.Config, SMS.Response>("sms") {
+    data object Phone : FactorType<Phone.Config, Phone.Response>("phone") {
 
         /**
-
+         * @param phone Phone number of the MFA factor in E.164 format. Used to send messages
          */
         @Serializable
         data class Response(
-            @SerialName("phone_number")
             val phone: String
         )
 
         /**
-         * @param phone The phone number to send the SMS to
+         * @param phone The phone number to send the SMS to. Number should conform to E.164 format
          */
         @Serializable
         data class Config(
-            @SerialName("phone_number")
             var phone: String? = null,
         )
 
         override suspend fun decodeResponse(json: JsonObject): Response {
-            return Response(json["phone_number"]?.jsonPrimitive?.contentOrNull ?: error("No 'phone_number' entry found in factor response"))
+            return Response(json["phone"]?.jsonPrimitive?.contentOrNull ?: error("No 'phone' entry found in factor response"))
         }
 
         override suspend fun encodeConfig(config: Config.() -> Unit): JsonObject {

--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/mfa/MfaApi.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/mfa/MfaApi.kt
@@ -1,5 +1,6 @@
 package io.github.jan.supabase.gotrue.mfa
 
+import io.github.jan.supabase.gotrue.Auth
 import io.github.jan.supabase.gotrue.AuthImpl
 import io.github.jan.supabase.gotrue.SessionStatus
 import io.github.jan.supabase.gotrue.providers.builtin.Phone
@@ -23,13 +24,31 @@ import kotlinx.serialization.json.put
 sealed interface MfaApi {
 
     /**
-     * Checks whether the current session was authenticated with MFA or the user has a verified MFA factor.
+     * The current MFA status of the user
+     * @see MfaStatus
      */
+    val status: MfaStatus
+
+    /**
+     * The current MFA status of the user as a flow. This flow will emit a new status any time [Auth.sessionStatus] changes.
+     *
+     * Note that if the user has verified a factor on another device and the user hasn't been updated on this device, [MfaStatus.active] will return false.
+     * You can use [Auth.retrieveUserForCurrentSession] to update the user and this property will update.
+     */
+    val statusFlow: Flow<MfaStatus>
+
+    /**
+     * Checks whether the current session was authenticated with MFA or the user has a verified MFA factor. Note that if the user has verified a factor on another device and the user hasn't been updated on this device, this will return false.
+     * You can use [Auth.retrieveUserForCurrentSession] to update the user and this property will update.
+     */
+    @Deprecated("Use statusFlow instead", ReplaceWith("statusFlow"))
     val isMfaEnabledFlow: Flow<Boolean>
 
     /**
-     * Checks whether the user has a verified MFA factor.
+     * Checks whether the user has a verified MFA factor. Note that if the user has verified a factor on another device and the user hasn't been updated on this device, this will return false.
+     * You can use [Auth.retrieveUserForCurrentSession] to update the user and this property will update.
      */
+    @Deprecated("Use status.enabled instead", ReplaceWith("status.enabled"))
     val isMfaEnabled: Boolean
         get() {
             val mfaLevel = getAuthenticatorAssuranceLevel()
@@ -38,24 +57,26 @@ sealed interface MfaApi {
 
     /**
      * Returns all verified factors from the current user session. If the user has no verified factors or there is no session, an empty list is returned.
+     * To fetch up-to-date factors, use [retrieveFactorsForCurrentUser].
      */
     val verifiedFactors: List<UserMfaFactor>
 
     /**
      * Checks whether the current session is authenticated with MFA
      */
+    @Deprecated("Use status.active instead", ReplaceWith("status.active"))
     val loggedInUsingMfa: Boolean
         get() = getAuthenticatorAssuranceLevel().current == AuthenticatorAssuranceLevel.AAL2
 
     /**
      * Checks whether the current session is authenticated with MFA
      */
+    @Deprecated("Use statusFlow instead", ReplaceWith("statusFlow"))
     val loggedInUsingMfaFlow: Flow<Boolean>
 
     /**
      * @param factorType The type of MFA factor to enroll. Currently only supports TOTP.
-     * @param issuer Domain which the user is enrolling with
-     * @param friendlyName Human readable name assigned to a device
+     * @param friendlyName Human-readable name assigned to a device
      * @return MfaEnrollResponse containing the id of the MFA factor, the type of MFA factor and the data of the MFA factor (like QR-Code for TOTP)
      * @see FactorType
      */
@@ -64,26 +85,27 @@ sealed interface MfaApi {
     /**
      * Unenrolls an MFA factor
      * @param factorId The id of the MFA factor to unenroll
-     * @param phone The phone number to unenroll. Only required for the [FactorType.SMS] factor type
      */
-    suspend fun unenroll(factorId: String, phone: String? = null,)
+    suspend fun unenroll(factorId: String)
 
     /**
      * Creates a new MFA challenge, which can be used to verify the user's code using [verifyChallenge]
      * @param factorId The id of the MFA factor to verify
-     * @param channel The channel to send the challenge to. Defaults to SMS (only applies to the [FactorType.SMS] factor type)
+     * @param channel The channel to send the challenge to. Defaults to SMS (only applies to the [FactorType.Phone] factor type)
      */
-    suspend fun createChallenge(factorId: String, channel: Phone.Channel = Phone.Channel.SMS): MfaChallenge
+    suspend fun createChallenge(factorId: String, channel: Phone.Channel? = null): MfaChallenge
 
     /**
      * Creates a new MFA challenge and immediately verifies it
      * @param factorId The id of the MFA factor to verify
      * @param code The code to verify
      * @param saveSession Whether to save the session after verification in Supabase Auth
-     * @param channel The channel to send the challenge to. Defaults to SMS (only applies to the [FactorType.SMS] factor type)
+     * @param channel The channel to send the challenge to. Defaults to SMS (only applies to the [FactorType.Phone] factor type)
      */
     suspend fun createChallengeAndVerify(factorId: String, code: String, channel: Phone.Channel = Phone.Channel.SMS, saveSession: Boolean = true): UserSession {
         val challenge = createChallenge(factorId, channel)
+        // Phone challenges cannot be verified immediately
+        if(challenge.factorType == "phone") error("Cannot verify a phone challenge immediately")
         return verifyChallenge(factorId, challenge.id, code, saveSession)
     }
 
@@ -97,7 +119,7 @@ sealed interface MfaApi {
     suspend fun verifyChallenge(factorId: String, challengeId: String, code: String, saveSession: Boolean = true): UserSession
 
     /**
-     * Retrieves all factors for the current user
+     * Retrieves all factors for the current user. This will make a network request to fetch the factors. Use [verifiedFactors] to get the factors from the current session.
      */
     suspend fun retrieveFactorsForCurrentUser(): List<UserMfaFactor>
 
@@ -108,28 +130,38 @@ sealed interface MfaApi {
 
 }
 
+@Suppress("DEPRECATION")
 internal class MfaApiImpl(
     val auth: AuthImpl
 ) : MfaApi {
 
-    override val isMfaEnabledFlow: Flow<Boolean> = auth.sessionStatus.map {
-        when(it) {
-            is SessionStatus.Authenticated -> isMfaEnabled
-            SessionStatus.LoadingFromStorage -> false
-            SessionStatus.NetworkError -> false
-            is SessionStatus.NotAuthenticated -> false
+    override val status: MfaStatus
+        get() {
+            val (current, next) = getAuthenticatorAssuranceLevel()
+            return MfaStatus(
+                enabled = next == AuthenticatorAssuranceLevel.AAL2,
+                active = current == AuthenticatorAssuranceLevel.AAL2
+            )
+        }
+
+    override val statusFlow: Flow<MfaStatus> = auth.sessionStatus.map {
+        if(it is SessionStatus.Authenticated) {
+            val (current, next) = getAuthenticatorAssuranceLevel()
+            MfaStatus(
+                enabled = next == AuthenticatorAssuranceLevel.AAL2,
+                active = current == AuthenticatorAssuranceLevel.AAL2
+            )
+        } else {
+            MfaStatus(false, false)
         }
     }
-    override val loggedInUsingMfaFlow: Flow<Boolean> = auth.sessionStatus.map {
-        when(it) {
-            is SessionStatus.Authenticated -> loggedInUsingMfa
-            SessionStatus.LoadingFromStorage -> false
-            SessionStatus.NetworkError -> false
-            is SessionStatus.NotAuthenticated -> false
-        }
-    }
+
+    @Deprecated("Use statusFlow instead", replaceWith = ReplaceWith("statusFlow"))
+    override val isMfaEnabledFlow: Flow<Boolean> = statusFlow.map { it.enabled }
+    @Deprecated("Use statusFlow instead", replaceWith = ReplaceWith("statusFlow"))
+    override val loggedInUsingMfaFlow: Flow<Boolean> = statusFlow.map { it.active }
     override val verifiedFactors: List<UserMfaFactor>
-        get() = (auth.sessionStatus.value as? SessionStatus.Authenticated)?.session?.user?.factors?.filter(UserMfaFactor::isVerified) ?: emptyList()
+        get() = auth.currentUserOrNull()?.factors?.filter(UserMfaFactor::isVerified) ?: emptyList()
 
     val api = auth.api
 
@@ -148,9 +180,11 @@ internal class MfaApiImpl(
         )
     }
 
-    override suspend fun createChallenge(factorId: String, channel: Phone.Channel): MfaChallenge {
+    override suspend fun createChallenge(factorId: String, channel: Phone.Channel?): MfaChallenge {
         val result = api.postJson("factors/$factorId/challenge", buildJsonObject {
-            put("channel", channel.value)
+            if (channel != null) {
+                put("channel", channel.value)
+            }
         })
         return result.safeBody()
     }
@@ -172,8 +206,7 @@ internal class MfaApiImpl(
         return session
     }
 
-    override suspend fun unenroll(factorId: String, phone: String?) {
-        //TODO: Add phone number to request
+    override suspend fun unenroll(factorId: String) {
         api.delete("factors/$factorId")
     }
 
@@ -188,7 +221,7 @@ internal class MfaApiImpl(
 
 
     override suspend fun retrieveFactorsForCurrentUser(): List<UserMfaFactor> {
-        return auth.retrieveUser(auth.currentAccessTokenOrNull() ?: error("Current session is null")).factors
+        return auth.retrieveUserForCurrentSession().factors
     }
 
 }

--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/mfa/MfaApi.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/mfa/MfaApi.kt
@@ -80,7 +80,7 @@ sealed interface MfaApi {
      * @return MfaEnrollResponse containing the id of the MFA factor, the type of MFA factor and the data of the MFA factor (like QR-Code for TOTP)
      * @see FactorType
      */
-    suspend fun <Config, Response> enroll(factorType: FactorType<Config, Response>, friendlyName: String? = null, config: Config.() -> Unit): MfaFactor<Response>
+    suspend fun <Config, Response> enroll(factorType: FactorType<Config, Response>, friendlyName: String? = null, config: Config.() -> Unit = {}): MfaFactor<Response>
 
     /**
      * Unenrolls an MFA factor

--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/mfa/MfaChallenge.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/mfa/MfaChallenge.kt
@@ -7,14 +7,15 @@ import kotlinx.serialization.Serializable
 /**
  * A challenge to verify the user's identity.
  * @property id The id of the challenge.
+ * @property factorType Factor Type which generated the challenge.
  */
 @Serializable
-data class MfaChallenge(val id: String) {
+data class MfaChallenge(val id: String, @SerialName("type") val factorType: String) {
 
     @SerialName("expires_at") private val expiresAtSeconds: Long = 0
 
     /**
-     * The time when the challenge expires.
+     * Timestamp in UNIX seconds when this challenge will no longer be usable.
      */
     val expiresAt: Instant
         get() = Instant.fromEpochSeconds(expiresAtSeconds)

--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/mfa/MfaStatus.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/mfa/MfaStatus.kt
@@ -1,0 +1,11 @@
+package io.github.jan.supabase.gotrue.mfa
+
+/**
+ * Represents the MFA status of a user.
+ * @property enabled Whether MFA is enabled for the user. If true, the user can log in using MFA and has at least one verified factor.
+ * @property active Whether MFA is active for the user. If true, the user is logged in using MFA.
+ */
+data class MfaStatus(
+    val enabled: Boolean,
+    val active: Boolean
+)

--- a/GoTrue/src/commonTest/kotlin/AuthTest.kt
+++ b/GoTrue/src/commonTest/kotlin/AuthTest.kt
@@ -85,7 +85,7 @@ class AuthTest {
             }
             client.auth.awaitInitialization()
             assertIs<SessionStatus.NotAuthenticated>(client.auth.sessionStatus.value)
-            val session = userSession(0)
+            val session = userSession(expiresIn = 0)
             client.auth.importSession(session)
             assertIs<SessionStatus.Authenticated>(client.auth.sessionStatus.value)
             assertEquals(newSession.expiresIn, client.auth.currentSessionOrNull()?.expiresIn)
@@ -109,7 +109,7 @@ class AuthTest {
             }
             client.auth.awaitInitialization()
             assertIs<SessionStatus.NotAuthenticated>(client.auth.sessionStatus.value)
-            val session = userSession(0)
+            val session = userSession(expiresIn = 0)
             client.auth.importSession(session)
             assertIs<SessionStatus.Authenticated>(client.auth.sessionStatus.value)
             assertEquals(session.expiresIn, client.auth.currentSessionOrNull()?.expiresIn) //The session shouldn't be refreshed automatically as alwaysAutoRefresh is false
@@ -199,9 +199,10 @@ class AuthTest {
 
 }
 
-fun userSession(expiresIn: Long = 3600) = UserSession(
-    accessToken = "accessToken",
+fun userSession(customToken: String = "accessToken", expiresIn: Long = 3600, user: UserInfo? = null) = UserSession(
+    accessToken = customToken,
     refreshToken = "refreshToken",
     expiresIn = expiresIn,
-    tokenType = "Bearer"
+    tokenType = "Bearer",
+    user = user
 )

--- a/GoTrue/src/commonTest/kotlin/MemorySessionManagerTest.kt
+++ b/GoTrue/src/commonTest/kotlin/MemorySessionManagerTest.kt
@@ -13,7 +13,7 @@ class MemorySessionManagerTest {
             val session = userSession()
             val sessionManager = MemorySessionManager(session)
             assertEquals(session, sessionManager.loadSession()) //Check if the session is loaded correctly
-            val newSession = userSession(200)
+            val newSession = userSession(expiresIn = 200)
             sessionManager.saveSession(newSession)
             assertEquals(newSession, sessionManager.loadSession()) //Check if the new session is saved correctly
             assertNotEquals(session, sessionManager.loadSession()) //Check if the new session is different from the old session

--- a/GoTrue/src/commonTest/kotlin/MfaApiTest.kt
+++ b/GoTrue/src/commonTest/kotlin/MfaApiTest.kt
@@ -1,5 +1,307 @@
+import app.cash.turbine.test
+import io.github.jan.supabase.SupabaseClientBuilder
+import io.github.jan.supabase.gotrue.Auth
+import io.github.jan.supabase.gotrue.auth
+import io.github.jan.supabase.gotrue.mfa.AuthenticatorAssuranceLevel
+import io.github.jan.supabase.gotrue.mfa.FactorType
+import io.github.jan.supabase.gotrue.mfa.MfaStatus
+import io.github.jan.supabase.gotrue.minimalSettings
+import io.github.jan.supabase.gotrue.providers.builtin.Phone
+import io.github.jan.supabase.gotrue.user.UserInfo
+import io.github.jan.supabase.gotrue.user.UserMfaFactor
+import io.github.jan.supabase.gotrue.user.UserSession
+import io.github.jan.supabase.testing.assertMethodIs
+import io.github.jan.supabase.testing.assertPathIs
+import io.github.jan.supabase.testing.createMockedSupabaseClient
+import io.github.jan.supabase.testing.pathAfterVersion
+import io.github.jan.supabase.testing.respondJson
+import io.github.jan.supabase.testing.toJsonElement
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpMethod
+import io.ktor.util.encodeBase64
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Clock
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
 class MfaApiTest {
 
-    //TODO: Implement tests
+    private val configuration: SupabaseClientBuilder.() -> Unit = {
+        install(Auth) {
+            minimalSettings()
+        }
+    }
+
+    @Test
+    fun testEnrollTOTP() {
+        runTest {
+            val friendlyName = "My Factor"
+            val issuer = "My App"
+            val expectedId = "123"
+            val expectedSecret = "secret"
+            val expectedQrCode = "qrCode"
+            val expectedUri = "uri"
+            val client = createMockedSupabaseClient(
+                configuration = configuration
+            ) {
+                assertPathIs("/factors", it.url.pathAfterVersion())
+                assertMethodIs(HttpMethod.Post, it.method)
+                val body = it.body.toJsonElement().jsonObject
+                assertEquals(friendlyName, body["friendly_name"]?.jsonPrimitive?.content)
+                assertEquals(FactorType.TOTP.value, body["factor_type"]?.jsonPrimitive?.content)
+                assertEquals(issuer, body["issuer"]?.jsonPrimitive?.content)
+                respondJson("""
+                    {
+                    "id": "$expectedId",
+                    "totp": {
+                        "secret": "$expectedSecret",
+                        "qr_code": "$expectedQrCode",
+                        "uri": "$expectedUri"
+                        }
+                    }
+                """.trimIndent())
+            }
+            val factor = client.auth.mfa.enroll(FactorType.TOTP, friendlyName) {
+                this.issuer = issuer
+            }
+            assertEquals(expectedId, factor.id)
+            assertEquals(expectedSecret, factor.data.secret)
+            assertEquals(expectedQrCode, factor.data.qrCode)
+            assertEquals(expectedUri, factor.data.uri)
+        }
+    }
+
+    @Test
+    fun testEnrollPhone() {
+        runTest {
+            val friendlyName = "My Factor"
+            val expectedId = "123"
+            val expectedPhone = "+491638976913"
+            val client = createMockedSupabaseClient(
+                configuration = configuration
+            ) {
+                assertPathIs("/factors", it.url.pathAfterVersion())
+                assertMethodIs(HttpMethod.Post, it.method)
+                val body = it.body.toJsonElement().jsonObject
+                assertEquals(friendlyName, body["friendly_name"]?.jsonPrimitive?.content)
+                assertEquals(FactorType.Phone.value, body["factor_type"]?.jsonPrimitive?.content)
+                assertEquals(expectedPhone, body["phone"]?.jsonPrimitive?.content)
+                respondJson("""
+                    {
+                    "id": "$expectedId",
+                    "phone": "$expectedPhone"
+                    }
+                """.trimIndent())
+            }
+            val factor = client.auth.mfa.enroll(FactorType.Phone, friendlyName) {
+                phone = expectedPhone
+            }
+            assertEquals(expectedId, factor.id)
+            assertEquals(expectedPhone, factor.data.phone)
+        }
+    }
+
+    @Test
+    fun testCreateChallengeWithChannel() {
+        testCreateChallenge(true)
+    }
+
+    @Test
+    fun testCreateChallengeWithoutChannel() {
+        testCreateChallenge(false)
+    }
+
+    @Test
+    fun testVerifyChallengeAndSave() {
+        testVerifyChallenge(true)
+    }
+
+    @Test
+    fun testVerifyChallengeWithoutSave() {
+        testVerifyChallenge(false)
+    }
+
+    @Test
+    fun testUnenrollFactor() {
+        runTest {
+            val expectedFactorId = "123"
+            val client = createMockedSupabaseClient(
+                configuration = configuration
+            ) {
+                assertPathIs("/factors/$expectedFactorId", it.url.pathAfterVersion())
+                assertMethodIs(HttpMethod.Delete, it.method)
+                respondJson("")
+            }
+            client.auth.mfa.unenroll(expectedFactorId)
+        }
+    }
+
+    @Test
+    fun testGetAALC1() {
+        testGetAAL(AuthenticatorAssuranceLevel.AAL1, AuthenticatorAssuranceLevel.AAL1)
+    }
+
+    @Test
+    fun testGetAALC2() {
+        testGetAAL(AuthenticatorAssuranceLevel.AAL1, AuthenticatorAssuranceLevel.AAL2)
+    }
+
+    @Test
+    fun testGetAALC3() {
+        testGetAAL(AuthenticatorAssuranceLevel.AAL2, AuthenticatorAssuranceLevel.AAL2)
+    }
+
+    @Test
+    fun testRetrieveVerifiedFactors() {
+        runTest {
+            val expectedFactor = verifiedFactor()
+            val client = createMockedSupabaseClient(
+                configuration = configuration
+            ) {
+                respondJson(UserInfo(id = "id", aud = "aud", factors = listOf(expectedFactor)))
+            }
+            client.auth.importAuthToken("token")
+            val factors = client.auth.mfa.retrieveFactorsForCurrentUser()
+            assertEquals(1, factors.size)
+            assertEquals(expectedFactor, factors.first())
+        }
+    }
+
+    @Test
+    fun testMfaProperties() {
+        runTest {
+            val client = createMockedSupabaseClient(
+                configuration = configuration
+            ) {
+                respond("")
+            }
+            client.auth.importSession(createSession(AuthenticatorAssuranceLevel.AAL1, AuthenticatorAssuranceLevel.AAL2))
+            assertEquals(MfaStatus(enabled = true, active = false), client.auth.mfa.status)
+            client.auth.importSession(createSession(AuthenticatorAssuranceLevel.AAL2, AuthenticatorAssuranceLevel.AAL1))
+            assertEquals(MfaStatus(enabled = false, active = true), client.auth.mfa.status)
+        }
+    }
+
+    @Test
+    fun testMfaStatus() {
+        runTest {
+            val client = createMockedSupabaseClient(
+                configuration = configuration
+            ) {
+                respond("")
+            }
+           client.auth.mfa.statusFlow.test {
+                assertEquals(MfaStatus(enabled = false, active = false), awaitItem())
+                client.auth.importSession(createSession(AuthenticatorAssuranceLevel.AAL1, AuthenticatorAssuranceLevel.AAL2))
+                assertEquals(MfaStatus(enabled = true, active = false), awaitItem())
+                client.auth.importSession(createSession(AuthenticatorAssuranceLevel.AAL2, AuthenticatorAssuranceLevel.AAL1))
+                assertEquals(MfaStatus(enabled = false, active = true), awaitItem())
+           }
+        }
+    }
+
+    private fun createSession(
+        currentAAL: AuthenticatorAssuranceLevel,
+        nextAAL: AuthenticatorAssuranceLevel
+    ): UserSession {
+        val data = buildJsonObject {
+            put("aal", currentAAL.name.lowercase())
+        }
+        val token = "ignore.${data.toString().encodeBase64()}"
+        val client = createMockedSupabaseClient(
+            configuration = configuration
+        ) {
+            respond("")
+        }
+        val factors = if(nextAAL == AuthenticatorAssuranceLevel.AAL1) emptyList() else listOf(verifiedFactor())
+        return userSession(customToken = token, user = UserInfo(id = "id", aud = "aud", factors = factors))
+    }
+
+    private fun testGetAAL(
+        current: AuthenticatorAssuranceLevel,
+        next: AuthenticatorAssuranceLevel
+    ) {
+        runTest {
+            val data = buildJsonObject {
+                put("aal", current.name.lowercase())
+            }
+            val token = "ignore.${data.toString().encodeBase64()}"
+            val client = createMockedSupabaseClient(
+                configuration = configuration
+            ) {
+                respond("")
+            }
+            val factors = if(next == AuthenticatorAssuranceLevel.AAL1) emptyList() else listOf(verifiedFactor())
+            client.auth.importSession(userSession(customToken = token, user = UserInfo(id = "id", aud = "aud", factors = factors)))
+            val (c, n) = client.auth.mfa.getAuthenticatorAssuranceLevel()
+            assertEquals(current.name.lowercase(), c.name.lowercase())
+            assertEquals(next.name.lowercase(), n.name.lowercase())
+        }
+    }
+
+    private fun testVerifyChallenge(saveSession: Boolean) {
+        runTest {
+            val expectedFactorId = "123"
+            val expectedChallengeId = "456"
+            val expectedCode = "789"
+            val expectedSession = userSession()
+            val client = createMockedSupabaseClient(
+                configuration = configuration
+            ) {
+                assertPathIs("/factors/$expectedFactorId/verify", it.url.pathAfterVersion())
+                assertMethodIs(HttpMethod.Post, it.method)
+                val body = it.body.toJsonElement().jsonObject
+                assertEquals(expectedCode, body["code"]?.jsonPrimitive?.content)
+                assertEquals(expectedChallengeId, body["challenge_id"]?.jsonPrimitive?.content)
+                respondJson(expectedSession)
+            }
+            val session = client.auth.mfa.verifyChallenge(expectedFactorId, expectedChallengeId, expectedCode, saveSession)
+            assertEquals(expectedSession, session)
+            if(saveSession) {
+                assertEquals(expectedSession, client.auth.currentSessionOrNull())
+            } else {
+                assertNull(client.auth.currentSessionOrNull())
+            }
+        }
+    }
+
+    private fun testCreateChallenge(withChannel: Boolean) {
+        runTest {
+            val expectedFactorId = "123"
+            val expectedChannel = "sms"
+            val expectedChallengeId = "456"
+            val expiresAt = 1L
+            val client = createMockedSupabaseClient(
+                configuration = configuration
+            ) {
+                assertPathIs("/factors/$expectedFactorId/challenge", it.url.pathAfterVersion())
+                assertMethodIs(HttpMethod.Post, it.method)
+                val body = it.body.toJsonElement().jsonObject
+                if(withChannel) {
+                    assertEquals(expectedChannel, body["channel"]?.jsonPrimitive?.content)
+                } else {
+                    assertNull(body["channel"])
+                }
+                respondJson("""
+                    {
+                    "id": "$expectedChallengeId",
+                    "type": "phone",
+                    "expires_at": "$expiresAt"
+                    }
+                """.trimIndent())
+            }
+            val challenge = client.auth.mfa.createChallenge(expectedFactorId, if(withChannel) Phone.Channel.SMS else null)
+            assertEquals(expectedChallengeId, challenge.id)
+            assertEquals("phone", challenge.factorType)
+            assertEquals(expiresAt, challenge.expiresAt.epochSeconds)
+        }
+    }
+
+    private fun verifiedFactor() = UserMfaFactor("id", Clock.System.now(), Clock.System.now(), "verified", factorType = "")
 
 }

--- a/GoTrue/src/settingsTest/kotlin/SettingsSessionManagerTest.kt
+++ b/GoTrue/src/settingsTest/kotlin/SettingsSessionManagerTest.kt
@@ -23,7 +23,7 @@ class SettingsSessionManagerTest {
             val sessionManager = SettingsSessionManager(settings)
             assertEquals(session, sessionManager.loadSession()) //Check if the session is loaded correctly
             assertEquals(session, json.decodeFromString(settings.getString(SettingsSessionManager.SETTINGS_KEY, ""))) //Check if the session is saved correctly
-            val newSession = userSession(200)
+            val newSession = userSession(expiresIn = 200)
             sessionManager.saveSession(newSession)
             assertEquals(newSession, sessionManager.loadSession()) //Check if the new session is saved correctly
             assertEquals(newSession,

--- a/sample/multi-factor-auth/common/src/commonMain/kotlin/io/github/jan/supabase/common/AppViewModel.kt
+++ b/sample/multi-factor-auth/common/src/commonMain/kotlin/io/github/jan/supabase/common/AppViewModel.kt
@@ -24,8 +24,7 @@ class AppViewModel(
 
     val sessionStatus = supabaseClient.auth.sessionStatus
     val loginAlert = MutableStateFlow<String?>(null)
-    val isLoggedInUsingMfa = supabaseClient.auth.mfa.loggedInUsingMfaFlow
-    val mfaEnabled = supabaseClient.auth.mfa.isMfaEnabledFlow
+    val statusFlow = supabaseClient.auth.mfa.statusFlow
     val enrolledFactor = MutableStateFlow<MfaFactor<FactorType.TOTP.Response>?>(null)
 
     //Auth

--- a/sample/multi-factor-auth/common/src/commonMain/kotlin/io/github/jan/supabase/common/ui/screen/MfaScreen.kt
+++ b/sample/multi-factor-auth/common/src/commonMain/kotlin/io/github/jan/supabase/common/ui/screen/MfaScreen.kt
@@ -4,16 +4,16 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import io.github.jan.supabase.common.AppViewModel
+import io.github.jan.supabase.gotrue.mfa.MfaStatus
 
 @Composable
 fun MfaScreen(viewModel: AppViewModel) {
-    val isLoggedInUsingMfa by viewModel.isLoggedInUsingMfa.collectAsState(false)
-    val mfaEnabled by viewModel.mfaEnabled.collectAsState(false)
+    val status by viewModel.statusFlow.collectAsState(MfaStatus(false, false))
     when {
-        isLoggedInUsingMfa && mfaEnabled -> { //only when logged in using mfa & mfa enabled
+        status.enabled && status.active -> { //only when logged in using mfa & mfa enabled
             AppScreen(viewModel)
         }
-        mfaEnabled && !isLoggedInUsingMfa -> { //show only when mfa enabled & not logged in using mfa
+        status.enabled && !status.active -> { //show only when mfa enabled & not logged in using mfa
             MfaLoginScreen(viewModel)
         }
         else -> { //show only when logged in using mfa and mfa disabled or not set up


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

You can only use the TOTP MFA type.

## What is the new behavior?

There is a new factor type `FactorType.Phone` and a new syntax for enrolling factors:
```kotlin
//Enrolling a phone factor
val factor = client.auth.mfa.enroll(FactorType.Phone, friendlyName) {
    phone = "+123456789"
}

//Enrolling a TOTP factor
val factor = client.auth.mfa.enroll(FactorType.TOTP, friendlyName) {
    issuer = "Issuer"
}
```
The `loggedInUsingMfa` and `isMfaEnabled` properties & flow variants have been deprecated in favor of `status` and `statusFlow`:
```kotlin
val (enabled, active) = client.auth.mfa.status

//Flow variant
client.auth.mfa.statusFlow.collect { (enabled, active) ->
    processChange(enabled, active)
}
```

## Additional context

Add any other context or screenshots.
