### PR TITLE
Introduce new experimental DSL for Postgrest Columns

### DIFF
--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/Columns.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/Columns.kt
@@ -1,5 +1,6 @@
 package io.github.jan.supabase.postgrest.query
 
+import io.github.jan.supabase.annotations.SupabaseExperimental
 import io.github.jan.supabase.postgrest.classPropertyNames
 import kotlin.jvm.JvmInline
 
@@ -16,6 +17,14 @@ value class Columns @PublishedApi internal constructor(val value: String) {
          * Select all columns
          */
         val ALL = Columns("*")
+
+        /**
+         * TODO
+         */
+        @SupabaseExperimental
+        inline operator fun invoke(builder: BasicColumnsBuilder.() -> Unit): Columns {
+            return Columns(BasicColumnsBuilder().apply(builder).build())
+        }
 
         /**
          * Select all columns given in the [value] parameter
@@ -40,21 +49,6 @@ value class Columns @PublishedApi internal constructor(val value: String) {
          * @param T The type of the columns to select
          */
         inline fun <reified T> type() = list(classPropertyNames<T>())
-
-        private fun String.clean(): String {
-            var quoted = false
-            val regex = Regex("\\s")
-            return this.map {
-                if (it == '"') {
-                    quoted = !quoted
-                }
-                if (regex.matches(it.toString()) && !quoted) {
-                    ""
-                } else {
-                    it
-                }
-            }.joinToString("")
-        }
 
     }
 

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/ColumnsBuilder.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/ColumnsBuilder.kt
@@ -1,0 +1,67 @@
+package io.github.jan.supabase.postgrest.query
+
+open class BasicColumnsBuilder {
+
+    internal val columns: MutableList<String> = mutableListOf<String>()
+
+    fun named(vararg columns: String) {
+        this.columns.addAll(columns)
+    }
+
+    fun all() {
+        columns.add("*")
+    }
+
+    fun json(column: String, key: String, returnAsText: Boolean = false) {
+        val operator = if(returnAsText) "->>" else "->"
+        columns.add("$column$operator$key")
+    }
+
+    fun foreign(name: String, columnsBuilder: ForeignColumnsBuilder.() -> Unit = {}) {
+        val foreignColumns = ForeignColumnsBuilder().apply(columnsBuilder)
+        val spread = if(foreignColumns.spread) "..." else ""
+        val key = if(foreignColumns.key != null) "!${foreignColumns.key}" else ""
+        columns.add("$spread$name$key(${foreignColumns.build()})")
+    }
+
+    infix fun String.withAlias(alias: String) = "$alias:$this"
+
+    infix fun String.withFunction(name: String) = "$this.$name"
+
+    infix fun String.withType(type: String) = "$this::$type"
+
+    fun avg() = "avg()"
+
+    fun count() = "count()"
+
+    fun max() = "max()"
+
+    fun min() = "min()"
+
+    fun sum() = "sum()"
+
+    fun build() = columns.joinToString(",").also(::println)
+
+}
+
+class ForeignColumnsBuilder(): BasicColumnsBuilder() {
+
+    var spread = false
+    var key: String? = null
+
+}
+
+internal fun String.clean(): String {
+    var quoted = false
+    val regex = Regex("\\s")
+    return this.map {
+        if (it == '"') {
+            quoted = !quoted
+        }
+        if (regex.matches(it.toString()) && !quoted) {
+            ""
+        } else {
+            it
+        }
+    }.joinToString("")
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature.

## What is the new behavior?

Introduces a new type-safe DSL for specifying columns when making a postgrest request. Example:
```kotlin
supabase.from("movies
    //Basic columns
    named("name", "id
    
    //Foreign columns
    foreign("actors")
        named("name")
    }
    foreign("studios"
        named("name")
    }
    //Or spread withi
    foreign("studios"
        spread = true
        named("name" 
    }
    
    //JSON columns (T
})
```
