### PR TITLE
Make `HttpRequestException` inherit from `IOException`

### DIFF
--- a/Supabase/src/commonMain/kotlin/io/github/jan/supabase/exceptions/HttpRequestException.kt
+++ b/Supabase/src/commonMain/kotlin/io/github/jan/supabase/exceptions/HttpRequestException.kt
@@ -1,8 +1,9 @@
 package io.github.jan.supabase.exceptions
 
 import io.ktor.client.request.HttpRequestBuilder
+import kotlinx.io.IOException
 
 /**
  * An exception that is thrown when a request fails due to network issues
  */
-class HttpRequestException(message: String, request: HttpRequestBuilder): Exception("HTTP request to ${request.url.buildString()} (${request.method.value}) failed with message: $message")
+class HttpRequestException(message: String, request: HttpRequestBuilder): IOException("HTTP request to ${request.url.buildString()} (${request.method.value}) failed with message: $message")


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature/Fix (closes #846)

## What is the current behavior?

`HttpRequestException` is a "normal" exception, in the contrary to the `HttpRequestTimeoutException` which inherits from `IOException`

## What is the new behavior?

`HttpRequestException` now inherits from `IOException`

