### PR TITLE
Adds AuthorizationDelegate & remember to fix Native Apple Login

### DIFF
--- a/plugins/ComposeAuth/src/appleMain/kotlin/io/github/jan/supabase/compose/auth/composable/AppleAuth.kt
+++ b/plugins/ComposeAuth/src/appleMain/kotlin/io/github/jan/supabase/compose/auth/composable/AppleAuth.kt
@@ -91,7 +91,7 @@ actual fun ComposeAuth.rememberSignInWithApple(
 }
 
 @BetaInteropApi
-class AuthorizationDelegate(
+internal class AuthorizationDelegate(
     private val composeAuth: ComposeAuth,
     private val scope: CoroutineScope,
     private val status: NativeSignInStatus.Started,

--- a/plugins/ComposeAuth/src/appleMain/kotlin/io/github/jan/supabase/compose/auth/composable/AppleAuth.kt
+++ b/plugins/ComposeAuth/src/appleMain/kotlin/io/github/jan/supabase/compose/auth/composable/AppleAuth.kt
@@ -2,8 +2,11 @@ package io.github.jan.supabase.compose.auth.composable
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import io.github.jan.supabase.compose.auth.ComposeAuth
 import io.github.jan.supabase.compose.auth.hash
 import io.github.jan.supabase.compose.auth.signInWithApple
@@ -46,6 +49,7 @@ actual fun ComposeAuth.rememberSignInWithApple(
 ): NativeSignInState {
     val state = remember { NativeSignInState(this.serializer) }
     val scope = rememberCoroutineScope()
+    var authorizationDelegate by remember { mutableStateOf<AuthorizationDelegate?>(null) }
 
     LaunchedEffect(key1 = state.status) {
         if (state.status is NativeSignInStatus.Started) {
@@ -61,14 +65,15 @@ actual fun ComposeAuth.rememberSignInWithApple(
                         nonce = hashedNonce
                     }
 
-                    val controller = ASAuthorizationController(listOf(request)).apply {
-                        delegate = authorizationController(scope, status) {
+                    authorizationDelegate =
+                        AuthorizationDelegate(this@rememberSignInWithApple, scope, status) {
                             onResult.invoke(it)
                             state.reset()
                         }
 
+                    val controller = ASAuthorizationController(listOf(request)).apply {
+                        delegate = authorizationDelegate
                         presentationContextProvider = presentationAnchor()
-
                     }
                     controller.performRequests()
                 } else {
@@ -86,40 +91,39 @@ actual fun ComposeAuth.rememberSignInWithApple(
 }
 
 @BetaInteropApi
-internal fun ComposeAuth.authorizationController(
-    scope: CoroutineScope,
-    status: NativeSignInStatus.Started,
-    onResult: (NativeSignInResult) -> Unit
-): ASAuthorizationControllerDelegateProtocol {
-    return object : NSObject(), ASAuthorizationControllerDelegateProtocol {
-        override fun authorizationController(
-            controller: ASAuthorizationController,
-            didCompleteWithAuthorization: ASAuthorization
-        ) {
-            try {
-                val credentials =
-                    didCompleteWithAuthorization.credential as? ASAuthorizationAppleIDCredential
-                credentials?.identityToken
-                    ?.let { NSString.create(it, encoding = NSUTF8StringEncoding)?.toString() }
-                    ?.let { idToken ->
-                        scope.launch {
-                            signInWithApple(idToken, status.nonce, status.extraData)
-                            onResult.invoke(NativeSignInResult.Success)
-                        }
+class AuthorizationDelegate(
+    private val composeAuth: ComposeAuth,
+    private val scope: CoroutineScope,
+    private val status: NativeSignInStatus.Started,
+    private val onResult: (NativeSignInResult) -> Unit
+) : NSObject(), ASAuthorizationControllerDelegateProtocol {
+    override fun authorizationController(
+        controller: ASAuthorizationController,
+        didCompleteWithAuthorization: ASAuthorization
+    ) {
+        try {
+            val credentials =
+                didCompleteWithAuthorization.credential as? ASAuthorizationAppleIDCredential
+            credentials?.identityToken
+                ?.let { NSString.create(it, encoding = NSUTF8StringEncoding)?.toString() }
+                ?.let { idToken ->
+                    scope.launch {
+                        composeAuth.signInWithApple(idToken, status.nonce, status.extraData)
+                        onResult.invoke(NativeSignInResult.Success)
                     }
-            } catch (e: Exception) {
-                onResult.invoke(NativeSignInResult.Error(e.message ?: "error"))
-            }
+                }
+        } catch (e: Exception) {
+            onResult.invoke(NativeSignInResult.Error(e.message ?: "error"))
         }
+    }
 
-        override fun authorizationController(
-            controller: ASAuthorizationController,
-            didCompleteWithError: NSError
-        ) {
-            when (didCompleteWithError.code.toUInt()) {
-                1001.toUInt() -> onResult.invoke(NativeSignInResult.ClosedByUser)
-                else -> onResult.invoke(NativeSignInResult.Error(didCompleteWithError.localizedDescription))
-            }
+    override fun authorizationController(
+        controller: ASAuthorizationController,
+        didCompleteWithError: NSError
+    ) {
+        when (didCompleteWithError.code.toUInt()) {
+            1001.toUInt() -> onResult.invoke(NativeSignInResult.ClosedByUser)
+            else -> onResult.invoke(NativeSignInResult.Error(didCompleteWithError.localizedDescription))
         }
     }
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bugfix for Apple Native Sign In (on iOS)

## What is the current behavior?

When using ComposeAuth `rememberSignInWithApple` on iOS, there is no response after the Native Apple Sign-In Dialog. `onResult` is never called. 

It seems that this is because the reference to the AuthorizationDelegate is not kept when pausing/resuming the App.

## What is the new behavior?

Converted AutorizationDelegate to a class & `remember` it. When using `rememberSignInWithApple` the onResult is now called properly.

https://github.com/user-attachments/assets/6e33c514-fc29-4473-ac6d-ed18c3bbfba8



## Additional context

I was not able to test it properly in the `supabase-kt` project. After uploading to `mavenLocal` the login failed with the error below. However, when I copied the same code in my project and used supabase `3.1.1` from mavenLocal it worked perfectly. In my opinion this error might be related to something else?

```
 Function 'dropCompressionHeaders' can not be called: No function found for symbol 'io.ktor.client.utils/dropCompressionHeaders|dropCompressionHeaders@io.ktor.http.HeadersBuilder(io.ktor.http.HttpMethod;io.ktor.util.Attributes){}[0]'
    at 0   ReceiptKit.debug.dylib              0x10681c473        kfun:kotlin.Throwable#<init>(kotlin.String?){} + 99 
    at 1   ReceiptKit.debug.dylib              0x106815fcb        kfun:kotlin.Error#<init>(kotlin.String?){} + 95 
    at 2   ReceiptKit.debug.dylib              0x10685025b        kfun:kotlin.native.internal.IrLinkageError#<init>(kotlin.String?){} + 95 
    at 3   ReceiptKit.debug.dylib              0x106850313        kfun:kotlin.native.internal#ThrowIrLinkageError(kotlin.String?){}kotlin.Nothing + 163 
    at 4   ReceiptKit.debug.dylib              0x107e05c1f        kfun:io.ktor.client.engine.darwin.internal.readHeaders$1.invoke#internal + 1547 
    at 5   ReceiptKit.debug.dylib              0x107e05cef        kfun:io.ktor.client.engine.darwin.internal.readHeaders$1.$<bridge-DNNN>invoke(

```