### PR TITLE
Fix postgrest request failing without body

### DIFF
--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/PostgrestQueryBuilder.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/PostgrestQueryBuilder.kt
@@ -78,7 +78,7 @@ class PostgrestQueryBuilder(
         val requestBuilder = UpsertRequestBuilder(postgrest.config.propertyConversionMethod).apply(request)
         val body = postgrest.serializer.encodeToJsonElement(values).jsonArray
         val columns = body.map { it.jsonObject.keys }.flatten().distinct()
-        requestBuilder.params["columns"] = listOf(columns.joinToString(","))
+        if(columns.isNotEmpty()) requestBuilder.params["columns"] = listOf(columns.joinToString(","))
         requestBuilder.onConflict?.let {
             requestBuilder.params["on_conflict"] = listOf(it)
         }
@@ -132,7 +132,7 @@ class PostgrestQueryBuilder(
         val requestBuilder = InsertRequestBuilder(postgrest.config.propertyConversionMethod).apply(request)
         val body = postgrest.serializer.encodeToJsonElement(values).jsonArray
         val columns = body.map { it.jsonObject.keys }.flatten().distinct()
-        requestBuilder.params["columns"] = listOf(columns.joinToString(","))
+        if(columns.isNotEmpty()) requestBuilder.params["columns"] = listOf(columns.joinToString(","))
         val insertRequest = InsertRequest(
             body = body,
             returning = requestBuilder.returning,

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,5 +10,5 @@ org.jetbrains.compose.experimental.uikit.enabled=true
 org.jetbrains.compose.experimental.jscanvas.enabled=true
 org.jetbrains.compose.experimental.wasm.enabled=true
 
-supabase-version = 3.0.0-dev-1
+supabase-version = 3.0.0-rc-1
 base-group = io.github.jan-tennert.supabase

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,5 +10,5 @@ org.jetbrains.compose.experimental.uikit.enabled=true
 org.jetbrains.compose.experimental.jscanvas.enabled=true
 org.jetbrains.compose.experimental.wasm.enabled=true
 
-supabase-version = 3.0.0-rc-1
+supabase-version = 3.0.0-dev-1
 base-group = io.github.jan-tennert.supabase


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Putting in an empty JsonObject into `insert` or `upsert` results in a rest exception, because an empty `columns` query parameter is getting added.

## What is the new behavior?

This has been fixed.