### PR TITLE
Make the dialog type for the Native Google Sign In configurable

### DIFF
--- a/plugins/ComposeAuth/src/androidMain/kotlin/io/github/jan/supabase/compose/auth/Utils.kt
+++ b/plugins/ComposeAuth/src/androidMain/kotlin/io/github/jan/supabase/compose/auth/Utils.kt
@@ -3,15 +3,29 @@ package io.github.jan.supabase.compose.auth
 import android.app.Activity
 import android.content.Context
 import android.content.ContextWrapper
+import com.google.android.libraries.identity.googleid.GetGoogleIdOption
 import com.google.android.libraries.identity.googleid.GetSignInWithGoogleOption
 
-internal fun getSignInWithGoogleOptions(
+internal fun getGoogleButtonOptions(
     config: GoogleLoginConfig?,
     nonce: String? = null
 ): GetSignInWithGoogleOption {
     val signInWithGoogleOption = GetSignInWithGoogleOption.Builder(config?.serverClientId ?: error("Trying to use Google Auth without setting the serverClientId"))
     signInWithGoogleOption.setNonce(nonce)
     return signInWithGoogleOption.build()
+}
+
+internal fun getGoogleBottomSheetOptions(
+    config: GoogleLoginConfig?,
+    filterByAuthorizedAccounts: Boolean = true,
+    nonce: String? = null
+): GetGoogleIdOption {
+    val googleIdOption: GetGoogleIdOption = GetGoogleIdOption.Builder()
+        .setFilterByAuthorizedAccounts(filterByAuthorizedAccounts)
+        .setServerClientId(config?.serverClientId ?: error("Trying to use Google Auth without setting the serverClientId"))
+        .setNonce(nonce)
+    .build()
+    return googleIdOption
 }
 
 internal fun Context.getActivity(): Activity? = when (this) {

--- a/plugins/ComposeAuth/src/androidMain/kotlin/io/github/jan/supabase/compose/auth/composable/GoogleAuth.kt
+++ b/plugins/ComposeAuth/src/androidMain/kotlin/io/github/jan/supabase/compose/auth/composable/GoogleAuth.kt
@@ -1,5 +1,7 @@
 package io.github.jan.supabase.compose.auth.composable
 
+import android.app.Activity
+import android.content.Context
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
@@ -17,7 +19,8 @@ import com.google.android.libraries.identity.googleid.GoogleIdTokenParsingExcept
 import io.github.jan.supabase.compose.auth.ComposeAuth
 import io.github.jan.supabase.compose.auth.applicationContext
 import io.github.jan.supabase.compose.auth.getActivity
-import io.github.jan.supabase.compose.auth.getSignInWithGoogleOptions
+import io.github.jan.supabase.compose.auth.getGoogleBottomSheetOptions
+import io.github.jan.supabase.compose.auth.getGoogleButtonOptions
 import io.github.jan.supabase.compose.auth.hash
 import io.github.jan.supabase.compose.auth.signInWithGoogle
 import io.github.jan.supabase.logging.d
@@ -33,12 +36,20 @@ import io.github.jan.supabase.logging.e
  * @return [NativeSignInState]
  */
 @Composable
-actual fun ComposeAuth.rememberSignInWithGoogle(onResult: (NativeSignInResult) -> Unit, fallback: suspend () -> Unit): NativeSignInState {
-    return signInWithCM(onResult, fallback)
+actual fun ComposeAuth.rememberSignInWithGoogle(
+    onResult: (NativeSignInResult) -> Unit,
+    type: GoogleDialogType,
+    fallback: suspend () -> Unit)
+: NativeSignInState {
+    return signInWithCM(onResult, type, fallback)
 }
 
 @Composable
-internal fun ComposeAuth.signInWithCM(onResult: (NativeSignInResult) -> Unit, fallback: suspend () -> Unit): NativeSignInState{
+internal fun ComposeAuth.signInWithCM(
+    onResult: (NativeSignInResult) -> Unit,
+    type: GoogleDialogType,
+    fallback: suspend () -> Unit
+): NativeSignInState{
     val state = remember { NativeSignInState(serializer) }
     val context = LocalContext.current
 
@@ -50,7 +61,7 @@ internal fun ComposeAuth.signInWithCM(onResult: (NativeSignInResult) -> Unit, fa
                 if (activity != null && config.googleLoginConfig != null) {
                     val hashedNonce = status.nonce?.hash()
                     ComposeAuth.logger.d { "Starting Google Sign In Flow${if(hashedNonce != null) " with hashed nonce: $hashedNonce" else ""}" }
-                    val response = makeRequest(context, activity, config, hashedNonce)
+                    val response = makeRequest(context, activity, config, hashedNonce, type)
                     if(response == null) {
                         onResult.invoke(NativeSignInResult.ClosedByUser)
                         ComposeAuth.logger.d { "Google Sign In Flow was closed by user" }
@@ -136,27 +147,39 @@ internal actual suspend fun handleGoogleSignOut() {
 }
 
 private suspend fun tryRequest(
-    context: android.content.Context,
-    activity: android.app.Activity,
+    context: Context,
+    activity: Activity,
     config: ComposeAuth.Config,
-    nonce: String?
+    nonce: String?,
+    type: GoogleDialogType,
+    onlyAuthorizedAccounts: Boolean = true
 ): GetCredentialResponse {
+    val option = when(type) {
+        GoogleDialogType.BOTTOM_SHEET -> getGoogleBottomSheetOptions(config.googleLoginConfig, onlyAuthorizedAccounts, nonce)
+        GoogleDialogType.DIALOG -> getGoogleButtonOptions(config.googleLoginConfig, nonce)
+    }
     val request = GetCredentialRequest.Builder()
-        .addCredentialOption(getSignInWithGoogleOptions(config.googleLoginConfig, nonce))
+        .addCredentialOption(option)
         .build()
     return CredentialManager.create(context).getCredential(activity, request)
 }
 
 private suspend fun makeRequest(
-    context: android.content.Context,
-    activity: android.app.Activity,
+    context: Context,
+    activity: Activity,
     config: ComposeAuth.Config,
-    nonce: String?
+    nonce: String?,
+    type: GoogleDialogType
 ): GetCredentialResponse? {
     return try {
         ComposeAuth.logger.d { "Trying to get Google ID Token Credential" }
-        tryRequest(context, activity, config, nonce)
+        tryRequest(context, activity, config, nonce, type)
     } catch(e: GetCredentialCancellationException) {
         return null
+    } catch(e: GetCredentialException) {
+        if(type == GoogleDialogType.BOTTOM_SHEET) {
+            ComposeAuth.logger.d { "Error while trying to get Google ID Token Credential. Retrying without only authorized accounts" }
+            tryRequest(context, activity, config, nonce, type, false)
+        } else null
     }
 }

--- a/plugins/ComposeAuth/src/appleMain/kotlin/io/github/jan/supabase/compose/auth/composable/GoogleAuth.kt
+++ b/plugins/ComposeAuth/src/appleMain/kotlin/io/github/jan/supabase/compose/auth/composable/GoogleAuth.kt
@@ -14,6 +14,10 @@ import io.github.jan.supabase.compose.auth.defaultLoginBehavior
  * @return [NativeSignInState]
  */
 @Composable
-actual fun ComposeAuth.rememberSignInWithGoogle(onResult: (NativeSignInResult) -> Unit, fallback: suspend () -> Unit): NativeSignInState = defaultLoginBehavior(fallback)
+actual fun ComposeAuth.rememberSignInWithGoogle(
+    onResult: (NativeSignInResult) -> Unit,
+    type: GoogleDialogType,
+    fallback: suspend () -> Unit
+): NativeSignInState = defaultLoginBehavior(fallback)
 
 internal actual suspend fun handleGoogleSignOut() = Unit

--- a/plugins/ComposeAuth/src/commonMain/kotlin/io/github/jan/supabase/compose/auth/composable/NativeGoogleAuth.kt
+++ b/plugins/ComposeAuth/src/commonMain/kotlin/io/github/jan/supabase/compose/auth/composable/NativeGoogleAuth.kt
@@ -6,6 +6,20 @@ import io.github.jan.supabase.compose.auth.ComposeAuth
 import io.github.jan.supabase.compose.auth.fallbackLogin
 
 /**
+ * Enum class for the type of Google Dialog
+ */
+enum class GoogleDialogType {
+    /**
+     * A bottom sheet dialog
+     */
+    BOTTOM_SHEET,
+    /**
+     * A standard dialog
+     */
+    DIALOG
+}
+
+/**
  * Composable function that implements Native Google Auth.
  *
  * On unsupported platforms it will use the [fallback]
@@ -17,6 +31,7 @@ import io.github.jan.supabase.compose.auth.fallbackLogin
 @Composable
 expect fun ComposeAuth.rememberSignInWithGoogle(
     onResult: (NativeSignInResult) -> Unit = {},
+    type: GoogleDialogType = GoogleDialogType.DIALOG,
     fallback: suspend () -> Unit = {
         fallbackLogin(Google)
     }

--- a/plugins/ComposeAuth/src/commonMain/kotlin/io/github/jan/supabase/compose/auth/composable/NativeGoogleAuth.kt
+++ b/plugins/ComposeAuth/src/commonMain/kotlin/io/github/jan/supabase/compose/auth/composable/NativeGoogleAuth.kt
@@ -1,3 +1,4 @@
+@file:Suppress("MatchingDeclarationName")
 package io.github.jan.supabase.compose.auth.composable
 
 import androidx.compose.runtime.Composable

--- a/plugins/ComposeAuth/src/noDefaultMain/kotlin/io/github/jan/supabase/compose/auth/composable/GoogleAuth.kt
+++ b/plugins/ComposeAuth/src/noDefaultMain/kotlin/io/github/jan/supabase/compose/auth/composable/GoogleAuth.kt
@@ -14,6 +14,10 @@ import io.github.jan.supabase.compose.auth.defaultLoginBehavior
  * @return [NativeSignInState]
  */
 @Composable
-actual fun ComposeAuth.rememberSignInWithGoogle(onResult: (NativeSignInResult) -> Unit, fallback: suspend () -> Unit): NativeSignInState = defaultLoginBehavior(fallback)
+actual fun ComposeAuth.rememberSignInWithGoogle(
+    onResult: (NativeSignInResult) -> Unit,
+    type: GoogleDialogType,
+    fallback: suspend () -> Unit
+): NativeSignInState = defaultLoginBehavior(fallback)
 
 internal actual suspend fun handleGoogleSignOut() = Unit


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature (closes #79)

## What is the current behavior?

You always use the dialog option.

## What is the new behavior?

You can specify a `type` parameter which can either be `GoogleDialogType.BOTTOM_SHEET` or `GoogleDialogType.DIALOG`
