### PR TITLE
Fix min loglevel

### DIFF
--- a/Supabase/src/commonMain/kotlin/io/github/jan/supabase/SupabaseClient.kt
+++ b/Supabase/src/commonMain/kotlin/io/github/jan/supabase/SupabaseClient.kt
@@ -73,19 +73,19 @@ interface SupabaseClient {
     companion object {
 
         /**
-         * The default logging level used for plugins. Can be changed within the [SupabaseClientBuilder]
+         * The default minimum logging level used for plugins. Can be changed within the [SupabaseClientBuilder]
          */
         var DEFAULT_LOG_LEVEL = LogLevel.INFO
             internal set
 
-        val LOGGER = createLogger("Supabase-Core")
+        val LOGGER: SupabaseLogger = createLogger("Supabase-Core")
 
         /**
          * Creates a new [SupabaseLogger] using the [KermitSupabaseLogger] implementation.
          * @param tag The tag for the logger
          * @param level The logging level. If set to null, the [DEFAULT_LOG_LEVEL] property will be used instead
          */
-        fun createLogger(tag: String, level: LogLevel? = null) = KermitSupabaseLogger(level, tag)
+        fun createLogger(tag: String, level: LogLevel? = null): SupabaseLogger = KermitSupabaseLogger(level, tag)
 
     }
 

--- a/Supabase/src/commonMain/kotlin/io/github/jan/supabase/SupabaseClient.kt
+++ b/Supabase/src/commonMain/kotlin/io/github/jan/supabase/SupabaseClient.kt
@@ -85,7 +85,8 @@ interface SupabaseClient {
          * @param tag The tag for the logger
          * @param level The logging level. If set to null, the [DEFAULT_LOG_LEVEL] property will be used instead
          */
-        fun createLogger(tag: String, level: LogLevel? = null): SupabaseLogger = KermitSupabaseLogger(level, tag)
+        fun createLogger(tag: String, level: LogLevel? = null): SupabaseLogger =
+            KermitSupabaseLogger(level ?: DEFAULT_LOG_LEVEL, tag)
 
     }
 

--- a/Supabase/src/commonMain/kotlin/io/github/jan/supabase/logging/SupabaseLogger.kt
+++ b/Supabase/src/commonMain/kotlin/io/github/jan/supabase/logging/SupabaseLogger.kt
@@ -42,7 +42,7 @@ abstract class SupabaseLogger {
  * @param tag The tag for this logger
  * @param logger The Kermit logger
  */
-class KermitSupabaseLogger(
+internal class KermitSupabaseLogger(
     override val level: LogLevel,
     tag: String,
     private val logger: Logger = Logger.withTag(tag)

--- a/Supabase/src/commonMain/kotlin/io/github/jan/supabase/logging/SupabaseLogger.kt
+++ b/Supabase/src/commonMain/kotlin/io/github/jan/supabase/logging/SupabaseLogger.kt
@@ -43,13 +43,13 @@ abstract class SupabaseLogger {
  * @param logger The Kermit logger
  */
 class KermitSupabaseLogger(
-    override val level: LogLevel?,
+    override val level: LogLevel,
     tag: String,
     private val logger: Logger = Logger.withTag(tag)
 ) : SupabaseLogger() {
 
     init {
-        logger.mutableConfig.minSeverity = (level ?: SupabaseClient.DEFAULT_LOG_LEVEL).toSeverity()
+        logger.mutableConfig.minSeverity = level.toSeverity()
     }
 
     override fun log(level: LogLevel, throwable: Throwable?, message: String) {

--- a/Supabase/src/commonMain/kotlin/io/github/jan/supabase/plugins/SupabasePluginProvider.kt
+++ b/Supabase/src/commonMain/kotlin/io/github/jan/supabase/plugins/SupabasePluginProvider.kt
@@ -35,11 +35,4 @@ interface SupabasePluginProvider<Config, PluginInstance : SupabasePlugin<Config>
      */
     fun create(supabaseClient: SupabaseClient, config: Config) : PluginInstance
 
-    /**
-     * Updates the plugin's log level
-     */
-    fun setLogLevel(level: LogLevel) {
-        logger.setLevel(level)
-    }
-
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix, feature, docs update

## What is the current behavior?

The global Kermit minSeverity will take precedence if it is higher than specified logLevel.

## What is the new behavior?

There doesn't appear to be good way to respect DEFAULT_LOG_LEVEL and the global minSeverity, so we should specify override the minSeverity.

## Additional context

The phrase "default logging level" could mean default level at and above which logs are shown, or default level applied to logs. I updated the docs specify this.

Finally, KermitSupabaseLogger seemed to be accidentally exposed in the API. I changed the API values to be explicit SupabaseLogger and made KermitSupabaseLogger internal. Also, setLevel was internal and never called, so I removed it.
