### PR TITLE
Remove sealed modifier where its not needed

### DIFF
--- a/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/Auth.kt
+++ b/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/Auth.kt
@@ -46,7 +46,7 @@ import kotlinx.serialization.json.JsonObject
  * }
  * ```
  */
-sealed interface Auth : MainPlugin<AuthConfig>, CustomSerializationPlugin {
+interface Auth : MainPlugin<AuthConfig>, CustomSerializationPlugin {
 
     /**
      * Returns the current session status

--- a/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/admin/AdminApi.kt
+++ b/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/admin/AdminApi.kt
@@ -23,7 +23,7 @@ import kotlinx.serialization.json.put
 /**
  * The admin interface for the supabase auth module. Service role access token is required. Import it via [Auth.importAuthToken]. Never share it publicly
  */
-sealed interface AdminApi {
+interface AdminApi {
 
     /**
      * Creates a new user using an email and password

--- a/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/mfa/MfaApi.kt
+++ b/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/mfa/MfaApi.kt
@@ -21,7 +21,7 @@ import kotlinx.serialization.json.put
 /**
  * An interface for interacting with Multi-Factor Authentication Api in GoTrue.
  */
-sealed interface MfaApi {
+interface MfaApi {
 
     /**
      * The current MFA status of the user

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/Postgrest.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/Postgrest.kt
@@ -36,7 +36,7 @@ import kotlinx.serialization.json.JsonObject
  * ```
  */
 
-sealed interface Postgrest : MainPlugin<Postgrest.Config>, CustomSerializationPlugin {
+interface Postgrest : MainPlugin<Postgrest.Config>, CustomSerializationPlugin {
 
     /**
      * Creates a new [PostgrestQueryBuilder] for the given table

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/Realtime.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/Realtime.kt
@@ -46,7 +46,7 @@ import kotlin.time.Duration.Companion.seconds
  * channel.subscribe()
  * ```
  */
-sealed interface Realtime : MainPlugin<Realtime.Config>, CustomSerializationPlugin {
+interface Realtime : MainPlugin<Realtime.Config>, CustomSerializationPlugin {
 
     /**
      * The current status of the realtime connection

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeChannel.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeChannel.kt
@@ -14,7 +14,7 @@ import kotlin.reflect.typeOf
 /**
  * Represents a realtime channel
  */
-sealed interface RealtimeChannel {
+interface RealtimeChannel {
 
     /**
      * The status of the channel as a [StateFlow]

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/BucketApi.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/BucketApi.kt
@@ -13,7 +13,7 @@ import kotlin.time.Duration
 /**
  * The api for interacting with a bucket
  */
-sealed interface BucketApi {
+interface BucketApi {
 
     /**
      * The id of the bucket

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/Storage.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/Storage.kt
@@ -49,7 +49,7 @@ import kotlin.time.Duration.Companion.seconds
  * val bytes = bucket.downloadAuthenticated("icon.png")
  * ```
  */
-sealed interface Storage : MainPlugin<Storage.Config>, CustomSerializationPlugin {
+interface Storage : MainPlugin<Storage.Config>, CustomSerializationPlugin {
 
     /**
      * Creates a new bucket in the storage

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/resumable/ResumableClient.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/resumable/ResumableClient.kt
@@ -34,7 +34,7 @@ import kotlin.time.Duration.Companion.days
 /**
  * Represents a resumable client. Can be used to create or continue resumable uploads.
  */
-sealed interface ResumableClient {
+interface ResumableClient {
 
     /**
      * Creates a new resumable upload or continues an existing one.

--- a/Supabase/src/commonMain/kotlin/io/github/jan/supabase/SupabaseClient.kt
+++ b/Supabase/src/commonMain/kotlin/io/github/jan/supabase/SupabaseClient.kt
@@ -15,7 +15,7 @@ import io.github.jan.supabase.plugins.SupabasePlugin
  *
  * To add functionality, add plugins like **Auth** or **Functions** within the [SupabaseClientBuilder]
  */
-sealed interface SupabaseClient {
+interface SupabaseClient {
 
     /**
      * The supabase url with either a http or https scheme.

--- a/plugins/ApolloGraphQL/src/commonMain/kotlin/io/github/jan/supabase/graphql/GraphQL.kt
+++ b/plugins/ApolloGraphQL/src/commonMain/kotlin/io/github/jan/supabase/graphql/GraphQL.kt
@@ -16,7 +16,7 @@ import io.ktor.client.statement.HttpResponse
  *
  * This plugin uses the default GraphQL endpoint for supabase projects and adds the `apikey` and `Authorization` headers automatically
  */
-sealed interface GraphQL: MainPlugin<GraphQL.Config> {
+interface GraphQL: MainPlugin<GraphQL.Config> {
 
     /**
      * The Apollo Client. Customizable via [Config.apolloConfiguration]

--- a/plugins/ComposeAuth/src/commonMain/kotlin/io/github/jan/supabase/compose/auth/ComposeAuth.kt
+++ b/plugins/ComposeAuth/src/commonMain/kotlin/io/github/jan/supabase/compose/auth/ComposeAuth.kt
@@ -59,7 +59,7 @@ import kotlinx.serialization.json.JsonObject
  * }
  *  ```
  */
-sealed interface ComposeAuth : SupabasePlugin<ComposeAuth.Config>, CustomSerializationPlugin {
+interface ComposeAuth : SupabasePlugin<ComposeAuth.Config>, CustomSerializationPlugin {
 
     /**
      * Config for [ComposeAuth]


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix

## What is the current behavior?

Some interface have the `sealed` modifier, even though there are not needed. This makes it impossible to mock them.

## What is the new behavior?

The modifier has been removed from certain interfaces.
