### PR TITLE
Improve base realtime `postgres`, `presence` and `broadcast` flow methods

### DIFF
--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeChannel.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeChannel.kt
@@ -2,15 +2,14 @@ package io.github.jan.supabase.realtime
 
 import io.github.jan.supabase.SupabaseClient
 import io.github.jan.supabase.annotations.SupabaseInternal
-import io.github.jan.supabase.decode
 import io.github.jan.supabase.encodeToJsonElement
-import io.github.jan.supabase.logging.e
-import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonObject
+import kotlin.reflect.KClass
+import kotlin.reflect.KType
+import kotlin.reflect.typeOf
 
 /**
  * Represents a realtime channel
@@ -70,6 +69,33 @@ sealed interface RealtimeChannel {
      */
     suspend fun untrack()
 
+    /**
+     * Non-inline variant of [postgresChangeFlow] for implementation and mocking purposes
+     */
+    @SupabaseInternal
+    fun <T : PostgresAction> RealtimeChannel.postgresChangeFlowInternal(action: KClass<T>, schema: String, filter: PostgresChangeFilter.() -> Unit = {}): Flow<T>
+
+    /**
+     * Non-inline variant of [broadcastFlow] for implementation and mocking purposes
+     */
+    @SupabaseInternal
+    fun <T : Any> RealtimeChannel.broadcastFlowInternal(type: KType, event: String): Flow<T>
+
+    /**
+     * Listen for clients joining / leaving the channel using presences
+     *
+     * Example:
+     * ```kotlin
+     * val presenceChangeFlow = channel.presenceChangeFlow()
+     *
+     * presenceChangeFlow.collect {
+     *    val joins = it.decodeJoinsAs<User>()
+     *    val leaves = it.decodeLeavesAs<User>()
+     * }
+     * ```
+     */
+    fun presenceChangeFlow(): Flow<PresenceAction>
+
     @SupabaseInternal
     fun RealtimeChannel.addPostgresChange(data: PostgresJoinConfig)
 
@@ -105,31 +131,6 @@ sealed interface RealtimeChannel {
 }
 
 /**
- * Listen for clients joining / leaving the channel using presences
- *
- * Example:
- * ```kotlin
- * val presenceChangeFlow = channel.presenceChangeFlow()
- *
- * presenceChangeFlow.collect {
- *    val joins = it.decodeJoinsAs<User>()
- *    val leaves = it.decodeLeavesAs<User>()
- * }
- * ```
- */
-@OptIn(SupabaseInternal::class)
-fun RealtimeChannel.presenceChangeFlow(): Flow<PresenceAction> {
-    return callbackFlow {
-        val callback: (PresenceAction) -> Unit = { action ->
-            trySend(action)
-        }
-
-        val id = callbackManager.addPresenceCallback(callback)
-        awaitClose { callbackManager.removeCallbackById(id) }
-    }
-}
-
-/**
  * Listen for postgres changes in a channel.
  *
  * Example:
@@ -144,34 +145,10 @@ fun RealtimeChannel.presenceChangeFlow(): Flow<PresenceAction> {
  * @param T The event type you want to listen to (e.g. [PostgresAction.Update] for updates or only [PostgresAction] for all)
  * @param schema The schema name of the table that is being monitored. For normal supabase tables that might be "public".
  */
-@OptIn(SupabaseInternal::class)
-inline fun <reified T : PostgresAction> RealtimeChannel.postgresChangeFlow(schema: String, filter: PostgresChangeFilter.() -> Unit = {}): Flow<T> {
-    if(status.value == RealtimeChannel.Status.SUBSCRIBED) error("You cannot call postgresChangeFlow after joining the channel")
-    val event = when(T::class) {
-        PostgresAction.Insert::class -> "INSERT"
-        PostgresAction.Update::class -> "UPDATE"
-        PostgresAction.Delete::class -> "DELETE"
-        PostgresAction.Select::class -> "SELECT"
-        PostgresAction::class -> "*"
-        else -> error("Unknown event type ${T::class}")
-    }
-    val postgrestBuilder = PostgresChangeFilter(event, schema).apply(filter)
-    val config = postgrestBuilder.buildConfig()
-    addPostgresChange(config)
-    return callbackFlow {
-        val callback: (PostgresAction) -> Unit = {
-            if (it is T) {
-                trySend(it)
-            }
-        }
-
-        val id = callbackManager.addPostgresCallback(config, callback)
-        awaitClose {
-            callbackManager.removeCallbackById(id)
-            removePostgresChange(config)
-        }
-    }
-}
+inline fun <reified T : PostgresAction> RealtimeChannel.postgresChangeFlow(
+    schema: String,
+    noinline filter: PostgresChangeFilter.() -> Unit = {}
+): Flow<T> = postgresChangeFlowInternal(T::class, schema, filter)
 
 /**
  * Broadcasts can be messages sent by other clients within the same channel under a specific [event].
@@ -187,18 +164,7 @@ inline fun <reified T : PostgresAction> RealtimeChannel.postgresChangeFlow(schem
  * @param event When a message is sent by another client, it will be sent under a specific event. This is the event that you want to listen to
  */
 @OptIn(SupabaseInternal::class)
-inline fun <reified T : Any> RealtimeChannel.broadcastFlow(event: String): Flow<T> = callbackFlow {
-    val id = callbackManager.addBroadcastCallback(event) {
-        val decodedValue = try {
-            supabaseClient.realtime.serializer.decode<T>(it.toString())
-        } catch(e: Exception) {
-            Realtime.logger.e(e) { "Couldn't decode $this as ${T::class.simpleName}. The corresponding handler wasn't called" }
-            null
-        }
-        decodedValue?.let { value -> trySend(value) }
-    }
-    awaitClose { callbackManager.removeCallbackById(id) }
-}
+inline fun <reified T : Any> RealtimeChannel.broadcastFlow(event: String): Flow<T> = broadcastFlowInternal(typeOf<T>(), event)
 
 /**
  * Sends a message to everyone who joined the channel. Can be used even if you aren't connected to the channel.

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeChannelImpl.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeChannelImpl.kt
@@ -269,7 +269,7 @@ internal class RealtimeChannelImpl(
         awaitClose { callbackManager.removeCallbackById(id) }
     }
 
-    override fun RealtimeChannel.presenceChangeFlow(): Flow<PresenceAction> = callbackFlow {
+    override fun presenceChangeFlow(): Flow<PresenceAction> = callbackFlow {
         val callback: (PresenceAction) -> Unit = { action ->
             trySend(action)
         }

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeChannelImpl.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeChannelImpl.kt
@@ -14,8 +14,11 @@ import io.github.jan.supabase.realtime.data.PostgresActionData
 import io.github.jan.supabase.supabaseJson
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.headers
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
@@ -28,6 +31,8 @@ import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.longOrNull
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonObject
+import kotlin.reflect.KClass
+import kotlin.reflect.KType
 
 internal class RealtimeChannelImpl(
     private val realtimeImpl: RealtimeImpl,
@@ -217,6 +222,59 @@ internal class RealtimeChannelImpl(
                 put("event", "untrack")
             }, (++realtimeImpl.ref).toString())
         )
+    }
+
+    override fun <T : PostgresAction> RealtimeChannel.postgresChangeFlowInternal(
+        action: KClass<T>,
+        schema: String,
+        filter: PostgresChangeFilter.() -> Unit
+    ): Flow<T> {
+        if(status.value == RealtimeChannel.Status.SUBSCRIBED) error("You cannot call postgresChangeFlow after joining the channel")
+        val event = when(action) {
+            PostgresAction.Insert::class -> "INSERT"
+            PostgresAction.Update::class -> "UPDATE"
+            PostgresAction.Delete::class -> "DELETE"
+            PostgresAction.Select::class -> "SELECT"
+            PostgresAction::class -> "*"
+            else -> error("Unknown event type $action")
+        }
+        val postgrestBuilder = PostgresChangeFilter(event, schema).apply(filter)
+        val config = postgrestBuilder.buildConfig()
+        addPostgresChange(config)
+        return callbackFlow {
+            val callback: (PostgresAction) -> Unit = {
+                if (action.isInstance(it)) {
+                    trySend(it as T)
+                }
+            }
+
+            val id = callbackManager.addPostgresCallback(config, callback)
+            awaitClose {
+                callbackManager.removeCallbackById(id)
+                removePostgresChange(config)
+            }
+        }
+    }
+
+    override fun <T : Any> RealtimeChannel.broadcastFlowInternal(type: KType, event: String): Flow<T> = callbackFlow {
+        val id = callbackManager.addBroadcastCallback(event) {
+            val decodedValue = try {
+                supabaseClient.realtime.serializer.decode<T>(type, it.toString())
+            } catch(e: Exception) {
+                Realtime.logger.e(e) { "Couldn't decode $it as $type. The corresponding handler wasn't called" }
+                null
+            }
+            decodedValue?.let { value -> trySend(value) }
+        }
+        awaitClose { callbackManager.removeCallbackById(id) }
+    }
+
+    override fun RealtimeChannel.presenceChangeFlow(): Flow<PresenceAction> = callbackFlow {
+        val callback: (PresenceAction) -> Unit = { action ->
+            trySend(action)
+        }
+        val id = callbackManager.addPresenceCallback(callback)
+        awaitClose { callbackManager.removeCallbackById(id) }
     }
 
 }

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeExt.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeExt.kt
@@ -30,7 +30,7 @@ internal fun <Data> List<PrimaryKey<Data>>.producer(data: Data): String =
 /**
  * Listens for presence changes and caches the presences based on their keys. This function automatically handles joins and leaves.
  *
- * If you want more control, use the [presenceChangeFlow] function.
+ * If you want more control, use the [RealtimeChannel.presenceChangeFlow] function.
  * @return a [Flow] of the current presences in a list. This list is updated and emitted whenever a presence joins or leaves.
  */
 inline fun <reified Data> RealtimeChannel.presenceDataFlow(): Flow<List<Data>> {

--- a/Realtime/src/commonTest/kotlin/RealtimeChannelTest.kt
+++ b/Realtime/src/commonTest/kotlin/RealtimeChannelTest.kt
@@ -17,7 +17,6 @@ import io.github.jan.supabase.realtime.RealtimeMessage
 import io.github.jan.supabase.realtime.broadcastFlow
 import io.github.jan.supabase.realtime.channel
 import io.github.jan.supabase.realtime.postgresChangeFlow
-import io.github.jan.supabase.realtime.presenceChangeFlow
 import io.github.jan.supabase.realtime.realtime
 import io.github.jan.supabase.testing.assertPathIs
 import io.github.jan.supabase.testing.pathAfterVersion


### PR DESCRIPTION
## What kind of change does this PR introduce?

Internal refactor

## What is the current behavior?

The base `postgresChangeFlow` and `broadcastFlow` implementation shouldn't be outside the `RealtimeChannel` class as they are essentially calling internal methods. Them being `inline` also makes it impossible to mock.

## What is the new behavior?

Basically nothing changes for the public API except the `presenceChangeFlow` being moved up to be a member function of `RealtimeChannel`. Internally, `postgresChangeFlow` and `broadcastFlow` now call a internal non-inline variant which actually implements the logic.
