### PR TITLE
Extract optional PostgREST properties and add schema support for RPC.

### DIFF
--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/Postgrest.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/Postgrest.kt
@@ -53,7 +53,6 @@ sealed interface Postgrest : MainPlugin<Postgrest.Config>, CustomSerializationPl
 
     /**
      * Creates a new [PostgrestQueryBuilder] for the given schema and table
-     * @param schema The schema to use for the requests
      * @param table The table to use for the requests
      */
     operator fun get(table: String): PostgrestQueryBuilder = from(table)

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/PostgrestRpc.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/PostgrestRpc.kt
@@ -2,8 +2,10 @@
 package io.github.jan.supabase.postgrest
 
 import io.github.jan.supabase.encodeToJsonElement
+import io.github.jan.supabase.exceptions.RestException
 import io.github.jan.supabase.postgrest.executor.RestRequestExecutor
 import io.github.jan.supabase.postgrest.query.PostgrestRequestBuilder
+import io.github.jan.supabase.postgrest.query.request.RpcPostgrestRequestBuilder
 import io.github.jan.supabase.postgrest.request.RpcRequest
 import io.github.jan.supabase.postgrest.result.PostgrestResult
 import io.ktor.http.HttpMethod
@@ -34,29 +36,28 @@ enum class RpcMethod(val httpMethod: HttpMethod) {
  *
  * @param function The name of the function
  * @param parameters The parameters for the function
- * @param method The HTTP method to use. Default is POST
  * @param request Filter the result
  * @throws RestException or one of its subclasses if the request failed
  */
 suspend inline fun <reified T : Any> Postgrest.rpc(
     function: String,
     parameters: T,
-    method: RpcMethod = RpcMethod.POST,
     request: PostgrestRequestBuilder.() -> Unit = {},
 ): PostgrestResult {
     val encodedParameters = if (parameters is JsonElement) parameters else serializer.encodeToJsonElement(parameters)
-    val requestBuilder = PostgrestRequestBuilder(config.propertyConversionMethod).apply(request)
+    val requestBuilder = RpcPostgrestRequestBuilder(config.defaultSchema, config.propertyConversionMethod).apply(request)
     val urlParams = buildMap {
         putAll(requestBuilder.params.mapToFirstValue())
-        if(method != RpcMethod.POST) {
+        if(requestBuilder.method != RpcMethod.POST) {
             putAll(encodedParameters.jsonObject.mapValues { it.value.toString() })
         }
     }
     val rpcRequest = RpcRequest(
-        method = method.httpMethod,
+        method = requestBuilder.method.httpMethod,
         count = requestBuilder.count,
         urlParams = urlParams,
-        body = encodedParameters
+        body = encodedParameters,
+        schema = requestBuilder.schema
     )
     return RestRequestExecutor.execute(postgrest = this, path = "rpc/$function", request = rpcRequest)
 }
@@ -65,20 +66,19 @@ suspend inline fun <reified T : Any> Postgrest.rpc(
  * Executes a database function
  *
  * @param function The name of the function
- * @param method The HTTP method to use. Default is POST
  * @param request Filter the result
  * @throws RestException or one of its subclasses if the request failed
  */
 suspend inline fun Postgrest.rpc(
     function: String,
-    method: RpcMethod = RpcMethod.POST,
-    request: PostgrestRequestBuilder.() -> Unit = {}
+    request: RpcPostgrestRequestBuilder.() -> Unit = {}
 ): PostgrestResult {
-    val requestBuilder = PostgrestRequestBuilder(config.propertyConversionMethod).apply(request)
+    val requestBuilder = RpcPostgrestRequestBuilder(config.defaultSchema, config.propertyConversionMethod).apply(request)
     val rpcRequest = RpcRequest(
-        method = method.httpMethod,
+        method = requestBuilder.method.httpMethod,
         count = requestBuilder.count,
-        urlParams = requestBuilder.params.mapToFirstValue()
+        urlParams = requestBuilder.params.mapToFirstValue(),
+        schema = requestBuilder.schema
     )
     return RestRequestExecutor.execute(postgrest = this, path = "rpc/$function", request = rpcRequest)
 }

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/PostgrestRpc.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/PostgrestRpc.kt
@@ -42,7 +42,7 @@ enum class RpcMethod(val httpMethod: HttpMethod) {
 suspend inline fun <reified T : Any> Postgrest.rpc(
     function: String,
     parameters: T,
-    request: PostgrestRequestBuilder.() -> Unit = {},
+    request: RpcPostgrestRequestBuilder.() -> Unit = {},
 ): PostgrestResult {
     val encodedParameters = if (parameters is JsonElement) parameters else serializer.encodeToJsonElement(parameters)
     val requestBuilder = RpcPostgrestRequestBuilder(config.defaultSchema, config.propertyConversionMethod).apply(request)

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/PostgrestRpc.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/PostgrestRpc.kt
@@ -57,7 +57,8 @@ suspend inline fun <reified T : Any> Postgrest.rpc(
         count = requestBuilder.count,
         urlParams = urlParams,
         body = encodedParameters,
-        schema = requestBuilder.schema
+        schema = requestBuilder.schema,
+        headers = requestBuilder.headers.build()
     )
     return RestRequestExecutor.execute(postgrest = this, path = "rpc/$function", request = rpcRequest)
 }
@@ -78,7 +79,8 @@ suspend inline fun Postgrest.rpc(
         method = requestBuilder.method.httpMethod,
         count = requestBuilder.count,
         urlParams = requestBuilder.params.mapToFirstValue(),
-        schema = requestBuilder.schema
+        schema = requestBuilder.schema,
+        headers = requestBuilder.headers.build()
     )
     return RestRequestExecutor.execute(postgrest = this, path = "rpc/$function", request = rpcRequest)
 }

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/PostgrestRequestBuilder.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/PostgrestRequestBuilder.kt
@@ -15,7 +15,7 @@ import kotlin.js.JsName
  * A builder for Postgrest requests.
  */
 @PostgrestFilterDSL
-class PostgrestRequestBuilder(@PublishedApi internal val propertyConversionMethod: PropertyConversionMethod) {
+open class PostgrestRequestBuilder(@PublishedApi internal val propertyConversionMethod: PropertyConversionMethod) {
 
     /**
      * The [Count] algorithm to use to count rows in the table or view.
@@ -162,12 +162,4 @@ class PostgrestRequestBuilder(@PublishedApi internal val propertyConversionMetho
     }
 
 }
-
-@SupabaseInternal
-inline fun postgrestRequest(propertyConversionMethod: PropertyConversionMethod = PropertyConversionMethod.CAMEL_CASE_TO_SNAKE_CASE, block: PostgrestRequestBuilder.() -> Unit): PostgrestRequestBuilder {
-    val filter = PostgrestRequestBuilder(propertyConversionMethod)
-    filter.block()
-    return filter
-}
-
 

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/request/InsertPostgrestRequestBuilder.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/request/InsertPostgrestRequestBuilder.kt
@@ -1,0 +1,19 @@
+package io.github.jan.supabase.postgrest.query.request
+
+import io.github.jan.supabase.postgrest.PropertyConversionMethod
+import io.github.jan.supabase.postgrest.query.PostgrestQueryBuilder
+import io.github.jan.supabase.postgrest.query.PostgrestRequestBuilder
+
+/**
+ * Request builder for [PostgrestQueryBuilder.insert]
+ */
+open class InsertPostgrestRequestBuilder(propertyConversionMethod: PropertyConversionMethod): PostgrestRequestBuilder(propertyConversionMethod) {
+
+    /**
+     * Make missing fields default to `null`.
+     * Otherwise, use the default value for the column. This only applies when
+     * inserting new rows, not when merging with existing rows under
+     */
+    var defaultToNull: Boolean = true
+
+}

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/request/RpcPostgrestRequestBuilder.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/request/RpcPostgrestRequestBuilder.kt
@@ -1,0 +1,24 @@
+package io.github.jan.supabase.postgrest.query.request
+
+import io.github.jan.supabase.postgrest.Postgrest
+import io.github.jan.supabase.postgrest.PropertyConversionMethod
+import io.github.jan.supabase.postgrest.RpcMethod
+import io.github.jan.supabase.postgrest.query.PostgrestRequestBuilder
+import io.github.jan.supabase.postgrest.rpc
+
+/**
+ * Request builder for [Postgrest.rpc]
+ */
+class RpcPostgrestRequestBuilder(defaultSchema: String, propertyConversionMethod: PropertyConversionMethod): PostgrestRequestBuilder(propertyConversionMethod) {
+
+    /**
+     * The HTTP method to use. Default is POST
+     */
+    var method: RpcMethod = RpcMethod.POST
+
+    /**
+     * The database schema
+     */
+    var schema: String = defaultSchema
+
+}

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/request/SelectPostgrestRequestBuilder.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/request/SelectPostgrestRequestBuilder.kt
@@ -1,0 +1,17 @@
+package io.github.jan.supabase.postgrest.query.request
+
+import io.github.jan.supabase.postgrest.PropertyConversionMethod
+import io.github.jan.supabase.postgrest.query.PostgrestQueryBuilder
+import io.github.jan.supabase.postgrest.query.PostgrestRequestBuilder
+
+/**
+ * Request builder for [PostgrestQueryBuilder.select]
+ */
+class SelectPostgrestRequestBuilder(propertyConversionMethod: PropertyConversionMethod): PostgrestRequestBuilder(propertyConversionMethod) {
+
+    /**
+     * If true, no body will be returned. Useful when using count.
+     */
+    var head: Boolean = false
+
+}

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/request/UpsertPostgrestRequestBuilder.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/request/UpsertPostgrestRequestBuilder.kt
@@ -1,0 +1,24 @@
+package io.github.jan.supabase.postgrest.query.request
+
+import io.github.jan.supabase.postgrest.PropertyConversionMethod
+import io.github.jan.supabase.postgrest.query.PostgrestQueryBuilder
+import io.github.jan.supabase.postgrest.query.PostgrestRequestBuilder
+
+/**
+ * Request builder for [PostgrestQueryBuilder.upsert]
+ */
+class UpsertPostgrestRequestBuilder(propertyConversionMethod: PropertyConversionMethod): InsertPostgrestRequestBuilder(propertyConversionMethod) {
+
+    /**
+     * Comma-separated UNIQUE column(s) to specify how
+     * duplicate rows are determined. Two rows are duplicates if all the
+     * `onConflict` columns are equal.
+     */
+    var onConflict: String? = null
+
+    /**
+     * If `true`, duplicate rows are ignored. If `false`, duplicate rows are merged with existing rows.
+     */
+    var ignoreDuplicates: Boolean = false
+
+}

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/request/RpcRequest.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/request/RpcRequest.kt
@@ -10,9 +10,9 @@ internal class RpcRequest(
     val count: Count? = null,
     override val urlParams: Map<String, String>,
     override val body: JsonElement? = null,
+    override val schema: String = "public"
 ) : PostgrestRequest {
 
-    override val schema: String = ""
     override val prefer = if (count != null) listOf("count=${count.identifier}") else listOf()
 
 }

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/request/RpcRequest.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/request/RpcRequest.kt
@@ -12,7 +12,7 @@ internal class RpcRequest(
     override val urlParams: Map<String, String>,
     override val body: JsonElement? = null,
     override val schema: String = "public",
-    override val headers: Headers
+    override val headers: Headers = Headers.Empty
 ) : PostgrestRequest {
 
     override val prefer = if (count != null) listOf("count=${count.identifier}") else listOf()

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/request/RpcRequest.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/request/RpcRequest.kt
@@ -1,7 +1,7 @@
 package io.github.jan.supabase.postgrest.request
 
 import io.github.jan.supabase.postgrest.query.Count
-import io.ktor.http.HttpMethod
+import io.ktor.http.*
 import kotlinx.serialization.json.JsonElement
 
 @PublishedApi
@@ -10,7 +10,8 @@ internal class RpcRequest(
     val count: Count? = null,
     override val urlParams: Map<String, String>,
     override val body: JsonElement? = null,
-    override val schema: String = "public"
+    override val schema: String = "public",
+    override val headers: Headers
 ) : PostgrestRequest {
 
     override val prefer = if (count != null) listOf("count=${count.identifier}") else listOf()

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/request/RpcRequest.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/request/RpcRequest.kt
@@ -1,7 +1,8 @@
 package io.github.jan.supabase.postgrest.request
 
 import io.github.jan.supabase.postgrest.query.Count
-import io.ktor.http.*
+import io.ktor.http.Headers
+import io.ktor.http.HttpMethod
 import kotlinx.serialization.json.JsonElement
 
 @PublishedApi

--- a/Postgrest/src/commonTest/kotlin/PostgrestRequestBuilderTest.kt
+++ b/Postgrest/src/commonTest/kotlin/PostgrestRequestBuilderTest.kt
@@ -1,7 +1,8 @@
 import io.github.jan.supabase.postgrest.query.Count
 import io.github.jan.supabase.postgrest.query.Order
 import io.github.jan.supabase.postgrest.query.Returning
-import io.ktor.http.*
+import io.github.jan.supabase.postgrest.query.postgrestRequest
+import io.ktor.http.HttpHeaders
 import kotlin.test.Test
 import kotlin.test.assertEquals
 

--- a/Postgrest/src/commonTest/kotlin/PostgrestRequestBuilderTest.kt
+++ b/Postgrest/src/commonTest/kotlin/PostgrestRequestBuilderTest.kt
@@ -1,8 +1,7 @@
 import io.github.jan.supabase.postgrest.query.Count
 import io.github.jan.supabase.postgrest.query.Order
 import io.github.jan.supabase.postgrest.query.Returning
-import io.github.jan.supabase.postgrest.query.postgrestRequest
-import io.ktor.http.HttpHeaders
+import io.ktor.http.*
 import kotlin.test.Test
 import kotlin.test.assertEquals
 

--- a/Postgrest/src/commonTest/kotlin/PostgrestRequestBuilderTest.kt
+++ b/Postgrest/src/commonTest/kotlin/PostgrestRequestBuilderTest.kt
@@ -1,7 +1,6 @@
 import io.github.jan.supabase.postgrest.query.Count
 import io.github.jan.supabase.postgrest.query.Order
 import io.github.jan.supabase.postgrest.query.Returning
-import io.github.jan.supabase.postgrest.query.postgrestRequest
 import io.ktor.http.HttpHeaders
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/Postgrest/src/commonTest/kotlin/Utils.kt
+++ b/Postgrest/src/commonTest/kotlin/Utils.kt
@@ -1,0 +1,10 @@
+import io.github.jan.supabase.annotations.SupabaseInternal
+import io.github.jan.supabase.postgrest.PropertyConversionMethod
+import io.github.jan.supabase.postgrest.query.PostgrestRequestBuilder
+
+@SupabaseInternal
+inline fun postgrestRequest(propertyConversionMethod: PropertyConversionMethod = PropertyConversionMethod.CAMEL_CASE_TO_SNAKE_CASE, block: PostgrestRequestBuilder.() -> Unit): PostgrestRequestBuilder {
+    val filter = PostgrestRequestBuilder(propertyConversionMethod)
+    filter.block()
+    return filter
+}

--- a/Postgrest/src/commonTest/kotlin/io.github.jan.supabase.postgrest/request/RpcRequestTest.kt
+++ b/Postgrest/src/commonTest/kotlin/io.github.jan.supabase.postgrest/request/RpcRequestTest.kt
@@ -19,6 +19,7 @@ class RpcRequestTest {
             count = Count.EXACT,
             body = JsonArray(listOf()),
             urlParams = mapOf("Key1" to "Value1"),
+            schema = "mySchema"
         )
 
         val count = (sut as RpcRequest).count
@@ -31,7 +32,7 @@ class RpcRequestTest {
                 "count=exact"
             ), sut.prefer
         )
-        assertEquals("", sut.schema)
+        assertEquals("mySchema", sut.schema)
         assertEquals(mapOf("Key1" to "Value1"), sut.urlParams)
         assertEquals(JsonArray(listOf()), sut.body)
     }
@@ -43,6 +44,7 @@ class RpcRequestTest {
             count = Count.EXACT,
             body = JsonArray(listOf()),
             urlParams = mapOf("Key1" to "Value1"),
+            schema = "mySchema"
         )
         val count = (sut as RpcRequest).count
         assertNotNull(count)
@@ -53,7 +55,7 @@ class RpcRequestTest {
                 "count=exact"
             ), sut.prefer
         )
-        assertEquals("", sut.schema)
+        assertEquals("mySchema", sut.schema)
         assertEquals(mapOf("Key1" to "Value1"), sut.urlParams)
         assertEquals(JsonArray(listOf()), sut.body)
     }
@@ -65,6 +67,7 @@ class RpcRequestTest {
             count = null,
             body = JsonArray(listOf()),
             urlParams = mapOf("Key1" to "Value1"),
+            schema = "mySchema"
         )
 
         val count = (sut as RpcRequest).count
@@ -74,7 +77,7 @@ class RpcRequestTest {
             listOf(
             ), sut.prefer
         )
-        assertEquals("", sut.schema)
+        assertEquals("mySchema", sut.schema)
         assertEquals(mapOf("Key1" to "Value1"), sut.urlParams)
         assertEquals(JsonArray(listOf()), sut.body)
     }
@@ -86,6 +89,7 @@ class RpcRequestTest {
             count = null,
             body = null,
             urlParams = mapOf("Key1" to "Value1"),
+            schema = "mySchema"
         )
 
         assertEquals("HEAD", sut.method.value)
@@ -93,7 +97,7 @@ class RpcRequestTest {
             listOf(
             ), sut.prefer
         )
-        assertEquals("", sut.schema)
+        assertEquals("mySchema", sut.schema)
         assertEquals(mapOf("Key1" to "Value1"), sut.urlParams)
         assertNull(sut.body)
     }
@@ -104,6 +108,7 @@ class RpcRequestTest {
             count = null,
             body = JsonArray(listOf()),
             urlParams = mapOf("Key1" to "Value1"),
+            schema = "mySchema"
         )
 
         assertEquals("POST", sut.method.value)
@@ -111,7 +116,7 @@ class RpcRequestTest {
             listOf(
             ), sut.prefer
         )
-        assertEquals("", sut.schema)
+        assertEquals("mySchema", sut.schema)
         assertEquals(mapOf("Key1" to "Value1"), sut.urlParams)
         assertEquals(JsonArray(listOf()), sut.body)
     }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature (closes #713)

## What is the current behavior?

Optional properties like `defaultToNull` for inserting or `head` for selecting are a function parameter. In increasing numbers, these function parameters get too clunky and as there are already some parameters in the DSL builder (`PostgrestRequestBuilder`), moving these properties would fit more.

## What is the new behavior?

The Select, Insert and Upsert methods now have their own DSL inheriting from the base builder and adding these "old" function parameters. The syntax now looks like this:
```kotlin
supabase.from("table").select {
    head = true
}
supabase.from("table").upsert(myValue) {
    defaultToNull = false
    ignoreDuplicates = false
}
supabase.postgrest.rpc("function") {
    method = RpcMethod.GET
    schema = "mySchema"
}
```

## Additional context

Add any other context or screenshots.
