### PR TITLE
Fix JS/Wasm hash check 

### DIFF
--- a/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/AuthImpl.kt
+++ b/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/AuthImpl.kt
@@ -369,6 +369,9 @@ internal class AuthImpl(
 
     override suspend fun exchangeCodeForSession(code: String, saveSession: Boolean): UserSession {
         val codeVerifier = codeVerifierCache.loadCodeVerifier()
+        require(codeVerifier != null) {
+            "No code verifier stored. Make sure to use `getOAuthUrl` for the OAuth Url to prepare the PKCE flow."
+        }
         val session = api.postJson("token?grant_type=pkce", buildJsonObject {
             put("auth_code", code)
             put("code_verifier", codeVerifier)

--- a/Auth/src/jsMain/kotlin/io/github/jan/supabase/auth/setupPlatform.kt
+++ b/Auth/src/jsMain/kotlin/io/github/jan/supabase/auth/setupPlatform.kt
@@ -23,7 +23,7 @@ actual fun Auth.setupPlatform() {
 
         parseFragmentAndImportSession(afterHash) {
             val newURL = window.location.href.split("?")[0];
-            window.history.replaceState({}, window.document.title, newURL);
+            window.history.replaceState(null, window.document.title, newURL);
         }
     }
 
@@ -35,7 +35,7 @@ actual fun Auth.setupPlatform() {
             importSession(session, source = SessionSource.External)
         }
         val newURL = window.location.href.split("?")[0];
-        window.history.replaceState({}, window.document.title, newURL);
+        window.history.replaceState(null, window.document.title, newURL);
     }
 
     if(IS_BROWSER) {

--- a/Auth/src/jsMain/kotlin/io/github/jan/supabase/auth/setupPlatform.kt
+++ b/Auth/src/jsMain/kotlin/io/github/jan/supabase/auth/setupPlatform.kt
@@ -2,6 +2,7 @@ package io.github.jan.supabase.auth
 
 import io.github.jan.supabase.annotations.SupabaseInternal
 import io.github.jan.supabase.auth.status.SessionSource
+import io.github.jan.supabase.logging.d
 import io.ktor.util.PlatformUtils.IS_BROWSER
 import kotlinx.browser.window
 import kotlinx.coroutines.launch
@@ -20,9 +21,9 @@ actual fun Auth.setupPlatform() {
             // No params after hash, no need to continue
             return
         }
-
+        Auth.logger.d { "Found hash: $afterHash" }
         parseFragmentAndImportSession(afterHash) {
-            val newURL = window.location.href.split("?")[0];
+            val newURL = window.location.href.split("#")[0];
             window.history.replaceState(null, window.document.title, newURL);
         }
     }
@@ -30,6 +31,7 @@ actual fun Auth.setupPlatform() {
     fun checkForPCKECode() {
         val url = URL(window.location.href)
         val code = url.searchParams.get("code") ?: return
+        Auth.logger.d { "Found PCKE code: $code" }
         authScope.launch {
             val session = exchangeCodeForSession(code)
             importSession(session, source = SessionSource.External)
@@ -39,12 +41,13 @@ actual fun Auth.setupPlatform() {
     }
 
     if(IS_BROWSER) {
+        Auth.logger.d { "Checking for hash..." }
+        checkForHash()
+        Auth.logger.d { "Checking for PCKE code..." }
+        checkForPCKECode()
+        Auth.logger.d { "Registering hash change listener..." }
         window.onhashchange = {
             checkForHash()
-        }
-        window.onload = {
-            checkForHash()
-            checkForPCKECode()
         }
     }
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix

## What is the current behavior?

Currently an error is thrown on initialisation since a closure is not a valid state object (it is not cloneable).

![image](https://github.com/user-attachments/assets/c94797ae-c8da-4c86-b021-f5df1208347d)

## What is the new behavior?

The code works as expected.

## Additional context

The WASM JS checks are [implemented correctly](https://github.com/supabase-community/supabase-kt/blob/2beaac5831f3988fe4fc44be32361b5e009748cd/Auth/src/wasmJsMain/kotlin/io/github/jan/supabase/auth/setupPlatform.kt#L25).
