### PR TITLE
Fix session expiration check

### DIFF
--- a/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/AuthImpl.kt
+++ b/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/AuthImpl.kt
@@ -423,8 +423,9 @@ internal class AuthImpl(
             Auth.logger.d { "Session imported successfully." }
             return
         }
-        if (session.expiresAt <= Clock.System.now()) {
-            Auth.logger.d { "Session is expired. Handling expired session..." }
+        val thresholdDate = session.expiresAt - session.expiresIn.seconds * (1 - SESSION_REFRESH_THRESHOLD)
+        if (thresholdDate <= Clock.System.now()) {
+            Auth.logger.d { "Session is under the threshold date. Refreshing session..." }
             tryImportingSession(
                 { handleExpiredSession(session, config.alwaysAutoRefresh) },
                 { importSession(session) }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (see https://github.com/supabase-community/supabase-kt/issues/906#issuecomment-2830202582)

## What is the current behavior?

If loading in a new session, it is only checked if the session is already expired.

## What is the new behavior?

The expiration threshold from the auto refresh mechanism is now also taken into account. (So the session get refreshed earlier)