### PR TITLE
Fix exception on non-session hash parameters and only consume used parameters

### DIFF
--- a/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/Auth.kt
+++ b/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/Auth.kt
@@ -411,6 +411,17 @@ interface Auth : MainPlugin<AuthConfig>, CustomSerializationPlugin {
 
     companion object : SupabasePluginProvider<AuthConfig, Auth> {
 
+        internal val HASH_PARAMETERS = listOf(
+            "access_token",
+            "refresh_token",
+            "expires_in",
+            "expires_at",
+            "token_type",
+            "type",
+            "provider_refresh_token",
+            "provider_token"
+        )
+
         override val key = "auth"
 
         override val logger: SupabaseLogger = SupabaseClient.createLogger("Supabase-Auth")

--- a/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/UrlUtils.kt
+++ b/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/UrlUtils.kt
@@ -1,0 +1,48 @@
+package io.github.jan.supabase.auth
+
+import io.github.jan.supabase.annotations.SupabaseInternal
+import io.github.jan.supabase.auth.status.SessionSource
+import io.github.jan.supabase.auth.user.UserSession
+import io.github.jan.supabase.buildUrl
+import io.github.jan.supabase.logging.d
+import io.ktor.client.request.HttpRequestBuilder
+import kotlinx.coroutines.launch
+
+@SupabaseInternal
+fun Auth.parseFragmentAndImportSession(fragment: String, onSessionSuccess: (UserSession) -> Unit = {}) {
+    Auth.logger.d { "Parsing deeplink fragment $fragment" }
+    val session = try {
+        parseSessionFromFragment(fragment)
+    } catch(e: IllegalArgumentException) {
+        Auth.logger.d(e) { "Received invalid session fragment. Ignoring." }
+        return
+    }
+    this as AuthImpl
+    authScope.launch {
+        val user = retrieveUser(session.accessToken)
+        val newSession = session.copy(user = user)
+        onSessionSuccess(newSession)
+        importSession(newSession, source = SessionSource.External)
+    }
+}
+
+@SupabaseInternal
+fun HttpRequestBuilder.redirectTo(url: String) {
+    this.url.parameters["redirect_to"] = url
+}
+
+internal fun consumeHashParameters(parameters: List<String>, url: String): String {
+    return buildUrl(url) {
+        fragment = fragment.split("&").filter {
+            it.split("=").first() !in parameters
+        }.joinToString("&")
+    }
+}
+
+internal fun consumeUrlParameter(parameters: List<String>, url: String): String {
+    return buildUrl(url) {
+        parameters.forEach { parameter ->
+            this.parameters.remove(parameter)
+        }
+    }
+}

--- a/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/Utils.kt
+++ b/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/Utils.kt
@@ -4,6 +4,7 @@ import io.github.jan.supabase.SupabaseClient
 import io.github.jan.supabase.annotations.SupabaseInternal
 import io.github.jan.supabase.auth.status.SessionSource
 import io.github.jan.supabase.auth.user.UserSession
+import io.github.jan.supabase.buildUrl
 import io.github.jan.supabase.logging.d
 import io.ktor.client.request.HttpRequestBuilder
 import kotlinx.coroutines.launch
@@ -11,7 +12,12 @@ import kotlinx.coroutines.launch
 @SupabaseInternal
 fun Auth.parseFragmentAndImportSession(fragment: String, onSessionSuccess: (UserSession) -> Unit = {}) {
     Auth.logger.d { "Parsing deeplink fragment $fragment" }
-    val session = parseSessionFromFragment(fragment)
+    val session = try {
+        parseSessionFromFragment(fragment)
+    } catch(e: IllegalArgumentException) {
+        Auth.logger.d(e) { "Received invalid session fragment. Ignoring." }
+        return
+    }
     this as AuthImpl
     authScope.launch {
         val user = retrieveUser(session.accessToken)
@@ -24,6 +30,22 @@ fun Auth.parseFragmentAndImportSession(fragment: String, onSessionSuccess: (User
 @SupabaseInternal
 fun HttpRequestBuilder.redirectTo(url: String) {
     this.url.parameters["redirect_to"] = url
+}
+
+internal fun consumeHashParameters(parameters: List<String>, url: String): String {
+    return buildUrl(url) {
+        fragment = fragment.split("&").filter {
+            it.split("=").first() !in parameters
+        }.joinToString("&")
+    }
+}
+
+internal fun consumeUrlParameter(parameters: List<String>, url: String): String {
+    return buildUrl(url) {
+        parameters.forEach { parameter ->
+            this.parameters.remove(parameter)
+        }
+    }
 }
 
 internal fun invalidArg(message: String): Nothing = throw IllegalArgumentException(message)

--- a/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/Utils.kt
+++ b/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/Utils.kt
@@ -1,52 +1,7 @@
 package io.github.jan.supabase.auth
 
 import io.github.jan.supabase.SupabaseClient
-import io.github.jan.supabase.annotations.SupabaseInternal
-import io.github.jan.supabase.auth.status.SessionSource
 import io.github.jan.supabase.auth.user.UserSession
-import io.github.jan.supabase.buildUrl
-import io.github.jan.supabase.logging.d
-import io.ktor.client.request.HttpRequestBuilder
-import kotlinx.coroutines.launch
-
-@SupabaseInternal
-fun Auth.parseFragmentAndImportSession(fragment: String, onSessionSuccess: (UserSession) -> Unit = {}) {
-    Auth.logger.d { "Parsing deeplink fragment $fragment" }
-    val session = try {
-        parseSessionFromFragment(fragment)
-    } catch(e: IllegalArgumentException) {
-        Auth.logger.d(e) { "Received invalid session fragment. Ignoring." }
-        return
-    }
-    this as AuthImpl
-    authScope.launch {
-        val user = retrieveUser(session.accessToken)
-        val newSession = session.copy(user = user)
-        onSessionSuccess(newSession)
-        importSession(newSession, source = SessionSource.External)
-    }
-}
-
-@SupabaseInternal
-fun HttpRequestBuilder.redirectTo(url: String) {
-    this.url.parameters["redirect_to"] = url
-}
-
-internal fun consumeHashParameters(parameters: List<String>, url: String): String {
-    return buildUrl(url) {
-        fragment = fragment.split("&").filter {
-            it.split("=").first() !in parameters
-        }.joinToString("&")
-    }
-}
-
-internal fun consumeUrlParameter(parameters: List<String>, url: String): String {
-    return buildUrl(url) {
-        parameters.forEach { parameter ->
-            this.parameters.remove(parameter)
-        }
-    }
-}
 
 internal fun invalidArg(message: String): Nothing = throw IllegalArgumentException(message)
 

--- a/Auth/src/commonTest/kotlin/UrlUtilsTest.kt
+++ b/Auth/src/commonTest/kotlin/UrlUtilsTest.kt
@@ -1,9 +1,12 @@
 import io.github.jan.supabase.auth.consumeHashParameters
 import io.github.jan.supabase.auth.consumeUrlParameter
+import io.github.jan.supabase.auth.redirectTo
+import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.client.request.url
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-class UtilsTest {
+class UrlUtilsTest {
 
     @Test
     fun testConsumeHashParameters() {
@@ -18,6 +21,18 @@ class UtilsTest {
         val url = "https://example.com/?test=123&state=abc&code=xyz"
         val newUrl = consumeUrlParameter(listOf("test", "state"), url)
         val expectedUrl = "https://example.com/?code=xyz"
+        assertEquals(expectedUrl, newUrl)
+    }
+
+    @Test
+    fun testRedirectTo() {
+        val url = "https://example.com/"
+        val redirectTo = "https://redirect.com"
+        val newUrl = HttpRequestBuilder().apply {
+            url(url)
+            redirectTo(redirectTo)
+        }.url.toString()
+        val expectedUrl = "https://example.com/?redirect_to=https%3A%2F%2Fredirect.com"
         assertEquals(expectedUrl, newUrl)
     }
 

--- a/Auth/src/commonTest/kotlin/UtilsTest.kt
+++ b/Auth/src/commonTest/kotlin/UtilsTest.kt
@@ -1,0 +1,24 @@
+import io.github.jan.supabase.auth.consumeHashParameters
+import io.github.jan.supabase.auth.consumeUrlParameter
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class UtilsTest {
+
+    @Test
+    fun testConsumeHashParameters() {
+        val url = "https://example.com/#test=123&state=abc&code=xyz"
+        val newUrl = consumeHashParameters(listOf("test", "state"), url)
+        val expectedUrl = "https://example.com/#code=xyz"
+        assertEquals(expectedUrl, newUrl)
+    }
+
+    @Test
+    fun testConsumeUrlParameter() {
+        val url = "https://example.com/?test=123&state=abc&code=xyz"
+        val newUrl = consumeUrlParameter(listOf("test", "state"), url)
+        val expectedUrl = "https://example.com/?code=xyz"
+        assertEquals(expectedUrl, newUrl)
+    }
+
+}

--- a/Auth/src/jsMain/kotlin/io/github/jan/supabase/auth/setupPlatform.kt
+++ b/Auth/src/jsMain/kotlin/io/github/jan/supabase/auth/setupPlatform.kt
@@ -23,7 +23,7 @@ actual fun Auth.setupPlatform() {
         }
         Auth.logger.d { "Found hash: $afterHash" }
         parseFragmentAndImportSession(afterHash) {
-            val newURL = window.location.href.split("#")[0];
+            val newURL = consumeHashParameters(Auth.HASH_PARAMETERS, window.location.href)
             window.history.replaceState(null, window.document.title, newURL);
         }
     }
@@ -36,7 +36,7 @@ actual fun Auth.setupPlatform() {
             val session = exchangeCodeForSession(code)
             importSession(session, source = SessionSource.External)
         }
-        val newURL = window.location.href.split("?")[0];
+        val newURL = consumeUrlParameter(listOf("code"), window.location.href)
         window.history.replaceState(null, window.document.title, newURL);
     }
 

--- a/Auth/src/wasmJsMain/kotlin/io/github/jan/supabase/auth/setupPlatform.kt
+++ b/Auth/src/wasmJsMain/kotlin/io/github/jan/supabase/auth/setupPlatform.kt
@@ -21,7 +21,7 @@ actual fun Auth.setupPlatform() {
         }
         Auth.logger.d { "Found hash: $afterHash" }
         parseFragmentAndImportSession(afterHash) {
-            val newURL = window.location.href.split("#")[0];
+            val newURL = consumeHashParameters(Auth.HASH_PARAMETERS, window.location.href)
             window.history.replaceState(null, window.document.title, newURL);
         }
     }
@@ -34,7 +34,7 @@ actual fun Auth.setupPlatform() {
             val session = exchangeCodeForSession(code)
             importSession(session)
         }
-        val newURL = window.location.href.split("?")[0];
+        val newURL = consumeUrlParameter(listOf("code"), window.location.href)
         window.history.replaceState(null, window.document.title, newURL);
     }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,7 +8,7 @@ pluginManagement {
 }
 
 plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention") version("0.8.0")
+    id("org.gradle.toolchains.foojay-resolver-convention") version("0.10.0")
 }
 
 // Main Modules


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (closes #910)

## What is the current behavior?

Exception on non-session hash parameters and all other hash parameters get removed

## What is the new behavior?

This has been fixed.
