### PR TITLE
Remove `toMap()` call for public `Realtime#subscriptions` property

### DIFF
--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeImpl.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeImpl.kt
@@ -40,8 +40,7 @@ import kotlinx.serialization.json.buildJsonObject
     private val _status = MutableStateFlow(Realtime.Status.DISCONNECTED)
     override val status: StateFlow<Realtime.Status> = _status.asStateFlow()
     private val _subscriptions = AtomicMutableMap<String, RealtimeChannel>()
-    override val subscriptions: Map<String, RealtimeChannel>
-        get() = _subscriptions.toMap()
+    override val subscriptions: Map<String, RealtimeChannel> = _subscriptions
     private val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
     private val mutex = Mutex()
     var heartbeatJob: Job? = null


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (closes #778)

## What is the current behavior?

The original map is not exposed to the public API, but rare errors like #778 can happen and the map is cast as read-only anyways, so we don't need this limitation.

## What is the new behavior?

The underlying map is exposed.
