### PR TITLE
Fix null result when sign up with Email provider

### DIFF
--- a/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/providers/builtin/DefaultAuthProvider.kt
+++ b/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/providers/builtin/DefaultAuthProvider.kt
@@ -19,6 +19,7 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.decodeFromJsonElement
+import kotlinx.serialization.json.jsonObject
 
 /**
  * A default authentication provider
@@ -96,7 +97,8 @@ sealed interface DefaultAuthProvider<C, R> : AuthProvider<C, R> {
         if (json.containsKey("access_token")) {
             val userSession = supabaseJson.decodeFromJsonElement<UserSession>(json)
             onSuccess(userSession)
-            return decodeResult(json)
+            val userJson = json["user"]?.jsonObject ?: buildJsonObject { }
+            return decodeResult(userJson)
         }
         return decodeResult(json)
     }

--- a/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/providers/builtin/DefaultAuthProvider.kt
+++ b/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/providers/builtin/DefaultAuthProvider.kt
@@ -1,7 +1,6 @@
 package io.github.jan.supabase.auth.providers.builtin
 
 import io.github.jan.supabase.SupabaseClient
-import io.github.jan.supabase.annotations.SupabaseExperimental
 import io.github.jan.supabase.annotations.SupabaseInternal
 import io.github.jan.supabase.auth.AuthImpl
 import io.github.jan.supabase.auth.FlowType
@@ -65,7 +64,6 @@ sealed interface DefaultAuthProvider<C, R> : AuthProvider<C, R> {
         }
     }
 
-    @OptIn(SupabaseExperimental::class)
     override suspend fun signUp(
         supabaseClient: SupabaseClient,
         onSuccess: suspend (UserSession) -> Unit,
@@ -95,10 +93,10 @@ sealed interface DefaultAuthProvider<C, R> : AuthProvider<C, R> {
             redirectUrl?.let { redirectTo(it) }
         }
         val json = response.body<JsonObject>()
-        if(json.containsKey("access_token")) {
+        if (json.containsKey("access_token")) {
             val userSession = supabaseJson.decodeFromJsonElement<UserSession>(json)
             onSuccess(userSession)
-            return null
+            return decodeResult(json)
         }
         return decodeResult(json)
     }


### PR DESCRIPTION
## What kind of change does this PR introduce?
Decode result when result of `signUpWith(Email)` contains `access_token 

## What is the current behavior?
Result returns null
Related issue: https://github.com/supabase-community/supabase-kt/issues/921

## What is the new behavior?
Result should still be parsed to make it available instead of null
