### PR TITLE
Improve behavior for realtime channel creation and improve docs

### DIFF
--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/Realtime.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/Realtime.kt
@@ -54,7 +54,7 @@ sealed interface Realtime : MainPlugin<Realtime.Config>, CustomSerializationPlug
     val status: StateFlow<Status>
 
     /**
-     * A list of all active the subscriptions
+     * A map of all active the subscriptions
      */
     val subscriptions: Map<String, RealtimeChannel>
 

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/Realtime.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/Realtime.kt
@@ -54,7 +54,7 @@ sealed interface Realtime : MainPlugin<Realtime.Config>, CustomSerializationPlug
     val status: StateFlow<Status>
 
     /**
-     * A map of all active the subscriptions
+     * A list of all active the subscriptions
      */
     val subscriptions: Map<String, RealtimeChannel>
 
@@ -102,6 +102,17 @@ sealed interface Realtime : MainPlugin<Realtime.Config>, CustomSerializationPlug
      * @param token The JWT access token
      */
     suspend fun setAuth(token: String? = null)
+
+    /**
+     * Creates a new [RealtimeChannel] and adds it to the [subscriptions]
+     *
+     * - This method does not subscribe to the channel. You have to call [RealtimeChannel.subscribe] to do so.
+     * - If the channel already exists, it will be returned
+     *
+     * @param channelId The id of the channel
+     * @param builder The builder for the channel
+     */
+    fun channel(channelId: String, builder: RealtimeChannelBuilder): RealtimeChannel
 
     /**
      * @property websocketConfig Custom configuration for the Ktor Websocket Client. This only applies if [Realtime.Config.websocketFactory] is null.
@@ -187,11 +198,15 @@ sealed interface Realtime : MainPlugin<Realtime.Config>, CustomSerializationPlug
 }
 
 /**
- * Creates a new [RealtimeChannel]
+ * Creates a new [RealtimeChannel] and adds it to the [Realtime.subscriptions]
+ *
+ * - This method does not subscribe to the channel. You have to call [RealtimeChannel.subscribe] to do so.
+ * - If the channel already exists, it will be returned
+ *
+ * @param channelId The id of the channel
+ * @param builder The builder for the channel
  */
-inline fun Realtime.channel(channelId: String, builder: RealtimeChannelBuilder.() -> Unit = {}): RealtimeChannel {
-    return RealtimeChannelBuilder("realtime:$channelId", this as RealtimeImpl).apply(builder).build()
-}
+inline fun Realtime.channel(channelId: String, builder: RealtimeChannelBuilder.() -> Unit = {}): RealtimeChannel = channel(channelId, RealtimeChannelBuilder("realtime:$channelId", this as RealtimeImpl).apply(builder))
 
 /**
  * Supabase Realtime is a way to listen to changes in the PostgreSQL database via websockets

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/Realtime.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/Realtime.kt
@@ -104,7 +104,7 @@ sealed interface Realtime : MainPlugin<Realtime.Config>, CustomSerializationPlug
      * Creates a new [RealtimeChannel] and adds it to the [subscriptions]
      *
      * - This method does not subscribe to the channel. You have to call [RealtimeChannel.subscribe] to do so.
-     * - If the channel already exists, it will be returned
+     * - If a channel with the same [channelId] already exists, it will be returned
      *
      * @param channelId The id of the channel
      * @param builder The builder for the channel
@@ -195,10 +195,10 @@ sealed interface Realtime : MainPlugin<Realtime.Config>, CustomSerializationPlug
 }
 
 /**
- * Creates a new [RealtimeChannel] and adds it to the [Realtime.subscriptions]
+ * Creates a new [RealtimeChannel] and adds it to the [subscriptions]
  *
  * - This method does not subscribe to the channel. You have to call [RealtimeChannel.subscribe] to do so.
- * - If the channel already exists, it will be returned
+ * - If a channel with the same [channelId] already exists, it will be returned
  *
  * @param channelId The id of the channel
  * @param builder The builder for the channel

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/Realtime.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/Realtime.kt
@@ -195,7 +195,7 @@ sealed interface Realtime : MainPlugin<Realtime.Config>, CustomSerializationPlug
 }
 
 /**
- * Creates a new [RealtimeChannel] and adds it to the [subscriptions]
+ * Creates a new [RealtimeChannel] and adds it to the [Realtime.subscriptions]
  *
  * - This method does not subscribe to the channel. You have to call [RealtimeChannel.subscribe] to do so.
  * - If a channel with the same [channelId] already exists, it will be returned
@@ -203,7 +203,7 @@ sealed interface Realtime : MainPlugin<Realtime.Config>, CustomSerializationPlug
  * @param channelId The id of the channel
  * @param builder The builder for the channel
  */
-inline fun Realtime.channel(channelId: String, builder: RealtimeChannelBuilder.() -> Unit = {}): RealtimeChannel = channel(channelId, RealtimeChannelBuilder("realtime:$channelId", this as RealtimeImpl).apply(builder))
+inline fun Realtime.channel(channelId: String, builder: RealtimeChannelBuilder.() -> Unit = {}): RealtimeChannel = channel(channelId, RealtimeChannelBuilder(RealtimeTopic.withChannelId(channelId)).apply(builder))
 
 /**
  * Supabase Realtime is a way to listen to changes in the PostgreSQL database via websockets

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/Realtime.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/Realtime.kt
@@ -68,9 +68,6 @@ sealed interface Realtime : MainPlugin<Realtime.Config>, CustomSerializationPlug
      */
     fun disconnect()
 
-    @SupabaseInternal
-    fun Realtime.addChannel(channel: RealtimeChannel)
-
     /**
      * Unsubscribes and removes a channel from the [subscriptions]
      * @param channel The channel to remove

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeChannelBuilder.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeChannelBuilder.kt
@@ -7,7 +7,7 @@ import io.github.jan.supabase.realtime.annotations.ChannelDsl
  * Used to build a realtime channel
  */
 @ChannelDsl
-class RealtimeChannelBuilder @PublishedApi internal constructor(private val topic: String, private val realtimeImpl: RealtimeImpl) {
+class RealtimeChannelBuilder @PublishedApi internal constructor(private val topic: String) {
 
     private var broadcastJoinConfig = BroadcastJoinConfig(acknowledgeBroadcasts = false, receiveOwnBroadcasts = false)
     private var presenceJoinConfig = PresenceJoinConfig("")
@@ -33,9 +33,9 @@ class RealtimeChannelBuilder @PublishedApi internal constructor(private val topi
     }
 
     @SupabaseInternal
-    fun build(): RealtimeChannel {
+    fun build(realtime: Realtime): RealtimeChannel {
         return RealtimeChannelImpl(
-            realtimeImpl,
+            realtime,
             topic,
             broadcastJoinConfig,
             presenceJoinConfig,

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeChannelImpl.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeChannelImpl.kt
@@ -54,9 +54,6 @@ internal class RealtimeChannelImpl(
             if(!realtimeImpl.config.connectOnSubscribe) error("You can't subscribe to a channel while the realtime client is not connected. Did you forget to call `realtime.connect()`?")
             realtimeImpl.connect()
         }
-        realtimeImpl.run {
-            addChannel(this@RealtimeChannelImpl)
-        }
         _status.value = RealtimeChannel.Status.SUBSCRIBING
         Realtime.logger.d { "Subscribing to channel $topic" }
         val currentJwt = accessToken()

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeChannelImpl.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeChannelImpl.kt
@@ -27,23 +27,23 @@ import kotlin.reflect.KClass
 import kotlin.reflect.KType
 
 internal class RealtimeChannelImpl(
-    private val realtimeImpl: RealtimeImpl,
+    override val realtime: Realtime,
     override val topic: String,
     private val broadcastJoinConfig: BroadcastJoinConfig,
     private val presenceJoinConfig: PresenceJoinConfig,
     private val isPrivate: Boolean,
 ) : RealtimeChannel {
 
+    private val realtimeImpl: RealtimeImpl = realtime as RealtimeImpl
     private val clientChanges = AtomicMutableList<PostgresJoinConfig>()
     @SupabaseInternal
     override val callbackManager = CallbackManagerImpl(realtimeImpl.serializer)
     private val _status = MutableStateFlow(RealtimeChannel.Status.UNSUBSCRIBED)
     override val status = _status.asStateFlow()
-    override val realtime: Realtime = realtimeImpl
     override val supabaseClient = realtimeImpl.supabaseClient
 
     private val broadcastUrl = realtimeImpl.broadcastUrl()
-    private val subTopic = topic.replaceFirst(Regex("^realtime:", RegexOption.IGNORE_CASE), "")
+    private val subTopic = topic.replaceFirst(Regex("^${RealtimeTopic.PREFIX}:", RegexOption.IGNORE_CASE), "")
     private val httpClient = realtimeImpl.supabaseClient.httpClient
 
     private suspend fun accessToken() = realtimeImpl.config.accessToken(supabaseClient) ?: realtimeImpl.accessToken

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeImpl.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeImpl.kt
@@ -1,7 +1,6 @@
 package io.github.jan.supabase.realtime
 
 import io.github.jan.supabase.SupabaseClient
-import io.github.jan.supabase.annotations.SupabaseInternal
 import io.github.jan.supabase.auth.Auth
 import io.github.jan.supabase.auth.status.SessionStatus
 import io.github.jan.supabase.buildUrl
@@ -239,11 +238,6 @@ import kotlin.io.encoding.ExperimentalEncodingApi
             Realtime.logger.d { "No more subscriptions, disconnecting from realtime websocket" }
             disconnect()
         }
-    }
-
-    @SupabaseInternal
-    override fun Realtime.addChannel(channel: RealtimeChannel) {
-        _subscriptions[channel.topic] = channel
     }
 
     override suspend fun close() {

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeImpl.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeImpl.kt
@@ -162,6 +162,13 @@ import kotlin.io.encoding.ExperimentalEncodingApi
         _status.value = Realtime.Status.DISCONNECTED
     }
 
+    override fun channel(channelId: String, builder: RealtimeChannelBuilder): RealtimeChannel {
+        if(subscriptions.containsKey(channelId)) return subscriptions[channelId]!!
+        val channel = builder.build()
+        _subscriptions[channelId] = channel
+        return channel
+    }
+
     private suspend fun onMessage(message: RealtimeMessage) {
         Realtime.logger.d { "Received message $message" }
         val channel = subscriptions[message.topic] as? RealtimeChannelImpl

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeImpl.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeImpl.kt
@@ -162,9 +162,10 @@ import kotlin.io.encoding.ExperimentalEncodingApi
     }
 
     override fun channel(channelId: String, builder: RealtimeChannelBuilder): RealtimeChannel {
-        if(subscriptions.containsKey(channelId)) return subscriptions[channelId]!!
-        val channel = builder.build()
-        _subscriptions[channelId] = channel
+        val topic = RealtimeTopic.withChannelId(channelId)
+        if(subscriptions.containsKey(topic)) return subscriptions[topic]!!
+        val channel = builder.build(this)
+        _subscriptions[topic] = channel
         return channel
     }
 

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeTopic.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeTopic.kt
@@ -1,0 +1,12 @@
+package io.github.jan.supabase.realtime
+
+@PublishedApi
+internal object RealtimeTopic {
+
+    const val PREFIX = "realtime"
+
+    fun withChannelId(channelId: String): String {
+        return "$PREFIX:$channelId"
+    }
+
+}

--- a/Realtime/src/commonTest/kotlin/RealtimeTest.kt
+++ b/Realtime/src/commonTest/kotlin/RealtimeTest.kt
@@ -1,6 +1,7 @@
 import io.github.jan.supabase.realtime.Realtime
 import io.github.jan.supabase.realtime.RealtimeImpl
 import io.github.jan.supabase.realtime.RealtimeMessage
+import io.github.jan.supabase.realtime.channel
 import io.github.jan.supabase.realtime.realtime
 import io.ktor.util.encodeBase64
 import kotlinx.coroutines.test.runTest
@@ -26,6 +27,22 @@ class RealtimeTest {
                     assertEquals(Realtime.Status.CONNECTED, it.realtime.status.value)
                     it.realtime.disconnect()
                     assertEquals(Realtime.Status.DISCONNECTED, it.realtime.status.value)
+                }
+            )
+        }
+    }
+
+    @Test
+    fun testExistingChannelShouldBeReturned() {
+        runTest {
+            createTestClient(
+                wsHandler = { _, _ ->
+                    //Does not matter for this test
+                },
+                supabaseHandler = {
+                    val channel = it.realtime.channel("channelId")
+                    val channel2 = it.realtime.channel("channelId")
+                    assertEquals(channel, channel2)
                 }
             )
         }

--- a/Realtime/src/commonTest/kotlin/RealtimeTestUtils.kt
+++ b/Realtime/src/commonTest/kotlin/RealtimeTestUtils.kt
@@ -5,6 +5,7 @@ import io.github.jan.supabase.realtime.Presence
 import io.github.jan.supabase.realtime.RealtimeChannel.Companion.CHANNEL_EVENT_PRESENCE_DIFF
 import io.github.jan.supabase.realtime.RealtimeChannel.Companion.CHANNEL_EVENT_SYSTEM
 import io.github.jan.supabase.realtime.RealtimeMessage
+import io.github.jan.supabase.realtime.RealtimeTopic
 import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.SendChannel
 import kotlinx.coroutines.flow.Flow
@@ -29,18 +30,18 @@ suspend fun Auth.importAuthTokenValid(token: String) {
 
 suspend fun handleSubscribe(incoming: ReceiveChannel<RealtimeMessage>, outgoing: SendChannel<RealtimeMessage>, channelId: String) {
     incoming.receive()
-    outgoing.send(RealtimeMessage("realtime:$channelId", CHANNEL_EVENT_SYSTEM, buildJsonObject { put("status", "ok") }, ""))
+    outgoing.send(RealtimeMessage(RealtimeTopic.withChannelId(channelId), CHANNEL_EVENT_SYSTEM, buildJsonObject { put("status", "ok") }, ""))
 }
 
 suspend fun SendChannel<RealtimeMessage>.sendBroadcast(channelId: String, event: String, message: JsonObject) {
-    send(RealtimeMessage("realtime:$channelId", "broadcast", buildJsonObject {
+    send(RealtimeMessage(RealtimeTopic.withChannelId(channelId), "broadcast", buildJsonObject {
         put("event", event)
         put("payload", message)
     }, ""))
 }
 
 suspend fun SendChannel<RealtimeMessage>.sendPresence(channelId: String, joins: Map<String, Presence>, leaves: Map<String, Presence>) {
-    send(RealtimeMessage("realtime:$channelId", CHANNEL_EVENT_PRESENCE_DIFF, buildJsonObject {
+    send(RealtimeMessage(RealtimeTopic.withChannelId(channelId), CHANNEL_EVENT_PRESENCE_DIFF, buildJsonObject {
         put("joins", transformPresenceMap(joins))
         put("leaves", transformPresenceMap(leaves))
     }, ""))

--- a/Realtime/src/commonTest/kotlin/RealtimeTopicTest.kt
+++ b/Realtime/src/commonTest/kotlin/RealtimeTopicTest.kt
@@ -1,0 +1,19 @@
+import io.github.jan.supabase.realtime.RealtimeTopic
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class RealtimeTopicTest {
+
+    @Test
+    fun testRealtimeTopic() {
+        val channelId = "channelId"
+        val topic = RealtimeTopic.withChannelId(channelId)
+        assertEquals("realtime:channelId", topic)
+    }
+
+    @Test
+    fun testRealtimePrefix() {
+        assertEquals("realtime", RealtimeTopic.PREFIX)
+    }
+
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update / Improvement (closes #818)

## What is the current behavior?

Calling `Realtime#channel()` will always create a new channel and override the existing one, if there is one by the given channel id. Also the docs are not very clear.

## What is the new behavior?

- *`Realtime#channel()` will now also return an existing channel, if there is one.*
- The internal implementation and the docs have also been improved.
