### PR TITLE
Fix KotlinXSerializer not using custom serializers

### DIFF
--- a/Supabase/src/commonMain/kotlin/io/github/jan/supabase/serializer/KotlinXSerializer.kt
+++ b/Supabase/src/commonMain/kotlin/io/github/jan/supabase/serializer/KotlinXSerializer.kt
@@ -14,6 +14,6 @@ class KotlinXSerializer(private val json: Json = Json) : SupabaseSerializer {
 
     @Suppress("UNCHECKED_CAST")
     override fun <T : Any> decode(type: KType, value: String): T =
-        json.decodeFromString(serializer(type), value) as T
+        json.decodeFromString(json.serializersModule.serializer(type), value) as T
 
 }

--- a/Supabase/src/commonMain/kotlin/io/github/jan/supabase/serializer/KotlinXSerializer.kt
+++ b/Supabase/src/commonMain/kotlin/io/github/jan/supabase/serializer/KotlinXSerializer.kt
@@ -10,7 +10,7 @@ import kotlin.reflect.KType
  */
 class KotlinXSerializer(private val json: Json = Json) : SupabaseSerializer {
 
-    override fun <T : Any> encode(type: KType, value: T): String = json.encodeToString(serializer(type), value)
+    override fun <T : Any> encode(type: KType, value: T): String = json.encodeToString(json.serializersModule.serializer(type), value)
 
     @Suppress("UNCHECKED_CAST")
     override fun <T : Any> decode(type: KType, value: String): T =


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (closes #880)

## What is the current behavior?

The KotlinXSerializer uses the top level `serializer()` method for getting the serializer for a given KType.

## What is the new behavior?

The `serializer()` method from the provided `serializersModule` is used.