### PR TITLE
Introduce KSP compiler for generating columns via `@Selectable` annotation

### DIFF
--- a/KSP/README.md
+++ b/KSP/README.md
@@ -1,0 +1,43 @@
+# Supabase KSP compiler
+
+Currently only supports generating columns for `@Selectable` types.
+
+To install it, add the KSP Gradle plugin to your project:
+
+```kotlin
+plugins {
+    id("com.google.devtools.ksp") version "2.0.21-1.0.25" //kotlinVersion-kspVersion
+}
+```
+
+Then add the Supabase KSP compiler to your dependencies:
+
+> [!NOTE]
+> `VERSION` is the same as the Supabase-kt version.
+
+**JVM**:
+
+```kotlin
+depdencies {
+    ksp("io.github.jan-tennert.supabase:ksp-compiler:VERSION")
+}
+```
+
+**Multiplatform**:
+
+```kotlin
+kotlin {
+    //...
+    jvm()
+    androidTarget()
+    iosX64()
+    //...
+}
+
+dependencies {
+    //Advised to use Gradle Version Catalogs
+    add("kspCommonMainMetadata", "io.github.jan-tennert.supabase:ksp-compiler:VERSION")
+    add("kspJvm", "io.github.jan-tennert.supabase:ksp-compiler:VERSION")
+    add("kspAndroid", "io.github.jan-tennert.supabase:ksp-compiler:VERSION")
+    add("kspIosX64", "io.github.jan-tennert.supabase:ksp-compiler:VERSION")
+}

--- a/KSP/README.md
+++ b/KSP/README.md
@@ -1,6 +1,6 @@
 # Supabase KSP compiler
 
-Currently only supports generating columns for `@Selectable` types.
+Currently only supports generating columns for `@Selectable` data classes.
 
 To install it, add the KSP Gradle plugin to your project:
 

--- a/KSP/build.gradle.kts
+++ b/KSP/build.gradle.kts
@@ -17,4 +17,5 @@ dependencies {
 
 tasks.named<KotlinCompilationTask<*>>("compileKotlin").configure {
     compilerOptions.freeCompilerArgs.add("-opt-in=io.github.jan.supabase.annotations.SupabaseInternal")
+    compilerOptions.freeCompilerArgs.add("-opt-in=io.github.jan.supabase.annotations.SupabaseExperimental")
 }

--- a/KSP/build.gradle.kts
+++ b/KSP/build.gradle.kts
@@ -1,0 +1,14 @@
+plugins {
+    id(libs.plugins.kotlin.jvm.get().pluginId)
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation(libs.ksp)
+    implementation(libs.kotlin.poet)
+    implementation(libs.kotlin.poet.ksp)
+    implementation(project(":postgrest-kt"))
+}

--- a/KSP/build.gradle.kts
+++ b/KSP/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
+
 plugins {
     id(libs.plugins.kotlin.jvm.get().pluginId)
 }
@@ -11,4 +13,8 @@ dependencies {
     implementation(libs.kotlin.poet)
     implementation(libs.kotlin.poet.ksp)
     implementation(project(":postgrest-kt"))
+}
+
+tasks.named<KotlinCompilationTask<*>>("compileKotlin").configure {
+    compilerOptions.freeCompilerArgs.add("-opt-in=io.github.jan.supabase.annotations.SupabaseInternal")
 }

--- a/KSP/src/main/kotlin/io/github/jan/supabase/ksp/ColumnOptions.kt
+++ b/KSP/src/main/kotlin/io/github/jan/supabase/ksp/ColumnOptions.kt
@@ -1,0 +1,12 @@
+package io.github.jan.supabase.ksp
+
+data class ColumnOptions(
+    val alias: String,
+    val columnName: String,
+    val isForeign: Boolean,
+    val jsonPath: List<String>?,
+    val returnAsText: Boolean,
+    val function: String?,
+    val cast: String?,
+    val innerColumns: String,
+)

--- a/KSP/src/main/kotlin/io/github/jan/supabase/ksp/ColumnOptions.kt
+++ b/KSP/src/main/kotlin/io/github/jan/supabase/ksp/ColumnOptions.kt
@@ -9,5 +9,4 @@ data class ColumnOptions(
     val function: String?,
     val cast: String?,
     val innerColumns: String,
-    val jsonKey: String?
 )

--- a/KSP/src/main/kotlin/io/github/jan/supabase/ksp/ColumnOptions.kt
+++ b/KSP/src/main/kotlin/io/github/jan/supabase/ksp/ColumnOptions.kt
@@ -2,11 +2,12 @@ package io.github.jan.supabase.ksp
 
 data class ColumnOptions(
     val alias: String,
-    val columnName: String,
+    val columnName: String?,
     val isForeign: Boolean,
     val jsonPath: List<String>?,
     val returnAsText: Boolean,
     val function: String?,
     val cast: String?,
     val innerColumns: String,
+    val jsonKey: String?
 )

--- a/KSP/src/main/kotlin/io/github/jan/supabase/ksp/PrimitiveColumnType.kt
+++ b/KSP/src/main/kotlin/io/github/jan/supabase/ksp/PrimitiveColumnType.kt
@@ -1,0 +1,16 @@
+package io.github.jan.supabase.ksp
+
+val primitiveColumnTypes = mapOf<String, String>(
+    "kotlin.String" to "text",
+    "kotlin.Int" to "int",
+    "kotlin.Long" to "int8",
+    "kotlin.Float" to "float4",
+    "kotlin.Double" to "float8",
+    "kotlin.Boolean" to "bool",
+    "kotlin.Byte" to "int2",
+    "kotlin.Short" to "int2",
+    "kotlin.Char" to "char",
+    //TIMESTAMPS etc.
+)
+
+fun isPrimitive(qualifiedName: String) = primitiveColumnTypes.containsKey(qualifiedName)

--- a/KSP/src/main/kotlin/io/github/jan/supabase/ksp/PrimitiveColumnType.kt
+++ b/KSP/src/main/kotlin/io/github/jan/supabase/ksp/PrimitiveColumnType.kt
@@ -2,7 +2,7 @@ package io.github.jan.supabase.ksp
 
 val primitiveColumnTypes = mapOf<String, String>(
     "kotlin.String" to "text",
-    "kotlin.Int" to "int",
+    "kotlin.Int" to "int4",
     "kotlin.Long" to "int8",
     "kotlin.Float" to "float4",
     "kotlin.Double" to "float8",
@@ -10,7 +10,15 @@ val primitiveColumnTypes = mapOf<String, String>(
     "kotlin.Byte" to "int2",
     "kotlin.Short" to "int2",
     "kotlin.Char" to "char",
-    //TIMESTAMPS etc.
+    "kotlinx.datetime.Instant" to "timestamptz",
+    "kotlinx.datetime.LocalDateTime" to "timestamp",
+    "kotlin.uuid.Uuid" to "uuid",
+    "kotlinx.datetime.LocalTime" to "time",
+    "kotlinx.datetime.LocalDate" to "date",
+    "kotlinx.serialization.json.JsonElement" to "jsonb",
+    "kotlinx.serialization.json.JsonObject" to "jsonb",
+    "kotlinx.serialization.json.JsonArray" to "jsonb",
+    "kotlinx.serialization.json.JsonPrimitive" to "jsonb",
 )
 
 fun isPrimitive(qualifiedName: String) = primitiveColumnTypes.containsKey(qualifiedName)

--- a/KSP/src/main/kotlin/io/github/jan/supabase/ksp/SelectableSymbolProcessor.kt
+++ b/KSP/src/main/kotlin/io/github/jan/supabase/ksp/SelectableSymbolProcessor.kt
@@ -1,0 +1,196 @@
+package io.github.jan.supabase.ksp
+
+import com.google.devtools.ksp.processing.CodeGenerator
+import com.google.devtools.ksp.processing.Dependencies
+import com.google.devtools.ksp.processing.KSPLogger
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.processing.SymbolProcessor
+import com.google.devtools.ksp.symbol.KSAnnotated
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSValueParameter
+import com.squareup.kotlinpoet.FileSpec
+import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.PropertySpec
+import com.squareup.kotlinpoet.ksp.toClassName
+import io.github.jan.supabase.postgrest.annotations.ApplyFunction
+import io.github.jan.supabase.postgrest.annotations.Cast
+import io.github.jan.supabase.postgrest.annotations.ColumnName
+import io.github.jan.supabase.postgrest.annotations.Foreign
+import io.github.jan.supabase.postgrest.annotations.JsonPath
+import io.github.jan.supabase.postgrest.annotations.Selectable
+import io.github.jan.supabase.postgrest.query.Columns
+
+class SelectableSymbolProcessor(
+    private val codeGenerator: CodeGenerator,
+    private val logger: KSPLogger,
+    private val options: Map<String, String>
+) : SymbolProcessor {
+    override fun process(resolver: Resolver): List<KSAnnotated> {
+        val symbols = resolver.getSymbolsWithAnnotation(Selectable::class.java.name).filterIsInstance<KSClassDeclaration>()
+        if (!symbols.iterator().hasNext()) return emptyList()
+        symbols.forEach { symbol ->
+            val className = symbol.simpleName.asString()
+            val packageName = symbol.containingFile?.packageName?.asString().orEmpty()
+            if (!symbol.modifiers.containsIgnoreCase("data")) {
+                logger.error("This object is not a data class", symbol)
+                return emptyList()
+            }
+            val companionObject = symbol.anyCompanionObject()
+            if(companionObject == null) {
+                logger.error("Companion object not found", symbol)
+                return emptyList()
+            }
+            val parameters = symbol.primaryConstructor?.parameters
+            if(parameters == null) {
+                logger.error("Primary constructor is null or has no parameter", symbol)
+                return emptyList()
+            }
+            val columns = parameters.map { processParameters(it, resolver) }.joinToString(",")
+            writeColumnsExtensionProperty(symbol, companionObject, columns, "${className}Columns", packageName)
+        }
+        return emptyList()
+    }
+
+    private fun writeColumnsExtensionProperty(
+        symbol: KSClassDeclaration,
+        companionObject: KSClassDeclaration,
+        columns: String,
+        className: String,
+        packageName: String
+    ) {
+        val fileSpec = FileSpec.builder(packageName, className)
+            .addImport("io.github.jan.supabase.postgrest.query", "Columns")
+            .addProperty(PropertySpec.builder("columns", Columns::class)
+                .receiver(companionObject.toClassName())
+                .getter(FunSpec.getterBuilder().addStatement("return Columns.raw(\"$columns\")").build())
+                .build()
+            )
+            .build()
+        codeGenerator.createNewFile(
+            Dependencies(false, symbol.containingFile!!),
+            packageName,
+            className,
+            extensionName = "kt"
+        ).bufferedWriter().use {
+            fileSpec.writeTo(it)
+        }
+    }
+
+    private fun processParameters(parameter: KSValueParameter, resolver: Resolver): String {
+        val parameterClass = resolver.getClassDeclarationByName(parameter.type.resolve().declaration.qualifiedName!!)
+        val innerColumns = if(!isPrimitive(parameterClass!!.qualifiedName!!.asString())) {
+            val annotation = parameterClass.annotations.getAnnotationOrNull(Selectable::class.java.simpleName)
+            if(annotation == null) {
+                logger.error("Type of parameter ${parameter.name!!.getShortName()} is not a primitive type and does not have @Selectable annotation", parameter)
+                return ""
+            } else {
+                val columns = parameterClass.primaryConstructor?.parameters
+                if(columns == null) {
+                    logger.error("Primary constructor of ${parameterClass.qualifiedName} is null or has no parameter", parameter)
+                    return ""
+                }
+                columns.map { processParameters(it, resolver) }.joinToString(",")
+            }
+        } else ""
+        val alias = parameter.name!!.getShortName()
+        val columnName = parameter.annotations.getAnnotationOrNull(ColumnName::class.java.simpleName)
+            ?.arguments?.getParameterValue<String>(ColumnName.NAME_PARAMETER_NAME) ?: alias
+        val isForeign = parameter.annotations.getAnnotationOrNull(Foreign::class.java.simpleName) != null
+        val jsonPathArguments = parameter.annotations.getAnnotationOrNull(JsonPath::class.java.simpleName)?.arguments
+        val jsonPath = jsonPathArguments?.getParameterValue<ArrayList<String>>(JsonPath.PATH_PARAMETER_NAME)
+        val returnAsText = jsonPathArguments?.getParameterValue<Boolean>(JsonPath.RETURN_AS_TEXT_PARAMETER_NAME) == true
+        val function = parameter.annotations.getAnnotationOrNull(ApplyFunction::class.java.simpleName)
+            ?.arguments?.getParameterValue<String>(ApplyFunction.FUNCTION_PARAMETER_NAME)
+        val cast = parameter.annotations.getAnnotationOrNull(Cast::class.java.simpleName)
+            ?.arguments?.getParameterValue<String>(Cast.TYPE_PARAMETER_NAME)
+        checkValidCombinations(
+            parameterName = parameter.name!!.asString(),
+            isForeign = isForeign,
+            jsonPath = jsonPath,
+            function = function
+        )
+        return buildColumns(
+            alias = alias,
+            columnName = columnName,
+            isForeign = isForeign,
+            jsonPath = jsonPath,
+            returnAsText = returnAsText,
+            function = function,
+            cast = cast,
+            innerColumns = innerColumns,
+            parameterName = parameter.name!!.asString(),
+            qualifiedTypeName = parameterClass.qualifiedName!!.asString()
+        )
+    }
+
+    private fun checkValidCombinations(
+        parameterName: String,
+        isForeign: Boolean,
+        jsonPath: List<String>?,
+        function: String?
+    ) {
+        require(!isForeign || jsonPath == null) {
+            "Parameter $parameterName can't have both @Foreign and @JsonPath annotation"
+        }
+        require(!isForeign  || function == null) {
+            "Parameter $parameterName can't have both @Foreign and @ApplyFunction annotation"
+        }
+        require(jsonPath == null || function == null) {
+            "Parameter $parameterName can't have both @JsonPath and @ApplyFunction annotation"
+        }
+    }
+
+    private fun buildColumns(
+        alias: String,
+        columnName: String,
+        isForeign: Boolean,
+        jsonPath: List<String>?,
+        returnAsText: Boolean,
+        function: String?,
+        cast: String?,
+        innerColumns: String,
+        parameterName: String,
+        qualifiedTypeName: String
+    ): String {
+        return buildString {
+            if(jsonPath != null) {
+                append(buildJsonPath(jsonPath, returnAsText))
+                return@buildString
+            }
+
+            //If the alias is the same as the column name, we can just assume parameter name (alias) is the column name
+            if(alias == columnName) {
+                append(alias)
+            } else {
+                append("$alias:$columnName")
+            }
+            if(isForeign) {
+                append("($innerColumns)")
+                return@buildString
+            }
+
+            //If a custom cast is provided, use it
+            if(cast != null && cast.isNotEmpty()) {
+                append("::$cast")
+            } else if(cast != null) { //If cast is empty, try to auto-cast
+                val autoCast = primitiveColumnTypes[qualifiedTypeName]
+                if(autoCast != null) {
+                    append("::$autoCast")
+                } else {
+                    logger.error("Type of parameter $parameterName is not a primitive type and does not have an automatic cast type")
+                }
+            }
+            if(function != null) {
+                append(".$function()")
+            }
+        }
+    }
+
+    private fun buildJsonPath(jsonPath: List<String>, returnAsText: Boolean): String {
+        val operator = if(returnAsText) "->>" else "->"
+        val formattedPath = if(jsonPath.size > 1) jsonPath.dropLast(1).joinToString("->") else ""
+        val key = jsonPath.last()
+        return "$formattedPath$operator$key"
+    }
+
+}

--- a/KSP/src/main/kotlin/io/github/jan/supabase/ksp/SelectableSymbolProcessor.kt
+++ b/KSP/src/main/kotlin/io/github/jan/supabase/ksp/SelectableSymbolProcessor.kt
@@ -11,8 +11,11 @@ import com.google.devtools.ksp.symbol.KSFile
 import com.google.devtools.ksp.symbol.KSNode
 import com.google.devtools.ksp.symbol.KSValueParameter
 import com.google.devtools.ksp.symbol.Modifier
+import com.squareup.kotlinpoet.AnnotationSpec
+import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.FunSpec
+import io.github.jan.supabase.annotations.SupabaseInternal
 import io.github.jan.supabase.postgrest.Postgrest
 import io.github.jan.supabase.postgrest.annotations.ApplyFunction
 import io.github.jan.supabase.postgrest.annotations.Cast
@@ -61,9 +64,10 @@ class SelectableSymbolProcessor(
         columns: Map<String, String>,
         sources: List<KSFile>
     ) {
-        //Maybe add comments and SupabaseInternal annotations
         val function = FunSpec.builder("addSelectableTypes")
             .addKdoc(COMMENT)
+            .addAnnotation(AnnotationSpec.builder(ClassName.bestGuess("kotlin.OptIn")).addMember("%T::class",
+                SupabaseInternal::class).build())
             .receiver(Postgrest.Config::class)
         columns.forEach { (qualifiedName, columns) ->
             function.addStatement("columnRegistry.registerColumns(\"$qualifiedName\", \"$columns\")")

--- a/KSP/src/main/kotlin/io/github/jan/supabase/ksp/SelectableSymbolProcessorProvider.kt
+++ b/KSP/src/main/kotlin/io/github/jan/supabase/ksp/SelectableSymbolProcessorProvider.kt
@@ -1,0 +1,11 @@
+package io.github.jan.supabase.ksp
+
+import com.google.devtools.ksp.processing.SymbolProcessor
+import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
+import com.google.devtools.ksp.processing.SymbolProcessorProvider
+
+class SelectableSymbolProcessorProvider: SymbolProcessorProvider {
+    override fun create(environment: SymbolProcessorEnvironment): SymbolProcessor {
+        return SelectableSymbolProcessor(environment.codeGenerator, environment.logger, environment.options)
+    }
+}

--- a/KSP/src/main/kotlin/io/github/jan/supabase/ksp/Utils.kt
+++ b/KSP/src/main/kotlin/io/github/jan/supabase/ksp/Utils.kt
@@ -3,7 +3,6 @@ package io.github.jan.supabase.ksp
 import com.google.devtools.ksp.symbol.KSAnnotation
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSValueArgument
-import com.google.devtools.ksp.symbol.Modifier
 
 fun Sequence<KSAnnotation>.getAnnotation(target: String): KSAnnotation {
     return getAnnotationOrNull(target) ?:
@@ -19,11 +18,6 @@ fun Sequence<KSAnnotation>.getAnnotationOrNull(target: String): KSAnnotation? {
     return null
 }
 
-fun Sequence<KSAnnotation>.hasAnnotation(target: String): Boolean {
-    for (element in this) if (element.shortName.asString() == target) return true
-    return false
-}
-
 fun <T> List<KSValueArgument>.getParameterValue(target: String): T {
     return getParameterValueIfExist(target) ?:
     throw NoSuchElementException("Sequence contains no element matching the predicate.")
@@ -32,8 +26,4 @@ fun <T> List<KSValueArgument>.getParameterValue(target: String): T {
 fun <T> List<KSValueArgument>.getParameterValueIfExist(target: String): T? {
     for (element in this) if (element.name?.asString() == target) (element.value as? T)?.let { return it }
     return null
-}
-
-fun Collection<Modifier>.containsIgnoreCase(name: String): Boolean {
-    return stream().anyMatch { it.name.equals(name, true) }
 }

--- a/KSP/src/main/kotlin/io/github/jan/supabase/ksp/Utils.kt
+++ b/KSP/src/main/kotlin/io/github/jan/supabase/ksp/Utils.kt
@@ -1,0 +1,39 @@
+package io.github.jan.supabase.ksp
+
+import com.google.devtools.ksp.symbol.KSAnnotation
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSValueArgument
+import com.google.devtools.ksp.symbol.Modifier
+
+fun Sequence<KSAnnotation>.getAnnotation(target: String): KSAnnotation {
+    return getAnnotationOrNull(target) ?:
+    throw NoSuchElementException("Sequence contains no element matching the predicate.")
+}
+
+fun KSClassDeclaration.anyCompanionObject(): KSClassDeclaration? {
+    return declarations.filterIsInstance<KSClassDeclaration>().firstOrNull { it.isCompanionObject }
+}
+
+fun Sequence<KSAnnotation>.getAnnotationOrNull(target: String): KSAnnotation? {
+    for (element in this) if (element.shortName.asString() == target) return element
+    return null
+}
+
+fun Sequence<KSAnnotation>.hasAnnotation(target: String): Boolean {
+    for (element in this) if (element.shortName.asString() == target) return true
+    return false
+}
+
+fun <T> List<KSValueArgument>.getParameterValue(target: String): T {
+    return getParameterValueIfExist(target) ?:
+    throw NoSuchElementException("Sequence contains no element matching the predicate.")
+}
+
+fun <T> List<KSValueArgument>.getParameterValueIfExist(target: String): T? {
+    for (element in this) if (element.name?.asString() == target) (element.value as? T)?.let { return it }
+    return null
+}
+
+fun Collection<Modifier>.containsIgnoreCase(name: String): Boolean {
+    return stream().anyMatch { it.name.equals(name, true) }
+}

--- a/KSP/src/main/resources/META-INF/services/com.google.devtools.ksp.processing.SymbolProcessorProvider
+++ b/KSP/src/main/resources/META-INF/services/com.google.devtools.ksp.processing.SymbolProcessorProvider
@@ -1,0 +1,1 @@
+io.github.jan.supabase.ksp.SelectableSymbolProcessorProvider

--- a/Postgrest/README.md
+++ b/Postgrest/README.md
@@ -60,7 +60,7 @@ val supabase = createSupabaseClient(
 ```
 
 > [!NOTE]
-> Generating columns for `@Selectable` requires the [KSP compiler](/KSP) to be installed.
+> Generating columns for `@Selectable` data classes requires the [KSP compiler](/KSP) to be installed.
 
 # Usage
 

--- a/Postgrest/README.md
+++ b/Postgrest/README.md
@@ -59,6 +59,9 @@ val supabase = createSupabaseClient(
 }
 ```
 
+> [!NOTE]
+> Generating columns for `@Selectable` requires the [KSP compiler](/KSP) to be installed.
+
 # Usage
 
 See [Postgrest documentation](https://supabase.com/docs/reference/kotlin/select) for usage

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/ColumnRegistry.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/ColumnRegistry.kt
@@ -1,0 +1,15 @@
+package io.github.jan.supabase.postgrest
+
+import kotlin.reflect.KClass
+
+class ColumnRegistry(
+    private val map: MutableMap<String, String> = mutableMapOf()
+) {
+
+    fun <T : Any> getColumns(kClass: KClass<T>): String = map[kClass.qualifiedName] ?: error("No columns registered for $kClass")
+
+    fun registerColumns(qualifiedName: String, columns: String) {
+        map[qualifiedName] = columns
+    }
+
+}

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/ColumnRegistry.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/ColumnRegistry.kt
@@ -1,7 +1,9 @@
 package io.github.jan.supabase.postgrest
 
+import io.github.jan.supabase.annotations.SupabaseInternal
 import kotlin.reflect.KClass
 
+@SupabaseInternal
 class ColumnRegistry(
     private val map: MutableMap<String, String> = mutableMapOf()
 ) {

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/Postgrest.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/Postgrest.kt
@@ -2,6 +2,7 @@ package io.github.jan.supabase.postgrest
 
 import io.github.jan.supabase.SupabaseClient
 import io.github.jan.supabase.SupabaseSerializer
+import io.github.jan.supabase.annotations.SupabaseInternal
 import io.github.jan.supabase.exceptions.RestException
 import io.github.jan.supabase.logging.SupabaseLogger
 import io.github.jan.supabase.plugins.CustomSerializationConfig
@@ -95,7 +96,7 @@ sealed interface Postgrest : MainPlugin<Postgrest.Config>, CustomSerializationPl
     data class Config(
         var defaultSchema: String = "public",
         var propertyConversionMethod: PropertyConversionMethod = PropertyConversionMethod.CAMEL_CASE_TO_SNAKE_CASE,
-        var columnRegistry: ColumnRegistry = ColumnRegistry()
+        @property:SupabaseInternal var columnRegistry: ColumnRegistry = ColumnRegistry()
     ): MainConfig(), CustomSerializationConfig {
 
         override var serializer: SupabaseSerializer? = null

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/Postgrest.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/Postgrest.kt
@@ -95,6 +95,7 @@ sealed interface Postgrest : MainPlugin<Postgrest.Config>, CustomSerializationPl
     data class Config(
         var defaultSchema: String = "public",
         var propertyConversionMethod: PropertyConversionMethod = PropertyConversionMethod.CAMEL_CASE_TO_SNAKE_CASE,
+        var columnRegistry: ColumnRegistry = ColumnRegistry()
     ): MainConfig(), CustomSerializationConfig {
 
         override var serializer: SupabaseSerializer? = null

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/PostgrestImpl.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/PostgrestImpl.kt
@@ -65,7 +65,7 @@ internal class PostgrestImpl(override val supabaseClient: SupabaseClient, overri
     override suspend fun rpc(function: String, request: RpcRequestBuilder.() -> Unit): PostgrestResult = rpcRequest(function, null, request)
 
     private suspend fun rpcRequest(function: String, body: JsonObject? = null, request: RpcRequestBuilder.() -> Unit): PostgrestResult {
-        val requestBuilder = RpcRequestBuilder(config.defaultSchema, config.propertyConversionMethod).apply(request)
+        val requestBuilder = RpcRequestBuilder(config.defaultSchema, config.propertyConversionMethod, config.columnRegistry).apply(request)
         val urlParams = buildMap {
             putAll(requestBuilder.params.mapToFirstValue())
             if(requestBuilder.method != RpcMethod.POST && body != null) {

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/annotations/ApplyFunction.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/annotations/ApplyFunction.kt
@@ -1,5 +1,7 @@
 package io.github.jan.supabase.postgrest.annotations
 
+import io.github.jan.supabase.annotations.SupabaseInternal
+
 /**
  * Annotation to apply a function to a column in a PostgREST query.
  * @param function The function to apply to the column.
@@ -9,7 +11,12 @@ package io.github.jan.supabase.postgrest.annotations
 annotation class ApplyFunction(val function: String) {
 
     companion object {
-        const val FUNCTION_PARAMETER_NAME = "function"
+        @SupabaseInternal const val FUNCTION_PARAMETER_NAME = "function"
+        const val AVG = "avg"
+        const val COUNT = "count"
+        const val MAX = "max"
+        const val MIN = "min"
+        const val SUM = "sum"
     }
 
 }

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/annotations/ApplyFunction.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/annotations/ApplyFunction.kt
@@ -1,0 +1,15 @@
+package io.github.jan.supabase.postgrest.annotations
+
+/**
+ * Annotation to apply a function to a column in a PostgREST query.
+ * @param function The function to apply to the column.
+ */
+@Target(AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.SOURCE)
+annotation class ApplyFunction(val function: String) {
+
+    companion object {
+        const val FUNCTION_PARAMETER_NAME = "function"
+    }
+
+}

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/annotations/Cast.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/annotations/Cast.kt
@@ -1,0 +1,15 @@
+package io.github.jan.supabase.postgrest.annotations
+
+/**
+ * Annotation to cast a column in a PostgREST query.
+ * @param type The type to cast the column to. If empty, the type will be inferred from the parameter type. For example, if the parameter is of type `String`, the column will be cast to `text`.
+ */
+@Target(AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.SOURCE)
+annotation class Cast(val type: String = "") {
+
+    companion object {
+        const val TYPE_PARAMETER_NAME = "type"
+    }
+
+}

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/annotations/Cast.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/annotations/Cast.kt
@@ -1,5 +1,7 @@
 package io.github.jan.supabase.postgrest.annotations
 
+import io.github.jan.supabase.annotations.SupabaseInternal
+
 /**
  * Annotation to cast a column in a PostgREST query.
  * @param type The type to cast the column to. If empty, the type will be inferred from the parameter type. For example, if the parameter is of type `String`, the column will be cast to `text`.
@@ -9,7 +11,7 @@ package io.github.jan.supabase.postgrest.annotations
 annotation class Cast(val type: String = "") {
 
     companion object {
-        const val TYPE_PARAMETER_NAME = "type"
+        @SupabaseInternal const val TYPE_PARAMETER_NAME = "type"
     }
 
 }

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/annotations/ColumnName.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/annotations/ColumnName.kt
@@ -1,0 +1,17 @@
+package io.github.jan.supabase.postgrest.annotations
+
+/**
+ * Annotation to specify the name of a column in a PostgREST query.
+ *
+ * If this annotation is not present, the name of the column will be inferred from the parameter name.
+ * @param name The name of the column.
+ */
+@Target(AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.SOURCE)
+annotation class ColumnName(val name: String) {
+
+    companion object {
+        const val NAME_PARAMETER_NAME = "name"
+    }
+
+}

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/annotations/ColumnName.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/annotations/ColumnName.kt
@@ -1,5 +1,7 @@
 package io.github.jan.supabase.postgrest.annotations
 
+import io.github.jan.supabase.annotations.SupabaseInternal
+
 /**
  * Annotation to specify the name of a column in a PostgREST query.
  *
@@ -11,7 +13,7 @@ package io.github.jan.supabase.postgrest.annotations
 annotation class ColumnName(val name: String) {
 
     companion object {
-        const val NAME_PARAMETER_NAME = "name"
+        @SupabaseInternal const val NAME_PARAMETER_NAME = "name"
     }
 
 }

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/annotations/Foreign.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/annotations/Foreign.kt
@@ -1,0 +1,10 @@
+package io.github.jan.supabase.postgrest.annotations
+
+/**
+ * Annotation to specify that a column is a foreign key in a PostgREST query.
+ *
+ * This annotation may be used in combination with [ColumnName] to specify the name of the foreign key column. The type of the parameter must be marked with [Selectable].
+ */
+@Target(AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.SOURCE)
+annotation class Foreign

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/annotations/Foreign.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/annotations/Foreign.kt
@@ -3,7 +3,7 @@ package io.github.jan.supabase.postgrest.annotations
 /**
  * Annotation to specify that a column is a foreign key in a PostgREST query.
  *
- * This annotation may be used in combination with [ColumnName] to specify the name of the foreign key column. The type of the parameter must be marked with [Selectable].
+ * This annotation may be used in combination with [ColumnName] to specify the name of the foreign key column. The type of the parameter must be annotated with [Selectable].
  */
 @Target(AnnotationTarget.VALUE_PARAMETER)
 @Retention(AnnotationRetention.SOURCE)

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/annotations/JsonPath.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/annotations/JsonPath.kt
@@ -15,7 +15,7 @@ package io.github.jan.supabase.postgrest.annotations
  * data class Example(@JsonPath("data", "id") val id: Int)
  * ```
  *
- * @param path The path to the JSON property.
+ * @param path The path to the JSON property. The first element of the array is always the column name.
  * @param returnAsText Whether to return the JSON property as text. If `true`, the JSON property will be returned as a string. If `false`, the JSON property will be returned as JSON.
  *
  */

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/annotations/JsonPath.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/annotations/JsonPath.kt
@@ -1,5 +1,7 @@
 package io.github.jan.supabase.postgrest.annotations
 
+import io.github.jan.supabase.annotations.SupabaseInternal
+
 /**
  * Annotation to specify a JSON path in a PostgREST query.
  *
@@ -24,8 +26,8 @@ package io.github.jan.supabase.postgrest.annotations
 annotation class JsonPath(vararg val path: String, val returnAsText: Boolean = false) {
 
     companion object {
-        const val PATH_PARAMETER_NAME = "path"
-        const val RETURN_AS_TEXT_PARAMETER_NAME = "returnAsText"
+        @SupabaseInternal const val PATH_PARAMETER_NAME = "path"
+        @SupabaseInternal const val RETURN_AS_TEXT_PARAMETER_NAME = "returnAsText"
     }
 
 }

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/annotations/JsonPath.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/annotations/JsonPath.kt
@@ -9,7 +9,10 @@ import io.github.jan.supabase.annotations.SupabaseInternal
  * Table with a JSON column `data`:
  * ```json
  * {
- *    "id": 1
+ *    "id": 1,
+ *    "nested": {
+ *        "name": "John"
+ *    }
  * }
  * ```
  * ```kotlin
@@ -17,18 +20,21 @@ import io.github.jan.supabase.annotations.SupabaseInternal
  * data class Example(
  *     @ColumnName("data")
  *     @JsonPath("id")
- *     val id: Int
+ *     val id: Int,
+ *
+ *     @ColumnName("data")
+ *     @JsonPath("nested", "name")
+ *     val name: String
  * )
  * ```
  *
- * @param key The key of the JSON property.
- * @param path Additional path to the JSON property. If the JSON property is nested, you can specify the path to the property.
+ * @param path The path to the JSON property. At least one path must be specified.
  * @param returnAsText Whether to return the JSON property as text. If `true`, the JSON property will be returned as a string. If `false`, the JSON property will be returned as JSON.
  *
  */
 @Target(AnnotationTarget.VALUE_PARAMETER)
 @Retention(AnnotationRetention.SOURCE)
-annotation class JsonPath(val key: String, vararg val path: String, val returnAsText: Boolean = false) {
+annotation class JsonPath(vararg val path: String, val returnAsText: Boolean = false) {
 
     companion object {
         @SupabaseInternal const val PATH_PARAMETER_NAME = "path"

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/annotations/JsonPath.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/annotations/JsonPath.kt
@@ -1,0 +1,31 @@
+package io.github.jan.supabase.postgrest.annotations
+
+/**
+ * Annotation to specify a JSON path in a PostgREST query.
+ *
+ * Example:
+ * Table with a JSON column `data`:
+ * ```json
+ * {
+ *    "id": 1
+ * }
+ * ```
+ * ```kotlin
+ * @Selectable
+ * data class Example(@JsonPath("data", "id") val id: Int)
+ * ```
+ *
+ * @param path The path to the JSON property.
+ * @param returnAsText Whether to return the JSON property as text. If `true`, the JSON property will be returned as a string. If `false`, the JSON property will be returned as JSON.
+ *
+ */
+@Target(AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.SOURCE)
+annotation class JsonPath(vararg val path: String, val returnAsText: Boolean = false) {
+
+    companion object {
+        const val PATH_PARAMETER_NAME = "path"
+        const val RETURN_AS_TEXT_PARAMETER_NAME = "returnAsText"
+    }
+
+}

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/annotations/JsonPath.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/annotations/JsonPath.kt
@@ -14,19 +14,25 @@ import io.github.jan.supabase.annotations.SupabaseInternal
  * ```
  * ```kotlin
  * @Selectable
- * data class Example(@JsonPath("data", "id") val id: Int)
+ * data class Example(
+ *     @ColumnName("data")
+ *     @JsonPath("id")
+ *     val id: Int
+ * )
  * ```
  *
- * @param path The path to the JSON property. The first element of the array is always the column name.
+ * @param key The key of the JSON property.
+ * @param path Additional path to the JSON property. If the JSON property is nested, you can specify the path to the property.
  * @param returnAsText Whether to return the JSON property as text. If `true`, the JSON property will be returned as a string. If `false`, the JSON property will be returned as JSON.
  *
  */
 @Target(AnnotationTarget.VALUE_PARAMETER)
 @Retention(AnnotationRetention.SOURCE)
-annotation class JsonPath(vararg val path: String, val returnAsText: Boolean = false) {
+annotation class JsonPath(val key: String, vararg val path: String, val returnAsText: Boolean = false) {
 
     companion object {
         @SupabaseInternal const val PATH_PARAMETER_NAME = "path"
+        @SupabaseInternal const val KEY_PARAMETER_NAME = "key"
         @SupabaseInternal const val RETURN_AS_TEXT_PARAMETER_NAME = "returnAsText"
     }
 

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/annotations/Selectable.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/annotations/Selectable.kt
@@ -3,18 +3,18 @@ package io.github.jan.supabase.postgrest.annotations
 import io.github.jan.supabase.postgrest.query.PostgrestQueryBuilder
 
 /**
- * Marks a class as selectable.
+ * Annotates a class as selectable.
  *
  * When using the **ksp-compiler** this annotation will be processed and columns for [PostgrestQueryBuilder.select] will be generated.
  *
  * The columns can be accessed via the generated extension property for the companion object of the class.
  *
  * **Note:**
- * - All classes marked with this annotation must have a companion object, which can be empty, and must be a data class
- * - All parameters in the primary constructor must a primitive type`*` or a type that is also marked with [Selectable]
- * - Parameters may be marked with [ColumnName], [ApplyFunction], [Cast], [JsonPath], [Foreign].
+ * - All classes annotated with this annotation must have a companion object, which can be empty, and must be a data class
+ * - All parameters in the primary constructor must a primitive type¹, a type that is also annotated with [Selectable] or a serializable type.
+ * - Parameters may be annotated with [ColumnName], [ApplyFunction], [Cast], [JsonPath], [Foreign].
  *
- * `*` Available primitive types are: String, Int, Long, Float, Double, Boolean
+ * ¹: Available primitive types are: String, Int, Long, Float, Double, Boolean, Byte, Short, Char, Instant, LocalDateTime, Uuid, LocalTime, LocalDate, JsonElement, JsonObject, JsonArray, JsonPrimitive
  *
  * Example usage:
  * ```kotlin

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/annotations/Selectable.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/annotations/Selectable.kt
@@ -1,5 +1,6 @@
 package io.github.jan.supabase.postgrest.annotations
 
+import io.github.jan.supabase.annotations.SupabaseExperimental
 import io.github.jan.supabase.postgrest.query.PostgrestQueryBuilder
 
 /**
@@ -40,4 +41,5 @@ import io.github.jan.supabase.postgrest.query.PostgrestQueryBuilder
  */
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.SOURCE)
+@SupabaseExperimental
 annotation class Selectable

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/annotations/Selectable.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/annotations/Selectable.kt
@@ -1,0 +1,43 @@
+package io.github.jan.supabase.postgrest.annotations
+
+import io.github.jan.supabase.postgrest.query.PostgrestQueryBuilder
+
+/**
+ * Marks a class as selectable.
+ *
+ * When using the **ksp-compiler** this annotation will be processed and columns for [PostgrestQueryBuilder.select] will be generated.
+ *
+ * The columns can be accessed via the generated extension property for the companion object of the class.
+ *
+ * **Note:**
+ * - All classes marked with this annotation must have a companion object, which can be empty, and must be a data class
+ * - All parameters in the primary constructor must a primitive type`*` or a type that is also marked with [Selectable]
+ * - Parameters may be marked with [ColumnName], [ApplyFunction], [Cast], [JsonPath], [Foreign].
+ *
+ * `*` Available primitive types are: String, Int, Long, Float, Double, Boolean
+ *
+ * Example usage:
+ * ```kotlin
+ * @Selectable
+ * data class User(
+ *    val id: Int,
+ *    val name: String,
+ *    val age: Int
+ *    //...
+ * ) {
+ *     companion object
+ * }
+ *
+ * //Usage
+ * val users: List<User> = supabase.from("users").select(User.columns).decodeList()
+ * ```
+ * @see ApplyFunction
+ * @see Cast
+ * @see ColumnName
+ * @see Foreign
+ * @see JsonPath
+ * @see PostgrestQueryBuilder.select
+ */
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.SOURCE)
+annotation class Selectable

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/PostgrestBuilderExtension.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/PostgrestBuilderExtension.kt
@@ -1,0 +1,43 @@
+package io.github.jan.supabase.postgrest.query
+
+import io.github.jan.supabase.annotations.SupabaseExperimental
+import io.github.jan.supabase.auth.PostgrestFilterDSL
+import io.github.jan.supabase.exceptions.HttpRequestException
+import io.github.jan.supabase.exceptions.RestException
+import io.github.jan.supabase.postgrest.annotations.Selectable
+import io.github.jan.supabase.postgrest.query.request.SelectRequestBuilder
+import io.github.jan.supabase.postgrest.result.PostgrestResult
+import io.ktor.client.plugins.HttpRequestTimeoutException
+
+/**
+ * Executes vertical filtering with select on [PostgrestQueryBuilder.table].
+ *
+ * - This method is a shorthand for [select] with the columns automatically determined by the [T] type.
+ * - [T] must be marked with [Selectable] and the `ksp-compiler` KSP dependency must be added to the project (via the KSP Gradle plugin).
+ *
+ * @param request Additional configurations for the request including filters
+ * @return PostgrestResult which is either an error, an empty JsonArray or the data you requested as an JsonArray
+ * @throws RestException or one of its subclasses if receiving an error response
+ * @throws HttpRequestTimeoutException if the request timed out
+ * @throws HttpRequestException on network related issues
+ */
+@SupabaseExperimental
+suspend inline fun <reified T : Any> PostgrestQueryBuilder.select(
+    request: @PostgrestFilterDSL SelectRequestBuilder.() -> Unit = {}
+): PostgrestResult {
+    val registry = postgrest.config.columnRegistry
+    val columns = registry.getColumns(T::class)
+    return select(Columns.raw(columns), request)
+}
+
+/**
+ * Return `data` after the query has been executed.
+ *
+ * - This method is a shorthand for [select] with the columns automatically determined by the [T] type.
+ * - [T] must be marked with [Selectable] and the `ksp-compiler` KSP dependency must be added to the project (via the KSP Gradle plugin).
+ */
+@SupabaseExperimental
+inline fun <reified T : Any> PostgrestRequestBuilder.select() {
+    val columns = columnRegistry.getColumns(T::class)
+    select(Columns.raw(columns))
+}

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/PostgrestRequestBuilder.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/PostgrestRequestBuilder.kt
@@ -3,6 +3,7 @@ package io.github.jan.supabase.postgrest.query
 
 import io.github.jan.supabase.annotations.SupabaseExperimental
 import io.github.jan.supabase.auth.PostgrestFilterDSL
+import io.github.jan.supabase.postgrest.ColumnRegistry
 import io.github.jan.supabase.postgrest.PropertyConversionMethod
 import io.github.jan.supabase.postgrest.query.filter.PostgrestFilterBuilder
 import io.github.jan.supabase.postgrest.result.PostgrestResult
@@ -14,7 +15,10 @@ import kotlin.js.JsName
  * A builder for Postgrest requests.
  */
 @PostgrestFilterDSL
-open class PostgrestRequestBuilder(@PublishedApi internal val propertyConversionMethod: PropertyConversionMethod) {
+open class PostgrestRequestBuilder(
+    @PublishedApi internal val propertyConversionMethod: PropertyConversionMethod,
+    @PublishedApi internal val columnRegistry: ColumnRegistry
+) {
 
     /**
      * The [Count] algorithm to use to count rows in the table or view.
@@ -26,7 +30,7 @@ open class PostgrestRequestBuilder(@PublishedApi internal val propertyConversion
      * The [Returning] option to use.
      */
     var returning: Returning = Returning.Minimal
-        private set
+        internal set
     @SupabaseExperimental val params: MutableMap<String, List<String>> = mutableMapOf()
     @SupabaseExperimental val headers: HeadersBuilder = HeadersBuilder()
 

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/request/InsertRequestBuilder.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/request/InsertRequestBuilder.kt
@@ -1,5 +1,6 @@
 package io.github.jan.supabase.postgrest.query.request
 
+import io.github.jan.supabase.postgrest.ColumnRegistry
 import io.github.jan.supabase.postgrest.PropertyConversionMethod
 import io.github.jan.supabase.postgrest.query.PostgrestQueryBuilder
 import io.github.jan.supabase.postgrest.query.PostgrestRequestBuilder
@@ -7,7 +8,7 @@ import io.github.jan.supabase.postgrest.query.PostgrestRequestBuilder
 /**
  * Request builder for [PostgrestQueryBuilder.insert]
  */
-open class InsertRequestBuilder(propertyConversionMethod: PropertyConversionMethod): PostgrestRequestBuilder(propertyConversionMethod) {
+open class InsertRequestBuilder(propertyConversionMethod: PropertyConversionMethod, columnRegistry: ColumnRegistry): PostgrestRequestBuilder(propertyConversionMethod, columnRegistry) {
 
     /**
      * Make missing fields default to `null`.

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/request/RpcRequestBuilder.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/request/RpcRequestBuilder.kt
@@ -1,13 +1,19 @@
 package io.github.jan.supabase.postgrest.query.request
 
+import io.github.jan.supabase.postgrest.ColumnRegistry
+import io.github.jan.supabase.postgrest.Postgrest
 import io.github.jan.supabase.postgrest.PropertyConversionMethod
 import io.github.jan.supabase.postgrest.RpcMethod
 import io.github.jan.supabase.postgrest.query.PostgrestRequestBuilder
 
 /**
- * Request builder for [Postgrest.rpcRequest]
+ * Request builder for [Postgrest.rpc]
  */
-class RpcRequestBuilder(defaultSchema: String, propertyConversionMethod: PropertyConversionMethod): PostgrestRequestBuilder(propertyConversionMethod) {
+class RpcRequestBuilder(
+    defaultSchema: String,
+    propertyConversionMethod: PropertyConversionMethod,
+    columnRegistry: ColumnRegistry
+): PostgrestRequestBuilder(propertyConversionMethod, columnRegistry) {
 
     /**
      * The HTTP method to use. Default is POST

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/request/SelectRequestBuilder.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/request/SelectRequestBuilder.kt
@@ -1,5 +1,6 @@
 package io.github.jan.supabase.postgrest.query.request
 
+import io.github.jan.supabase.postgrest.ColumnRegistry
 import io.github.jan.supabase.postgrest.PropertyConversionMethod
 import io.github.jan.supabase.postgrest.query.PostgrestQueryBuilder
 import io.github.jan.supabase.postgrest.query.PostgrestRequestBuilder
@@ -7,7 +8,10 @@ import io.github.jan.supabase.postgrest.query.PostgrestRequestBuilder
 /**
  * Request builder for [PostgrestQueryBuilder.select]
  */
-class SelectRequestBuilder(propertyConversionMethod: PropertyConversionMethod): PostgrestRequestBuilder(propertyConversionMethod) {
+class SelectRequestBuilder(
+    propertyConversionMethod: PropertyConversionMethod,
+    columnRegistry: ColumnRegistry
+): PostgrestRequestBuilder(propertyConversionMethod, columnRegistry) {
 
     /**
      * If true, no body will be returned. Useful when using count.

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/request/UpsertRequestBuilder.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/request/UpsertRequestBuilder.kt
@@ -1,12 +1,16 @@
 package io.github.jan.supabase.postgrest.query.request
 
+import io.github.jan.supabase.postgrest.ColumnRegistry
 import io.github.jan.supabase.postgrest.PropertyConversionMethod
 import io.github.jan.supabase.postgrest.query.PostgrestQueryBuilder
 
 /**
  * Request builder for [PostgrestQueryBuilder.upsert]
  */
-class UpsertRequestBuilder(propertyConversionMethod: PropertyConversionMethod): InsertRequestBuilder(propertyConversionMethod) {
+class UpsertRequestBuilder(
+    propertyConversionMethod: PropertyConversionMethod,
+    columnRegistry: ColumnRegistry
+): InsertRequestBuilder(propertyConversionMethod, columnRegistry) {
 
     /**
      * Comma-separated UNIQUE column(s) to specify how

--- a/buildSrc/src/main/kotlin/Modules.kt
+++ b/buildSrc/src/main/kotlin/Modules.kt
@@ -1,3 +1,4 @@
+import org.gradle.kotlin.dsl.DependencyHandlerScope
 import org.jetbrains.compose.desktop.DesktopExtension
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
 import org.jetbrains.kotlin.gradle.plugin.KotlinDependencyHandler

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,9 +33,12 @@ androidx-core = "1.13.1"
 androidx-compat = "1.7.0"
 androidx-lifecycle = "2.8.6"
 filekit = "0.8.7"
+ksp = "2.0.21-1.0.25"
+kotlin-poet = "2.0.0"
 
 [plugins]
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 kotlinx-plugin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
@@ -52,6 +55,9 @@ kotlinx-atomicfu = { id = "org.jetbrains.kotlinx.atomicfu", version.ref = "atomi
 power-assert = { id = "org.jetbrains.kotlin.plugin.power-assert", version.ref = "kotlin" }
 
 [libraries]
+ksp = { module = "com.google.devtools.ksp:symbol-processing-api", version.ref = "ksp" }
+kotlin-poet = { module = "com.squareup:kotlinpoet", version.ref = "kotlin-poet" }
+kotlin-poet-ksp = { module = "com.squareup:kotlinpoet-ksp", version.ref = "kotlin-poet" }
 kotlinx-atomicfu = { module = "org.jetbrains.kotlinx:atomicfu", version.ref = "atomicfu" }
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinx-datetime" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,6 +14,7 @@ plugins {
 // Main Modules
 include("Auth")
 include("Postgrest")
+include("KSP")
 include("Storage")
 include("Realtime")
 include("Functions")
@@ -51,6 +52,7 @@ project(":Storage").name = "storage-kt"
 project(":Realtime").name = "realtime-kt"
 project(":Functions").name = "functions-kt"
 project(":Supabase").name = "supabase-kt"
+project(":KSP").name = "ksp-compiler"
 project(":plugins:ApolloGraphQL").name = "apollo-graphql"
 project(":plugins:ComposeAuth").name = "compose-auth"
 project(":plugins:ComposeAuthUI").name = "compose-auth-ui"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the new behavior?

New KSP compiler module which processes `@Selectable` annotated data classes. I kept the KSP compiler more general, so if we ever want to add a new annotation, we can just use this module.
### How it works
- [**Add the KSP compiler**](https://github.com/supabase-community/supabase-kt/tree/postgrest-column-ksp/KSP)

- **Annotate your data models with `@Selectable`:**
```kotlin
@Selectable
@Serializable
data class Movie(
    val id: Int,

    val name: String

    @ColumnName("created_at") //if the parameter names differs from the column name, add this annotation
    val createdAt: Instant,

    @Foreign //Mark a foreign relationship
    @ColumnName("studio_id") //Either the table name or column name
    val studio: Studio //This should also be a `@Selectable` type

    @ColumnName("metadata") //query JSON columns
    @JsonPath("video", "resolution") 
    val resolution: String
)
```
- **Call the generated `addSelectableTypes()` method in the PostgrestConfig:**
```kotlin
install(Postgrest) {
    addSelectableTypes()
}
```
- **Use the new overloads for selecting:**
```kotlin
val movies: List<Movie> = supabase.from("movies").select<Movie>().decodeList()
//or for insert, update, etc.:
//Note that `myNewMovie` is obviously a different type
val updatedMovie: Movie = supabase.from("movies").insert(myNewMovie) { 
    select<Movie>()
}
```

### Design details

There are 5 annotations: 
- `@Serializable` - Data classes will be processed by the compiler and columns will be generated based of the constructor parameters.
- `@ColumnName` - Used to specify the actual column name when the parameter name differs. For foreign columns, this can be either the column name or foreign table.
- `@JsonPath` - Used to specify a Json Path to query a JSON column
- `@Foreign` - Used for foreign columns so the compiler knows that it has to generate nested columns
- `@ApplyFunction` - Used to apply an aggregate function

**Todo:**
- [ ] Find a solution for spreading embedded resources 
- [ ] Tests

### Implementation

There is a new Postgrest config property `columnRegistry` which stores column data under the full class name for annotated data classes. The KSP compiler fills this registry when the generated `addSelectableTypes()` method is called.
Example for the generated method **[Not visible normally]**:
```kotlin
/**
 * Adds the types annotated with [Selectable] to the ColumnRegistry. Allows to use the automatically generated columns in the PostgrestQueryBuilder.
 *
 * This file is generated by the SelectableSymbolProcessor.
 * Do not modify it manually.
 */
@OptIn(SupabaseInternal::class)
public fun Postgrest.Config.addSelectableTypes() {
  columnRegistry.registerColumns("Movie", "id,title:movie_title,studio:studios(id,name),someAverage:column_name.avg(),jsonKey:json_data->array->0->>key")
  columnRegistry.registerColumns("Studio", "id,name")
}

```

## Additional context

See discussion in #761 
