### PR TITLE
Add support for third party auth and add Slack OIDC provider

### DIFF
--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/AccessToken.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/AccessToken.kt
@@ -1,0 +1,36 @@
+package io.github.jan.supabase.gotrue
+
+import io.github.jan.supabase.SupabaseClient
+import io.github.jan.supabase.annotations.SupabaseInternal
+import io.github.jan.supabase.plugins.MainConfig
+import io.github.jan.supabase.plugins.MainPlugin
+
+/**
+ * Returns the access token used for requests. The token is resolved in the following order:
+ * 1. [jwtToken] if not null
+ * 2. [SupabaseClient.customAccessToken] if not null
+ * 3. [Auth.currentAccessTokenOrNull] if the Auth plugin is installed
+ * 4. [SupabaseClient.supabaseKey] if [keyAsFallback] is true
+ */
+@SupabaseInternal
+suspend fun SupabaseClient.accessToken(
+    jwtToken: String? = null,
+    keyAsFallback: Boolean = true
+): String? {
+    val key = if(keyAsFallback) supabaseKey else null
+    return jwtToken ?: customAccessToken?.invoke()
+    ?: pluginManager.getPluginOrNull(Auth)?.currentAccessTokenOrNull() ?: key
+}
+
+/**
+ * Returns the access token used for requests. The token is resolved in the following order:
+ * 1. [jwtToken] if not null
+ * 2. [SupabaseClient.customAccessToken] if not null
+ * 3. [Auth.currentAccessTokenOrNull] if the Auth plugin is installed
+ * 4. [SupabaseClient.supabaseKey] if [keyAsFallback] is true
+ */
+@SupabaseInternal
+suspend fun <C : MainConfig> SupabaseClient.accessToken(
+    plugin: MainPlugin<C>,
+    keyAsFallback: Boolean = true
+) = accessToken(plugin.config.jwtToken, keyAsFallback)

--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/AccessToken.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/AccessToken.kt
@@ -8,29 +8,29 @@ import io.github.jan.supabase.plugins.MainPlugin
 /**
  * Returns the access token used for requests. The token is resolved in the following order:
  * 1. [jwtToken] if not null
- * 2. [SupabaseClient.customAccessToken] if not null
+ * 2. [SupabaseClient.resolveAccessToken] if not null
  * 3. [Auth.currentAccessTokenOrNull] if the Auth plugin is installed
  * 4. [SupabaseClient.supabaseKey] if [keyAsFallback] is true
  */
 @SupabaseInternal
-suspend fun SupabaseClient.accessToken(
+suspend fun SupabaseClient.resolveAccessToken(
     jwtToken: String? = null,
     keyAsFallback: Boolean = true
 ): String? {
     val key = if(keyAsFallback) supabaseKey else null
-    return jwtToken ?: customAccessToken?.invoke()
+    return jwtToken ?: accessToken?.invoke()
     ?: pluginManager.getPluginOrNull(Auth)?.currentAccessTokenOrNull() ?: key
 }
 
 /**
  * Returns the access token used for requests. The token is resolved in the following order:
  * 1. [jwtToken] if not null
- * 2. [SupabaseClient.customAccessToken] if not null
+ * 2. [SupabaseClient.resolveAccessToken] if not null
  * 3. [Auth.currentAccessTokenOrNull] if the Auth plugin is installed
  * 4. [SupabaseClient.supabaseKey] if [keyAsFallback] is true
  */
 @SupabaseInternal
-suspend fun <C : MainConfig> SupabaseClient.accessToken(
+suspend fun <C : MainConfig> SupabaseClient.resolveAccessToken(
     plugin: MainPlugin<C>,
     keyAsFallback: Boolean = true
-) = accessToken(plugin.config.jwtToken, keyAsFallback)
+) = resolveAccessToken(plugin.config.jwtToken, keyAsFallback)

--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/AccessToken.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/AccessToken.kt
@@ -24,7 +24,7 @@ suspend fun SupabaseClient.resolveAccessToken(
 
 /**
  * Returns the access token used for requests. The token is resolved in the following order:
- * 1. [jwtToken] if not null
+ * 1. [MainConfig.jwtToken] if not null
  * 2. [SupabaseClient.resolveAccessToken] if not null
  * 3. [Auth.currentAccessTokenOrNull] if the Auth plugin is installed
  * 4. [SupabaseClient.supabaseKey] if [keyAsFallback] is true

--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/Auth.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/Auth.kt
@@ -442,7 +442,7 @@ sealed interface Auth : MainPlugin<AuthConfig>, CustomSerializationPlugin {
  * The Auth plugin handles everything related to Supabase's authentication system
  */
 val SupabaseClient.auth: Auth
-    get() = if(accessTokenProvider == null) pluginManager.getPlugin(Auth) else error("The Auth plugin is not available when using a custom access token provider")
+    get() = pluginManager.getPlugin(Auth)
 
 private suspend fun Auth.tryToGetUser(jwt: String) = try {
     retrieveUser(jwt)

--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/Auth.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/Auth.kt
@@ -442,7 +442,7 @@ sealed interface Auth : MainPlugin<AuthConfig>, CustomSerializationPlugin {
  * The Auth plugin handles everything related to Supabase's authentication system
  */
 val SupabaseClient.auth: Auth
-    get() = pluginManager.getPlugin(Auth)
+    get() = if(accessTokenProvider == null) pluginManager.getPlugin(Auth) else error("The Auth plugin is not available when using a custom access token provider")
 
 private suspend fun Auth.tryToGetUser(jwt: String) = try {
     retrieveUser(jwt)

--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/AuthImpl.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/AuthImpl.kt
@@ -87,7 +87,7 @@ internal class AuthImpl(
         get() = Auth.key
 
     init {
-        if(supabaseClient.customAccessToken != null) error("The Auth plugin is not available when using a custom access token provider. Please uninstall the Auth plugin.")
+        if(supabaseClient.accessToken != null) error("The Auth plugin is not available when using a custom access token provider. Please uninstall the Auth plugin.")
     }
 
     override fun init() {

--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/AuthImpl.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/AuthImpl.kt
@@ -87,7 +87,7 @@ internal class AuthImpl(
         get() = Auth.key
 
     init {
-        if(supabaseClient.accessTokenProvider != null) error("The Auth plugin is not available when using a custom access token provider. Please uninstall the Auth plugin.")
+        if(supabaseClient.customAccessToken != null) error("The Auth plugin is not available when using a custom access token provider. Please uninstall the Auth plugin.")
     }
 
     override fun init() {

--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/AuthImpl.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/AuthImpl.kt
@@ -87,6 +87,7 @@ internal class AuthImpl(
         get() = Auth.key
 
     override fun init() {
+        if(supabaseClient.accessTokenProvider != null) error("The Auth plugin is not available when using a custom access token provider. Please uninstall the Auth plugin.")
         setupPlatform()
         if (config.autoLoadFromStorage) {
             authScope.launch {

--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/AuthImpl.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/AuthImpl.kt
@@ -86,8 +86,11 @@ internal class AuthImpl(
     override val pluginKey: String
         get() = Auth.key
 
-    override fun init() {
+    init {
         if(supabaseClient.accessTokenProvider != null) error("The Auth plugin is not available when using a custom access token provider. Please uninstall the Auth plugin.")
+    }
+
+    override fun init() {
         setupPlatform()
         if (config.autoLoadFromStorage) {
             authScope.launch {

--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/AuthenticatedSupabaseApi.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/AuthenticatedSupabaseApi.kt
@@ -21,7 +21,11 @@ class AuthenticatedSupabaseApi @SupabaseInternal constructor(
 ): SupabaseApi(resolveUrl, parseErrorResponse, supabaseClient) {
 
     override suspend fun rawRequest(url: String, builder: HttpRequestBuilder.() -> Unit): HttpResponse = super.rawRequest(url) {
-        val jwtToken = jwtToken ?: supabaseClient.pluginManager.getPluginOrNull(Auth)?.currentAccessTokenOrNull() ?: supabaseClient.supabaseKey
+        val jwtToken = jwtToken ?: if(supabaseClient.accessTokenProvider != null) {
+            supabaseClient.accessTokenProvider!!()
+        } else {
+            supabaseClient.pluginManager.getPluginOrNull(Auth)?.currentAccessTokenOrNull()
+        } ?: supabaseClient.supabaseKey
         bearerAuth(jwtToken)
         builder()
         defaultRequest?.invoke(this)

--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/AuthenticatedSupabaseApi.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/AuthenticatedSupabaseApi.kt
@@ -21,7 +21,7 @@ class AuthenticatedSupabaseApi @SupabaseInternal constructor(
 ): SupabaseApi(resolveUrl, parseErrorResponse, supabaseClient) {
 
     override suspend fun rawRequest(url: String, builder: HttpRequestBuilder.() -> Unit): HttpResponse {
-        val accessToken = supabaseClient.accessToken(jwtToken) ?: error("No access token available")
+        val accessToken = supabaseClient.resolveAccessToken(jwtToken) ?: error("No access token available")
         return super.rawRequest(url) {
             bearerAuth(accessToken)
             builder()

--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/AuthenticatedSupabaseApi.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/AuthenticatedSupabaseApi.kt
@@ -21,13 +21,9 @@ class AuthenticatedSupabaseApi @SupabaseInternal constructor(
 ): SupabaseApi(resolveUrl, parseErrorResponse, supabaseClient) {
 
     override suspend fun rawRequest(url: String, builder: HttpRequestBuilder.() -> Unit): HttpResponse {
-        val customAccessToken = if(supabaseClient.accessTokenProvider != null) {
-            supabaseClient.accessTokenProvider!!()
-        } else null
+        val accessToken = supabaseClient.accessToken(jwtToken) ?: error("No access token available")
         return super.rawRequest(url) {
-            // 1. A custom token in the plugin config 2. The token from a third party provider 3. The token from the current session (Supabase Auth) 4. The default token from the client
-            val jwtToken = jwtToken ?: customAccessToken ?: supabaseClient.pluginManager.getPluginOrNull(Auth)?.currentAccessTokenOrNull() ?: supabaseClient.supabaseKey
-            bearerAuth(jwtToken)
+            bearerAuth(accessToken)
             builder()
             defaultRequest?.invoke(this)
         }

--- a/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/providers/Providers.kt
+++ b/GoTrue/src/commonMain/kotlin/io/github/jan/supabase/gotrue/providers/Providers.kt
@@ -55,6 +55,12 @@ data object Slack : OAuthProvider() {
 
 }
 
+data object SlackOIDC : OAuthProvider() {
+
+    override val name = "slack_oidc"
+
+}
+
 data object Twitch : OAuthProvider() {
 
     override val name = "twitch"

--- a/GoTrue/src/commonTest/kotlin/AccessTokenTest.kt
+++ b/GoTrue/src/commonTest/kotlin/AccessTokenTest.kt
@@ -1,0 +1,73 @@
+import io.github.jan.supabase.gotrue.Auth
+import io.github.jan.supabase.gotrue.accessToken
+import io.github.jan.supabase.gotrue.auth
+import io.github.jan.supabase.gotrue.minimalSettings
+import io.github.jan.supabase.testing.createMockedSupabaseClient
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class AccessTokenTest {
+
+    @Test
+    fun testAccessTokenWithJwtToken() {
+        runTest {
+            val client = createMockedSupabaseClient(
+                configuration = {
+                    install(Auth) {
+                        minimalSettings()
+                    }
+                }
+            )
+            client.auth.importAuthToken("myAuth") //this should be ignored as per plugin tokens override the used access token
+            assertEquals("myJwtToken", client.accessToken("myJwtToken"))
+        }
+    }
+
+    @Test
+    fun testAccessTokenWithKeyAsFallback() {
+        runTest {
+            val client = createMockedSupabaseClient(supabaseKey = "myKey")
+            assertEquals("myKey", client.accessToken())
+        }
+    }
+
+    @Test
+    fun testAccessTokenWithoutKey() {
+        runTest {
+            val client = createMockedSupabaseClient()
+            assertNull(client.accessToken(keyAsFallback = false))
+        }
+    }
+
+    @Test
+    fun testAccessTokenWithCustomAccessToken() {
+        runTest {
+            val client = createMockedSupabaseClient(
+                configuration = {
+                    accessToken = {
+                        "myCustomToken"
+                    }
+                }
+            )
+            assertEquals("myCustomToken", client.accessToken())
+        }
+    }
+
+    @Test
+    fun testAccessTokenWithAuth() {
+        runTest {
+            val client = createMockedSupabaseClient(
+                configuration = {
+                    install(Auth) {
+                        minimalSettings()
+                    }
+                }
+            )
+            client.auth.importAuthToken("myAuth")
+            assertEquals("myAuth", client.accessToken())
+        }
+    }
+
+}

--- a/GoTrue/src/commonTest/kotlin/AccessTokenTest.kt
+++ b/GoTrue/src/commonTest/kotlin/AccessTokenTest.kt
@@ -1,7 +1,7 @@
 import io.github.jan.supabase.gotrue.Auth
-import io.github.jan.supabase.gotrue.accessToken
 import io.github.jan.supabase.gotrue.auth
 import io.github.jan.supabase.gotrue.minimalSettings
+import io.github.jan.supabase.gotrue.resolveAccessToken
 import io.github.jan.supabase.testing.createMockedSupabaseClient
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
@@ -21,7 +21,7 @@ class AccessTokenTest {
                 }
             )
             client.auth.importAuthToken("myAuth") //this should be ignored as per plugin tokens override the used access token
-            assertEquals("myJwtToken", client.accessToken("myJwtToken"))
+            assertEquals("myJwtToken", client.resolveAccessToken("myJwtToken"))
         }
     }
 
@@ -29,7 +29,7 @@ class AccessTokenTest {
     fun testAccessTokenWithKeyAsFallback() {
         runTest {
             val client = createMockedSupabaseClient(supabaseKey = "myKey")
-            assertEquals("myKey", client.accessToken())
+            assertEquals("myKey", client.resolveAccessToken())
         }
     }
 
@@ -37,7 +37,7 @@ class AccessTokenTest {
     fun testAccessTokenWithoutKey() {
         runTest {
             val client = createMockedSupabaseClient()
-            assertNull(client.accessToken(keyAsFallback = false))
+            assertNull(client.resolveAccessToken(keyAsFallback = false))
         }
     }
 
@@ -51,7 +51,7 @@ class AccessTokenTest {
                     }
                 }
             )
-            assertEquals("myCustomToken", client.accessToken())
+            assertEquals("myCustomToken", client.resolveAccessToken())
         }
     }
 
@@ -66,7 +66,7 @@ class AccessTokenTest {
                 }
             )
             client.auth.importAuthToken("myAuth")
-            assertEquals("myAuth", client.accessToken())
+            assertEquals("myAuth", client.resolveAccessToken())
         }
     }
 

--- a/GoTrue/src/commonTest/kotlin/AuthTest.kt
+++ b/GoTrue/src/commonTest/kotlin/AuthTest.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.buildJsonObject
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
 import kotlin.test.assertNull
 
@@ -43,6 +44,22 @@ class AuthTest {
             )
             client.auth.awaitInitialization()
             assertIs<SessionStatus.Authenticated>(client.auth.sessionStatus.value)
+        }
+    }
+
+    @Test
+    fun testErrorWhenUsingAccessToken() {
+        runTest {
+            assertFailsWith<IllegalStateException> {
+                createMockedSupabaseClient(
+                    configuration = {
+                        accessToken = {
+                            "myToken"
+                        }
+                        install(Auth)
+                    }
+                )
+            }
         }
     }
 

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeChannelImpl.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeChannelImpl.kt
@@ -3,7 +3,7 @@ package io.github.jan.supabase.realtime
 import io.github.jan.supabase.annotations.SupabaseInternal
 import io.github.jan.supabase.collections.AtomicMutableList
 import io.github.jan.supabase.decodeIfNotEmptyOrDefault
-import io.github.jan.supabase.gotrue.Auth
+import io.github.jan.supabase.gotrue.accessToken
 import io.github.jan.supabase.logging.d
 import io.github.jan.supabase.logging.e
 import io.github.jan.supabase.logging.w
@@ -17,7 +17,6 @@ import io.ktor.http.headers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
-import kotlinx.datetime.Clock
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
@@ -61,9 +60,7 @@ internal class RealtimeChannelImpl(
         }
         _status.value = RealtimeChannel.Status.SUBSCRIBING
         Realtime.logger.d { "Subscribing to channel $topic" }
-        val currentJwt = realtimeImpl.config.jwtToken ?: supabaseClient.pluginManager.getPluginOrNull(Auth)?.currentSessionOrNull()?.let {
-            if(it.expiresAt > Clock.System.now()) it.accessToken else null
-        }
+        val currentJwt = supabaseClient.accessToken(realtimeImpl, keyAsFallback = false)
         val postgrestChanges = clientChanges.toList()
         val joinConfig = RealtimeJoinPayload(RealtimeJoinConfig(broadcastJoinConfig, presenceJoinConfig, postgrestChanges, isPrivate))
         val joinConfigObject = buildJsonObject {

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeChannelImpl.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeChannelImpl.kt
@@ -3,7 +3,7 @@ package io.github.jan.supabase.realtime
 import io.github.jan.supabase.annotations.SupabaseInternal
 import io.github.jan.supabase.collections.AtomicMutableList
 import io.github.jan.supabase.decodeIfNotEmptyOrDefault
-import io.github.jan.supabase.gotrue.accessToken
+import io.github.jan.supabase.gotrue.resolveAccessToken
 import io.github.jan.supabase.logging.d
 import io.github.jan.supabase.logging.e
 import io.github.jan.supabase.logging.w
@@ -60,7 +60,7 @@ internal class RealtimeChannelImpl(
         }
         _status.value = RealtimeChannel.Status.SUBSCRIBING
         Realtime.logger.d { "Subscribing to channel $topic" }
-        val currentJwt = supabaseClient.accessToken(realtimeImpl, keyAsFallback = false)
+        val currentJwt = supabaseClient.resolveAccessToken(realtimeImpl, keyAsFallback = false)
         val postgrestChanges = clientChanges.toList()
         val joinConfig = RealtimeJoinPayload(RealtimeJoinConfig(broadcastJoinConfig, presenceJoinConfig, postgrestChanges, isPrivate))
         val joinConfigObject = buildJsonObject {

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/BucketApi.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/BucketApi.kt
@@ -3,7 +3,7 @@ package io.github.jan.supabase.storage
 import io.github.jan.supabase.SupabaseClient
 import io.github.jan.supabase.exceptions.HttpRequestException
 import io.github.jan.supabase.exceptions.RestException
-import io.github.jan.supabase.gotrue.accessToken
+import io.github.jan.supabase.gotrue.resolveAccessToken
 import io.github.jan.supabase.storage.resumable.ResumableClient
 import io.ktor.client.plugins.HttpRequestTimeoutException
 import io.ktor.utils.io.ByteReadChannel
@@ -316,6 +316,6 @@ sealed interface BucketApi {
  */
 suspend fun BucketApi.authenticatedRequest(path: String): Pair<String, String> {
     val url = authenticatedUrl(path)
-    val token = supabaseClient.accessToken(supabaseClient.storage) ?: error("No access token available")
+    val token = supabaseClient.resolveAccessToken(supabaseClient.storage) ?: error("No access token available")
     return token to url
 }

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/BucketApi.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/BucketApi.kt
@@ -3,7 +3,7 @@ package io.github.jan.supabase.storage
 import io.github.jan.supabase.SupabaseClient
 import io.github.jan.supabase.exceptions.HttpRequestException
 import io.github.jan.supabase.exceptions.RestException
-import io.github.jan.supabase.gotrue.Auth
+import io.github.jan.supabase.gotrue.accessToken
 import io.github.jan.supabase.storage.resumable.ResumableClient
 import io.ktor.client.plugins.HttpRequestTimeoutException
 import io.ktor.utils.io.ByteReadChannel
@@ -314,8 +314,8 @@ sealed interface BucketApi {
  * **Authentication: Bearer <your_access_token>**
  * @param path The path to download
  */
-fun BucketApi.authenticatedRequest(path: String): Pair<String, String> {
+suspend fun BucketApi.authenticatedRequest(path: String): Pair<String, String> {
     val url = authenticatedUrl(path)
-    val token = supabaseClient.storage.config.jwtToken ?: supabaseClient.pluginManager.getPluginOrNull(Auth)?.currentAccessTokenOrNull() ?: supabaseClient.supabaseKey
+    val token = supabaseClient.accessToken(supabaseClient.storage) ?: error("No access token available")
     return token to url
 }

--- a/Supabase/src/commonMain/kotlin/io/github/jan/supabase/AccessTokenProvider.kt
+++ b/Supabase/src/commonMain/kotlin/io/github/jan/supabase/AccessTokenProvider.kt
@@ -6,9 +6,5 @@ package io.github.jan.supabase
  * obtaining it from the third-party auth client library. Note that this
  * function may be called concurrently and many times. Use memoization and
  * locking techniques if this is not supported by the client libraries.
- *
- * When set, the Auth plugin from `auth-kt` cannot be used.
- * Create another client if you wish to use Supabase Auth and third-party
- * authentications concurrently in the same application.
  */
 typealias AccessTokenProvider = suspend () -> String

--- a/Supabase/src/commonMain/kotlin/io/github/jan/supabase/AccessTokenProvider.kt
+++ b/Supabase/src/commonMain/kotlin/io/github/jan/supabase/AccessTokenProvider.kt
@@ -11,4 +11,4 @@ package io.github.jan.supabase
  * Create another client if you wish to use Supabase Auth and third-party
  * authentications concurrently in the same application.
  */
-typealias AccessTokenProvider = () -> String
+typealias AccessTokenProvider = suspend () -> String

--- a/Supabase/src/commonMain/kotlin/io/github/jan/supabase/AccessTokenProvider.kt
+++ b/Supabase/src/commonMain/kotlin/io/github/jan/supabase/AccessTokenProvider.kt
@@ -1,0 +1,14 @@
+package io.github.jan.supabase
+
+/**
+ * Optional function for using a third-party authentication system with
+ * Supabase. The function should return an access token or ID token (JWT) by
+ * obtaining it from the third-party auth client library. Note that this
+ * function may be called concurrently and many times. Use memoization and
+ * locking techniques if this is not supported by the client libraries.
+ *
+ * When set, the Auth plugin from `auth-kt` cannot be used.
+ * Create another client if you wish to use Supabase Auth and third-party
+ * authentications concurrently in the same application.
+ */
+typealias AccessTokenProvider = () -> String

--- a/Supabase/src/commonMain/kotlin/io/github/jan/supabase/SupabaseClient.kt
+++ b/Supabase/src/commonMain/kotlin/io/github/jan/supabase/SupabaseClient.kt
@@ -57,7 +57,7 @@ sealed interface SupabaseClient {
      * The custom access token provider used to provide custom access tokens for requests. Configured within the [SupabaseClientBuilder]
      */
     @SupabaseInternal
-    val customAccessToken: AccessTokenProvider?
+    val accessToken: AccessTokenProvider?
 
     /**
      * Releases all resources held by the [httpClient] and all plugins the [pluginManager]
@@ -94,7 +94,7 @@ internal class SupabaseClientImpl(
     requestTimeout: Long,
     httpEngine: HttpClientEngine?,
     override val defaultSerializer: SupabaseSerializer,
-    override val customAccessToken: AccessTokenProvider?,
+    override val accessToken: AccessTokenProvider?,
 ) : SupabaseClient {
 
     init {

--- a/Supabase/src/commonMain/kotlin/io/github/jan/supabase/SupabaseClient.kt
+++ b/Supabase/src/commonMain/kotlin/io/github/jan/supabase/SupabaseClient.kt
@@ -53,8 +53,11 @@ sealed interface SupabaseClient {
      */
     val defaultSerializer: SupabaseSerializer
 
+    /**
+     * The custom access token provider used to provide custom access tokens for requests. Configured within the [SupabaseClientBuilder]
+     */
     @SupabaseInternal
-    val accessTokenProvider: AccessTokenProvider?
+    val customAccessToken: AccessTokenProvider?
 
     /**
      * Releases all resources held by the [httpClient] and all plugins the [pluginManager]
@@ -91,7 +94,7 @@ internal class SupabaseClientImpl(
     requestTimeout: Long,
     httpEngine: HttpClientEngine?,
     override val defaultSerializer: SupabaseSerializer,
-    override val accessTokenProvider: AccessTokenProvider?,
+    override val customAccessToken: AccessTokenProvider?,
 ) : SupabaseClient {
 
     init {

--- a/Supabase/src/commonMain/kotlin/io/github/jan/supabase/SupabaseClient.kt
+++ b/Supabase/src/commonMain/kotlin/io/github/jan/supabase/SupabaseClient.kt
@@ -39,7 +39,7 @@ sealed interface SupabaseClient {
     val pluginManager: PluginManager
 
     /**
-     * The http client used to interact with the supabase api
+     * The http client used to interact with the Supabase api
      */
     val httpClient: KtorSupabaseHttpClient
 
@@ -52,6 +52,9 @@ sealed interface SupabaseClient {
      * The default serializer used to serialize and deserialize custom data types.
      */
     val defaultSerializer: SupabaseSerializer
+
+    @SupabaseInternal
+    val accessTokenProvider: AccessTokenProvider?
 
     /**
      * Releases all resources held by the [httpClient] and all plugins the [pluginManager]
@@ -88,6 +91,7 @@ internal class SupabaseClientImpl(
     requestTimeout: Long,
     httpEngine: HttpClientEngine?,
     override val defaultSerializer: SupabaseSerializer,
+    override val accessTokenProvider: AccessTokenProvider?,
 ) : SupabaseClient {
 
     init {

--- a/Supabase/src/commonMain/kotlin/io/github/jan/supabase/SupabaseClientBuilder.kt
+++ b/Supabase/src/commonMain/kotlin/io/github/jan/supabase/SupabaseClientBuilder.kt
@@ -66,6 +66,19 @@ class SupabaseClientBuilder @PublishedApi internal constructor(private val supab
      */
     var defaultSerializer: SupabaseSerializer = KotlinXSerializer(Json { ignoreUnknownKeys = true })
 
+    /**
+     * Optional function for using a third-party authentication system with
+     * Supabase. The function should return an access token or ID token (JWT) by
+     * obtaining it from the third-party auth client library. Note that this
+     * function may be called concurrently and many times. Use memoization and
+     * locking techniques if this is not supported by the client libraries.
+     *
+     * When set, the Auth plugin from `auth-kt` cannot be used.
+     * Create another client if you wish to use Supabase Auth and third-party
+     * authentications concurrently in the same application.
+     */
+    var accessToken: AccessTokenProvider? = null
+
     private val httpConfigOverrides = mutableListOf<HttpClientConfig<*>.() -> Unit>()
     private val plugins = mutableMapOf<String, ((SupabaseClient) -> SupabasePlugin<*>)>()
 
@@ -95,7 +108,8 @@ class SupabaseClientBuilder @PublishedApi internal constructor(private val supab
             useHTTPS,
             requestTimeout.inWholeMilliseconds,
             httpEngine,
-            defaultSerializer
+            defaultSerializer,
+            accessToken
         )
     }
 

--- a/test-common/src/commonTest/kotlin/SupabaseClientTest.kt
+++ b/test-common/src/commonTest/kotlin/SupabaseClientTest.kt
@@ -40,7 +40,7 @@ class SupabaseClientTest {
                     }
                 }
             )
-            assertEquals("myToken", client.customAccessToken?.invoke())
+            assertEquals("myToken", client.accessToken?.invoke())
         }
     }
 

--- a/test-common/src/commonTest/kotlin/SupabaseClientTest.kt
+++ b/test-common/src/commonTest/kotlin/SupabaseClientTest.kt
@@ -34,14 +34,6 @@ class SupabaseClientTest {
     fun testAccessTokenProvider() {
         runTest {
             val client = createMockedSupabaseClient(
-                requestHandler = {
-                    assertEquals(
-                        "supabase-kt/${BuildConfig.PROJECT_VERSION}",
-                        it.headers["X-Client-Info"],
-                        "X-Client-Info header should be set to 'supabase-kt/${BuildConfig.PROJECT_VERSION}'"
-                    )
-                    respond("")
-                },
                 configuration = {
                     accessToken = {
                         "myToken"

--- a/test-common/src/commonTest/kotlin/SupabaseClientTest.kt
+++ b/test-common/src/commonTest/kotlin/SupabaseClientTest.kt
@@ -31,6 +31,28 @@ class SupabaseClientTest {
     }
 
     @Test
+    fun testAccessTokenProvider() {
+        runTest {
+            val client = createMockedSupabaseClient(
+                requestHandler = {
+                    assertEquals(
+                        "supabase-kt/${BuildConfig.PROJECT_VERSION}",
+                        it.headers["X-Client-Info"],
+                        "X-Client-Info header should be set to 'supabase-kt/${BuildConfig.PROJECT_VERSION}'"
+                    )
+                    respond("")
+                },
+                configuration = {
+                    accessToken = {
+                        "myToken"
+                    }
+                }
+            )
+            assertEquals("myToken", client.accessTokenProvider?.invoke())
+        }
+    }
+
+    @Test
     fun testDefaultLogLevel() {
         createMockedSupabaseClient(
             configuration = {

--- a/test-common/src/commonTest/kotlin/SupabaseClientTest.kt
+++ b/test-common/src/commonTest/kotlin/SupabaseClientTest.kt
@@ -40,7 +40,7 @@ class SupabaseClientTest {
                     }
                 }
             )
-            assertEquals("myToken", client.accessTokenProvider?.invoke())
+            assertEquals("myToken", client.customAccessToken?.invoke())
         }
     }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

No support for third party auth and missing the Slack OIDC provider.

## What is the new behavior?

The provider has been added and there is a new option in the `SupabaseClientBuilder`:
```kotlin
val supabase = createSupabaseClient(supabaseUrl, supabaseKey) {
    accessToken = {
          //fetch the third party token
         "my-token"
    }
}
```
If this property is not null, the `Auth` plugin will not be available and this custom provider function will be used for auth.

## Additional context

Check https://github.com/supabase/supabase-js/pull/1004.
