### PR TITLE
Deprecate NativeSignInResult.NetworkError as it isn't used

### DIFF
--- a/plugins/ComposeAuth/src/commonMain/kotlin/io/github/jan/supabase/compose/auth/composable/NativeSignInResult.kt
+++ b/plugins/ComposeAuth/src/commonMain/kotlin/io/github/jan/supabase/compose/auth/composable/NativeSignInResult.kt
@@ -19,7 +19,7 @@ sealed interface NativeSignInResult {
      * Network error occurred
      * @property message The error message
      */
-    @Deprecated
+    @Deprecated("Use Error instead. This will be removed in a future version.")
     data class NetworkError(val message: String) : NativeSignInResult
 
     /**

--- a/plugins/ComposeAuth/src/commonMain/kotlin/io/github/jan/supabase/compose/auth/composable/NativeSignInResult.kt
+++ b/plugins/ComposeAuth/src/commonMain/kotlin/io/github/jan/supabase/compose/auth/composable/NativeSignInResult.kt
@@ -19,6 +19,7 @@ sealed interface NativeSignInResult {
      * Network error occurred
      * @property message The error message
      */
+    @Deprecated
     data class NetworkError(val message: String) : NativeSignInResult
 
     /**


### PR DESCRIPTION
## What kind of change does this PR introduce?

Improvement (closes #937)

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
