### PR TITLE
 Deprecate minimalSettings in favor of minimalConfig

### DIFF
--- a/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/AuthConfig.kt
+++ b/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/AuthConfig.kt
@@ -148,6 +148,7 @@ val AuthConfig.deepLinkOrNull: String?
  * @param enableLifecycleCallbacks Whether to stop auto-refresh on focus loss, and resume it on focus again. Currently only supported on Android.
  * @see AuthConfigDefaults
  */
+@Deprecated("Use the new minimalConfig function instead", ReplaceWith("minimalConfig()"))
 @Suppress("LongParameterList", "unused")
 fun AuthConfigDefaults.minimalSettings(
     alwaysAutoRefresh: Boolean = false,

--- a/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/MinimalConfig.kt
+++ b/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/MinimalConfig.kt
@@ -1,0 +1,15 @@
+package io.github.jan.supabase.auth
+
+/**
+ * Applies minimal configuration to the [AuthConfig]. This is useful for server side applications, where you don't need to store the session or code verifier.
+ * @see AuthConfigDefaults
+ */
+fun AuthConfigDefaults.minimalConfig() {
+    this.alwaysAutoRefresh = false
+    this.autoLoadFromStorage = false
+    this.autoSaveToStorage = false
+    this.sessionManager = MemorySessionManager()
+    this.codeVerifierCache = MemoryCodeVerifierCache()
+    this.enableLifecycleCallbacks = false
+}
+

--- a/Auth/src/commonTest/kotlin/AccessTokenTest.kt
+++ b/Auth/src/commonTest/kotlin/AccessTokenTest.kt
@@ -1,6 +1,6 @@
 import io.github.jan.supabase.auth.Auth
 import io.github.jan.supabase.auth.auth
-import io.github.jan.supabase.auth.minimalSettings
+import io.github.jan.supabase.auth.minimalConfig
 import io.github.jan.supabase.auth.resolveAccessToken
 import io.github.jan.supabase.testing.createMockedSupabaseClient
 import kotlinx.coroutines.test.runTest
@@ -16,7 +16,7 @@ class AccessTokenTest {
             val client = createMockedSupabaseClient(
                 configuration = {
                     install(Auth) {
-                        minimalSettings()
+                        minimalConfig()
                     }
                 }
             )
@@ -61,7 +61,7 @@ class AccessTokenTest {
             val client = createMockedSupabaseClient(
                 configuration = {
                     install(Auth) {
-                        minimalSettings()
+                        minimalConfig()
                     }
                 }
             )

--- a/Auth/src/commonTest/kotlin/AdminApiTest.kt
+++ b/Auth/src/commonTest/kotlin/AdminApiTest.kt
@@ -4,7 +4,7 @@ import io.github.jan.supabase.auth.SignOutScope
 import io.github.jan.supabase.auth.admin.LinkType
 import io.github.jan.supabase.auth.admin.generateLinkFor
 import io.github.jan.supabase.auth.auth
-import io.github.jan.supabase.auth.minimalSettings
+import io.github.jan.supabase.auth.minimalConfig
 import io.github.jan.supabase.auth.user.UserInfo
 import io.github.jan.supabase.auth.user.UserMfaFactor
 import io.github.jan.supabase.testing.assertMethodIs
@@ -17,7 +17,6 @@ import io.ktor.client.engine.mock.respond
 import io.ktor.http.HttpMethod
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Clock
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.boolean
 import kotlinx.serialization.json.buildJsonObject
@@ -32,7 +31,7 @@ class AdminApiTest {
 
     private val configuration: SupabaseClientBuilder.() -> Unit = {
         install(Auth) {
-            minimalSettings()
+            minimalConfig()
         }
     }
 

--- a/Auth/src/commonTest/kotlin/AuthApiTest.kt
+++ b/Auth/src/commonTest/kotlin/AuthApiTest.kt
@@ -6,7 +6,7 @@ import io.github.jan.supabase.auth.OtpType
 import io.github.jan.supabase.auth.PKCEConstants
 import io.github.jan.supabase.auth.SignOutScope
 import io.github.jan.supabase.auth.auth
-import io.github.jan.supabase.auth.minimalSettings
+import io.github.jan.supabase.auth.minimalConfig
 import io.github.jan.supabase.auth.providers.Google
 import io.github.jan.supabase.auth.providers.builtin.Email
 import io.github.jan.supabase.auth.providers.builtin.IDToken
@@ -37,7 +37,7 @@ class AuthRequestTest {
 
     private val configuration: SupabaseClientBuilder.() -> Unit = {
         install(Auth) {
-            minimalSettings()
+            minimalConfig()
             flowType = FlowType.PKCE
         }
     }

--- a/Auth/src/commonTest/kotlin/AuthRestExceptionTest.kt
+++ b/Auth/src/commonTest/kotlin/AuthRestExceptionTest.kt
@@ -3,7 +3,7 @@ import io.github.jan.supabase.auth.Auth
 import io.github.jan.supabase.auth.auth
 import io.github.jan.supabase.auth.exception.AuthRestException
 import io.github.jan.supabase.auth.exception.AuthWeakPasswordException
-import io.github.jan.supabase.auth.minimalSettings
+import io.github.jan.supabase.auth.minimalConfig
 import io.github.jan.supabase.auth.providers.builtin.Email
 import io.github.jan.supabase.exceptions.BadRequestRestException
 import io.github.jan.supabase.testing.createMockedSupabaseClient
@@ -25,7 +25,7 @@ class AuthRestExceptionTest {
 
     private val configuration: SupabaseClientBuilder.() -> Unit = {
         install(Auth) {
-            minimalSettings()
+            minimalConfig()
         }
     }
 

--- a/Auth/src/commonTest/kotlin/AuthTest.kt
+++ b/Auth/src/commonTest/kotlin/AuthTest.kt
@@ -2,6 +2,7 @@ import io.github.jan.supabase.SupabaseClientBuilder
 import io.github.jan.supabase.auth.Auth
 import io.github.jan.supabase.auth.MemorySessionManager
 import io.github.jan.supabase.auth.auth
+import io.github.jan.supabase.auth.minimalConfig
 import io.github.jan.supabase.auth.minimalSettings
 import io.github.jan.supabase.auth.providers.Github
 import io.github.jan.supabase.auth.status.SessionStatus
@@ -24,7 +25,7 @@ class AuthTest {
 
     private val configuration: SupabaseClientBuilder.() -> Unit = {
         install(Auth) {
-            minimalSettings()
+            minimalConfig()
         }
     }
 

--- a/Auth/src/commonTest/kotlin/MfaApiTest.kt
+++ b/Auth/src/commonTest/kotlin/MfaApiTest.kt
@@ -5,7 +5,7 @@ import io.github.jan.supabase.auth.auth
 import io.github.jan.supabase.auth.mfa.AuthenticatorAssuranceLevel
 import io.github.jan.supabase.auth.mfa.FactorType
 import io.github.jan.supabase.auth.mfa.MfaStatus
-import io.github.jan.supabase.auth.minimalSettings
+import io.github.jan.supabase.auth.minimalConfig
 import io.github.jan.supabase.auth.providers.builtin.Phone
 import io.github.jan.supabase.auth.user.UserInfo
 import io.github.jan.supabase.auth.user.UserMfaFactor
@@ -33,7 +33,7 @@ class MfaApiTest {
 
     private val configuration: SupabaseClientBuilder.() -> Unit = {
         install(Auth) {
-            minimalSettings()
+            minimalConfig()
         }
     }
 

--- a/Functions/src/commonTest/kotlin/FunctionsTest.kt
+++ b/Functions/src/commonTest/kotlin/FunctionsTest.kt
@@ -1,7 +1,7 @@
 import io.github.jan.supabase.SupabaseClientBuilder
 import io.github.jan.supabase.auth.Auth
 import io.github.jan.supabase.auth.auth
-import io.github.jan.supabase.auth.minimalSettings
+import io.github.jan.supabase.auth.minimalConfig
 import io.github.jan.supabase.functions.FunctionRegion
 import io.github.jan.supabase.functions.Functions
 import io.github.jan.supabase.functions.functions
@@ -32,7 +32,7 @@ class FunctionsTest {
             val supabase = createMockedSupabaseClient(
                 configuration ={
                     install(Auth) {
-                        minimalSettings()
+                        minimalConfig()
                     }
                     configuration()
                 },

--- a/Realtime/src/commonTest/kotlin/RealtimeChannelTest.kt
+++ b/Realtime/src/commonTest/kotlin/RealtimeChannelTest.kt
@@ -1,7 +1,7 @@
 import app.cash.turbine.test
 import io.github.jan.supabase.auth.Auth
 import io.github.jan.supabase.auth.auth
-import io.github.jan.supabase.auth.minimalSettings
+import io.github.jan.supabase.auth.minimalConfig
 import io.github.jan.supabase.postgrest.query.filter.FilterOperation
 import io.github.jan.supabase.postgrest.query.filter.FilterOperator
 import io.github.jan.supabase.realtime.CallbackManagerImpl
@@ -164,7 +164,7 @@ class RealtimeChannelTest {
                 },
                 supabaseConfig = {
                     install(Auth) {
-                        minimalSettings()
+                        minimalConfig()
                     }
                 }
             )

--- a/Storage/src/commonTest/kotlin/StorageTest.kt
+++ b/Storage/src/commonTest/kotlin/StorageTest.kt
@@ -1,7 +1,7 @@
 import io.github.jan.supabase.SupabaseClientBuilder
 import io.github.jan.supabase.auth.Auth
 import io.github.jan.supabase.auth.auth
-import io.github.jan.supabase.auth.minimalSettings
+import io.github.jan.supabase.auth.minimalConfig
 import io.github.jan.supabase.storage.Storage
 import io.github.jan.supabase.storage.resumable.MemoryResumableCache
 import io.github.jan.supabase.storage.storage
@@ -202,7 +202,7 @@ class StorageTest {
                         }
                     }
                     install(Auth) {
-                        minimalSettings()
+                        minimalConfig()
                         enableLifecycleCallbacks = false
                     }
                 }

--- a/plugins/ApolloGraphQL/src/commonTest/kotlin/ApolloHttpInterceptorTest.kt
+++ b/plugins/ApolloGraphQL/src/commonTest/kotlin/ApolloHttpInterceptorTest.kt
@@ -7,7 +7,7 @@ import com.apollographql.apollo.network.http.HttpInterceptorChain
 import io.github.jan.supabase.SupabaseClient
 import io.github.jan.supabase.auth.Auth
 import io.github.jan.supabase.auth.auth
-import io.github.jan.supabase.auth.minimalSettings
+import io.github.jan.supabase.auth.minimalConfig
 import io.github.jan.supabase.graphql.ApolloHttpInterceptor
 import io.github.jan.supabase.graphql.GraphQL
 import io.github.jan.supabase.graphql.graphql
@@ -38,7 +38,7 @@ class ApolloHttpInterceptorTest {
                 configuration = {
                     install(GraphQL)
                     install(Auth) {
-                        minimalSettings()
+                        minimalConfig()
                     }
                 }
             )

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -21,6 +21,7 @@ include("Supabase")
 include("bom")
 
 // Test module
+include("test")
 include("test-common")
 
 // Serializers

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -21,7 +21,6 @@ include("Supabase")
 include("bom")
 
 // Test module
-include("test")
 include("test-common")
 
 // Serializers


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

`AuthConfigDefaults#minimalSettings()` has a very long parameter list, which are not really needed since you can just override them after calling this method.

## What is the new behavior?

New `AuthConfigDefaults#minimalConfig()` method without parameters, and deprecation of the old method
