### PR TITLE
Fix OAuth server listener resuming coroutine twice

### DIFF
--- a/Auth/src/desktopMain/kotlin/io/github/jan/supabase/auth/server/HttpCallbackServer.kt
+++ b/Auth/src/desktopMain/kotlin/io/github/jan/supabase/auth/server/HttpCallbackServer.kt
@@ -59,21 +59,16 @@ internal suspend fun createServer(
                 }
             }
         }
-        launch {
-            suspendCancellableCoroutine {
-                server.monitor.subscribe(ApplicationStopPreparing) { _ ->
-                    if(!it.isCompleted) {
-                        it.resume(Unit)
-                        timeoutScope.cancel()
-                    }
-                }
-                server.start()
-                it.invokeOnCancellation { _ ->
-                    server.stop()
-                    timeoutScope.cancel()
-                }
+        suspendCancellableCoroutine {
+            server.monitor.subscribe(ApplicationStopPreparing) { _ ->
+                it.resume(Unit)
+                timeoutScope.cancel()
             }
-        }.join()
+            server.start()
+            it.invokeOnCancellation { _ ->
+                server.stop()
+            }
+        }
     }
 }
 

--- a/Auth/src/desktopMain/kotlin/io/github/jan/supabase/auth/server/HttpCallbackServer.kt
+++ b/Auth/src/desktopMain/kotlin/io/github/jan/supabase/auth/server/HttpCallbackServer.kt
@@ -61,8 +61,10 @@ internal suspend fun createServer(
         }
         suspendCancellableCoroutine {
             server.monitor.subscribe(ApplicationStopPreparing) { _ ->
-                it.resume(Unit)
-                timeoutScope.cancel()
+                if(!it.isCompleted) {
+                    it.resume(Unit)
+                    timeoutScope.cancel()
+                }
             }
             server.start()
             it.invokeOnCancellation { _ ->

--- a/Auth/src/desktopMain/kotlin/io/github/jan/supabase/auth/server/HttpCallbackServer.kt
+++ b/Auth/src/desktopMain/kotlin/io/github/jan/supabase/auth/server/HttpCallbackServer.kt
@@ -62,11 +62,13 @@ internal suspend fun createServer(
         launch {
             suspendCancellableCoroutine {
                 server.monitor.subscribe(ApplicationStopPreparing) { _ ->
-                    it.resume(Unit)
-                    timeoutScope.cancel()
+                    if(!it.isCompleted) {
+                        it.resume(Unit)
+                        timeoutScope.cancel()
+                    }
                 }
                 server.start()
-                it.invokeOnCancellation {
+                it.invokeOnCancellation { _ ->
                     server.stop()
                     timeoutScope.cancel()
                 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (closes #890)

## What is the current behavior?

The stopping listener could cause the coroutine to be resumed multiple times

## What is the new behavior?

This has been fixed
