### PR TITLE
Add sketch integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ __For versions below 3.0.0:__
 - [Compose Auth UI](/plugins/ComposeAuthUI) - Provides UI Components for Compose Multiplatform.
 - [Coil Integration](/plugins/CoilIntegration) - Provides a [Coil2](https://github.com/coil-kt/coil) Integration for displaying images stored in Supabase Storage. Only supports Android.
 - [Coil3 Integration](/plugins/Coil3Integration) - Provides a [Coil3](https://github.com/coil-kt/coil) Integration for displaying images stored in Supabase Storage. Supports all Compose Multiplatform targets.
-- *[Compose-ImageLoader Integration](/plugins/ImageLoaderIntegration) - Deprecated. Use Coil 3 or create your own integration*
+- [Sketch Integration](/plugins/SketchIntegration) - Provides a [Sketch](https://github.com/panpf/sketch) Integration for displaying images stored in Supabase Storage. Supports all Compose Multiplatform targets.
 
 ### Miscellaneous
 - [Supabase Edge Functions Kotlin](https://github.com/manriif/supabase-edge-functions-kt) - Build, serve and deploy Supabase Edge Functions with Kotlin and Gradle.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,6 +35,7 @@ androidx-lifecycle = "2.9.0"
 filekit = "0.8.8"
 kotlinx-browser = "0.3"
 secure-random = "0.5.1"
+sketch = "4.1.0"
 
 [plugins]
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
@@ -118,6 +119,7 @@ coil3 = { module = "io.coil-kt.coil3:coil", version.ref = "coil3" }
 coil3-network-core = { module = "io.coil-kt.coil3:coil-network-core", version.ref = "coil3" }
 coil2 = { module = "io.coil-kt:coil", version.ref = "coil2" }
 imageloader = { module = "io.github.qdsfdhvh:image-loader", version.ref = "imageloader" }
+sketch-http = { module = "io.github.panpf.sketch4:sketch-http", version.ref = "sketch" }
 
 # Sample dependencies
 koin-core = { module = "io.insert-koin:koin-core", version.ref = "koin" }

--- a/plugins/SketchIntegration/README.md
+++ b/plugins/SketchIntegration/README.md
@@ -1,9 +1,9 @@
 # Supabase-kt Coil 3 Integration
 
-Extends supabase-kt with a Coil3 integration for image loading.
-**Requires supabase-kt `3.0.0` or higher.**
+Extends supabase-kt with a [Sketch](https://github.com/panpf/sketch) integration for image loading.
+**Requires supabase-kt `3.2.0` or higher.**
 
-Current supported Coil3 version: `3.2.0` and higher.
+Current supported Sketch version: `4.1.0` and higher.
 
 Supported targets:
 
@@ -29,7 +29,7 @@ Newest version: [![](https://img.shields.io/github/release/supabase-community/su
 
 ```kotlin
 dependencies {
-    implementation("io.github.jan-tennert.supabase:coil3-integration:VERSION")
+    implementation("io.github.jan-tennert.supabase:sketch-integration:VERSION")
 }
 ```
 
@@ -43,30 +43,27 @@ val client = createSupabaseClient(
     install(Storage) {
         //your config
     }
-    install(Coil3Integration)
+    install(SketchIntegration)
 }
 ```
 
-If you don't have a coil-network artifact in your dependencies, you will need to add it. See the [Coil documentation](https://coil-kt.github.io/coil/upgrading_to_coil3/#network-images) for more information.
+If you don't have a sketch-http artifact in your dependencies, you will need to add it. See the [Sketch documentation](https://github.com/panpf/sketch#install) for more information.
 
 # Usage
 
-### Add Supabase Fetcher to Coil
+### Add Supabase Fetcher to Sketch
 
-Create a new ImageLoader with the Supabase Fetcher and a [network fetcher](https://coil-kt.github.io/coil/upgrading_to_coil3/#network-images).
+Create Sketch with the Supabase Fetcher.
 
 ```kotlin
-ImageLoader.Builder(context)
-    .components {
-        add(supabaseClient.coil3)
-        //You also need the add the network fetcher factory if you don't have it already
-        //Depending on the network artifact you added, this will be different
-        add(KtorNetworkFetcherFactory())
+Sketch.Builder(it).apply {
+    components {
+        supportSupabaseStorage(supabase)
     }
-    .build()
+}.build()
 ```
 
-You can also replace the default Coil Image Loader in your application. 
+You can also replace the default Sketch object
 For Compose Multiplatform Applications using the `coil-compose` dependency, you can use the `setSingletonImageLoaderFactory` composable function:
 ```kotlin
 setSingletonImageLoaderFactory { platformContext ->

--- a/plugins/SketchIntegration/README.md
+++ b/plugins/SketchIntegration/README.md
@@ -68,7 +68,7 @@ You can also replace the default Sketch object
 SingletonSketch.setSafe {
     Sketch.Builder(it).apply {
         components {
-            supportSupabaseStorage
+            supportSupabaseStorage(supabase)
         }
     }.build()
 }

--- a/plugins/SketchIntegration/README.md
+++ b/plugins/SketchIntegration/README.md
@@ -64,39 +64,33 @@ Sketch.Builder(it).apply {
 ```
 
 You can also replace the default Sketch object
-For Compose Multiplatform Applications using the `coil-compose` dependency, you can use the `setSingletonImageLoaderFactory` composable function:
 ```kotlin
-setSingletonImageLoaderFactory { platformContext ->
-    ImageLoader.Builder(platformContext)
-        .components {
-            add(supabaseClient.coil3)
-            //Your network fetcher factory
-            add(KtorNetworkFetcherFactory())
+SingletonSketch.setSafe {
+    Sketch.Builder(it).apply {
+        components {
+            supportSupabaseStorage
         }
-        .build()
+    }.build()
 }
 ```
-You call this composable before any `Image` composable is used. Presumably in your `Root` composable.
 
-See the [Coil documentation](https://coil-kt.github.io/coil/getting_started/#image-loaders) for more information.
+See the [Sketch documentation](https://github.com/panpf/sketch/blob/main/docs/getting_started.md#singleton-mode) for more information.
 
 ### Display images from Supabase Storage
 
 You can easily create an image request like this:
 
 ```kotlin
-val request = ImageRequest.Builder(context)
-    .data(authenticatedStorageItem("icons", "profile.png")) //for non-public buckets
-    .build()
+val request = ImageRequest(context, authenticatedStorageItem("icons", "profile.png").asSketchUri())
 ```
 
-Or if you are using [Compose Multiplatform](https://coil-kt.github.io/coil/compose/):
+Or if you are using [Sketch Compose](https://github.com/panpf/sketch/blob/main/docs/compose.md):
 
 ```kotlin
 AsyncImage(
-    model = publicStorageItem("icons", "profile.png"), //for public buckets
-    contentDescription = null,
+    uri = authenticatedStorageItem("icons", "profile.png").asSketchUri(),
+    contentDescription = "profile image"
 )
 ```
 
-The Coil integration will automatically add the Authorization header to the request if the bucket is not public.
+The Sketch integration will automatically add the Authorization header to the request if the bucket is not public.

--- a/plugins/SketchIntegration/build.gradle.kts
+++ b/plugins/SketchIntegration/build.gradle.kts
@@ -1,0 +1,27 @@
+plugins {
+    id(libs.plugins.kotlin.multiplatform.get().pluginId)
+    id(libs.plugins.android.library.get().pluginId)
+}
+
+description = "Extends supabase-kt with a Sketch integration for easy image loading"
+
+repositories {
+    mavenCentral()
+    maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
+}
+
+@OptIn(org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi::class)
+kotlin {
+    defaultConfig()
+    jvm()
+    sourceSets {
+        val commonMain by getting {
+            dependencies {
+                api(project(":storage-kt"))
+                api(libs.sketch.http)
+            }
+        }
+    }
+}
+
+configureLibraryAndroidTarget()

--- a/plugins/SketchIntegration/build.gradle.kts
+++ b/plugins/SketchIntegration/build.gradle.kts
@@ -13,12 +13,18 @@ repositories {
 @OptIn(org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi::class)
 kotlin {
     defaultConfig()
-    jvm()
+    composeTargets()
     sourceSets {
         val commonMain by getting {
             dependencies {
                 api(project(":storage-kt"))
                 api(libs.sketch.http)
+            }
+        }
+        val commonTest by getting {
+            dependencies {
+                implementation(project(":test-common"))
+                implementation(libs.bundles.testing)
             }
         }
     }

--- a/plugins/SketchIntegration/src/androidMain/AndroidManifest.xml
+++ b/plugins/SketchIntegration/src/androidMain/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest/>

--- a/plugins/SketchIntegration/src/commonMain/kotlin/io/github/jan/supabase/coil/SketchIntegration.kt
+++ b/plugins/SketchIntegration/src/commonMain/kotlin/io/github/jan/supabase/coil/SketchIntegration.kt
@@ -14,6 +14,7 @@ import io.github.jan.supabase.storage.storage
 /**
  * A plugin that implements [Fetcher.Factory] to support using [StorageItem] as data when creating an [ImageRequest] or using it as a model in Compose Multiplatform.
  */
+@SupabaseExperimental
 interface SketchIntegration: SupabasePlugin<SketchIntegration.Config>, Fetcher.Factory {
 
     /**

--- a/plugins/SketchIntegration/src/commonMain/kotlin/io/github/jan/supabase/coil/SketchIntegration.kt
+++ b/plugins/SketchIntegration/src/commonMain/kotlin/io/github/jan/supabase/coil/SketchIntegration.kt
@@ -1,0 +1,83 @@
+package io.github.jan.supabase.coil
+
+import com.github.panpf.sketch.fetch.Fetcher
+import com.github.panpf.sketch.request.RequestContext
+import io.github.jan.supabase.SupabaseClient
+import io.github.jan.supabase.annotations.SupabaseExperimental
+import io.github.jan.supabase.logging.SupabaseLogger
+import io.github.jan.supabase.logging.d
+import io.github.jan.supabase.plugins.SupabasePlugin
+import io.github.jan.supabase.plugins.SupabasePluginProvider
+import io.github.jan.supabase.storage.StorageItem
+import io.github.jan.supabase.storage.storage
+
+/**
+ * A plugin that implements [Fetcher.Factory] to support using [StorageItem] as data when creating an [ImageRequest] or using it as a model in Compose Multiplatform.
+ */
+interface SketchIntegration: SupabasePlugin<SketchIntegration.Config>, Fetcher.Factory {
+
+    /**
+     * The configuration for the sketch integration.
+     */
+    class Config
+
+    companion object : SupabasePluginProvider<Config, SketchIntegration> {
+
+        override val key = "sketch"
+
+        override val logger: SupabaseLogger = SupabaseClient.createLogger("Supabase-Sketch")
+
+        override fun create(supabaseClient: SupabaseClient, config: Config): SketchIntegration {
+            return SketchIntegrationImpl(supabaseClient, config)
+        }
+
+        override fun createConfig(init: Config.() -> Unit): Config {
+            return Config().apply(init)
+        }
+
+    }
+
+}
+
+internal class SketchIntegrationImpl(
+    override val supabaseClient: SupabaseClient,
+    override val config: SketchIntegration.Config
+) : SketchIntegration {
+
+    override fun create(requestContext: RequestContext): Fetcher? {
+        val uri = requestContext.request.uri
+        if(!isSupabaseUri(uri)) {
+            if(uri.scheme == SupabaseStorageFetcher.SCHEME) SketchIntegration.logger.d { "Invalid Supabase URI: $uri" }
+            return null
+        }
+        SketchIntegration.logger.d { "Creating Storage Fetcher" }
+        return SupabaseStorageFetcher(supabaseClient.storage, requestContext)
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+        other as SketchIntegrationImpl
+        if (supabaseClient != other.supabaseClient) return false
+        if (config != other.config) return false
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = supabaseClient.hashCode()
+        result = 31 * result + config.hashCode()
+        return result
+    }
+
+    override fun toString(): String {
+        return "SketchIntegrationImpl(supabaseClient=$supabaseClient, config=$config)"
+    }
+
+}
+
+/**
+ * With the [SketchIntegration] plugin installed, you can use this property to access the coil fetcher factory.
+ */
+@SupabaseExperimental
+val SupabaseClient.sketch: SketchIntegration
+    get() = pluginManager.getPlugin(SketchIntegration)

--- a/plugins/SketchIntegration/src/commonMain/kotlin/io/github/jan/supabase/coil/SketchUri.kt
+++ b/plugins/SketchIntegration/src/commonMain/kotlin/io/github/jan/supabase/coil/SketchUri.kt
@@ -1,0 +1,24 @@
+package io.github.jan.supabase.coil
+
+import com.github.panpf.sketch.util.Uri
+import io.github.jan.supabase.storage.StorageItem
+import io.ktor.http.parseQueryString
+
+fun StorageItem.asSketchUri(): String {
+    return "supabase:///${bucketId}/${path}?authenticated=${authenticated}&bla=da"
+}
+
+internal fun Uri.toStorageItem(): StorageItem {
+    if(pathSegments.isEmpty()) {
+        error("Invalid StorageItem URI: $this")
+    }
+    val bucketId = pathSegments[0]
+    val path = pathSegments.drop(1).joinToString("/")
+    val query = query?.let { parseQueryString(it) }?.get("authenticated")?.toBoolean() ?: false
+    return StorageItem(bucketId = bucketId, path = path, authenticated = query)
+}
+
+internal fun isSupabaseUri(uri: Uri): Boolean =
+    SupabaseStorageFetcher.SCHEME.equals(uri.scheme, ignoreCase = true).also(::println)
+            && uri.authority?.takeIf { it.isNotEmpty() } == null
+            && uri.pathSegments.size > 1

--- a/plugins/SketchIntegration/src/commonMain/kotlin/io/github/jan/supabase/coil/SketchUri.kt
+++ b/plugins/SketchIntegration/src/commonMain/kotlin/io/github/jan/supabase/coil/SketchUri.kt
@@ -1,11 +1,21 @@
 package io.github.jan.supabase.coil
 
 import com.github.panpf.sketch.util.Uri
+import io.github.jan.supabase.annotations.SupabaseExperimental
 import io.github.jan.supabase.storage.StorageItem
 import io.ktor.http.parseQueryString
 
+/**
+ * Converts a [StorageItem] to a Sketch URI.
+ *
+ * The URI will have the format `supabase:///<bucketId>/<path>?authenticated=<authenticated>`.
+ * This is an experimental feature and may change in the future.
+ *
+ * @return The Sketch URI representation of the [StorageItem].
+ */
+@SupabaseExperimental
 fun StorageItem.asSketchUri(): String {
-    return "supabase:///${bucketId}/${path}?authenticated=${authenticated}&bla=da"
+    return "supabase:///${bucketId}/${path}?authenticated=${authenticated}"
 }
 
 internal fun Uri.toStorageItem(): StorageItem {

--- a/plugins/SketchIntegration/src/commonMain/kotlin/io/github/jan/supabase/coil/SketchUri.kt
+++ b/plugins/SketchIntegration/src/commonMain/kotlin/io/github/jan/supabase/coil/SketchUri.kt
@@ -19,6 +19,6 @@ internal fun Uri.toStorageItem(): StorageItem {
 }
 
 internal fun isSupabaseUri(uri: Uri): Boolean =
-    SupabaseStorageFetcher.SCHEME.equals(uri.scheme, ignoreCase = true).also(::println)
+    SupabaseStorageFetcher.SCHEME.equals(uri.scheme, ignoreCase = true)
             && uri.authority?.takeIf { it.isNotEmpty() } == null
             && uri.pathSegments.size > 1

--- a/plugins/SketchIntegration/src/commonMain/kotlin/io/github/jan/supabase/coil/SupabaseStorageFetcher.kt
+++ b/plugins/SketchIntegration/src/commonMain/kotlin/io/github/jan/supabase/coil/SupabaseStorageFetcher.kt
@@ -1,0 +1,75 @@
+package io.github.jan.supabase.coil
+
+import com.github.panpf.sketch.ComponentRegistry
+import com.github.panpf.sketch.annotation.WorkerThread
+import com.github.panpf.sketch.fetch.FetchResult
+import com.github.panpf.sketch.fetch.Fetcher
+import com.github.panpf.sketch.http.HttpHeaders
+import com.github.panpf.sketch.request.ImageRequest
+import com.github.panpf.sketch.request.RequestContext
+import com.github.panpf.sketch.request.httpHeaders
+import io.github.jan.supabase.SupabaseClient
+import io.github.jan.supabase.logging.d
+import io.github.jan.supabase.storage.Storage
+import io.github.jan.supabase.storage.StorageItem
+import io.github.jan.supabase.storage.authenticatedRequest
+
+/**
+ * Adds support for fetching [StorageItem]s from Supabase Storage in Sketch.
+ */
+fun ComponentRegistry.Builder.supportSupabaseStorage(supabase: SupabaseClient): ComponentRegistry.Builder = apply {
+    addFetcher(supabase.sketch)
+}
+
+
+internal class SupabaseStorageFetcher(
+    private val storage: Storage,
+    private val request: RequestContext
+) : Fetcher {
+
+    @WorkerThread
+    override suspend fun fetch(): Result<FetchResult> {
+        val item = request.request.uri.toStorageItem()
+        SketchIntegration.logger.d { "Received fetcher request for item $item" }
+        val bucket = storage[item.bucketId]
+        val (token, url) = if (item.authenticated) {
+            bucket.authenticatedRequest(item.path)
+        } else {
+            null to bucket.publicUrl(item.path)
+        }
+        val newRequest = ImageRequest(request.request.context, url) {
+            httpHeaders(HttpHeaders {
+                if (item.authenticated) {
+                    set("Authorization", "Bearer $token")
+                }
+            })
+        }
+        val newContext = RequestContext(request.sketch, newRequest)
+        val fetcher = request.sketch.components.newFetcherOrThrow(newContext)
+        return fetcher.fetch()
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+        other as SupabaseStorageFetcher
+        if(storage != other.storage) return false
+        if (request != other.request) return false
+        return true
+    }
+
+    override fun toString(): String {
+        return "SupabaseStorageFetcher(storage=$storage, request=$request)"
+    }
+
+    override fun hashCode(): Int {
+        var result = storage.hashCode()
+        result = 31 * result + request.hashCode()
+        return result
+    }
+
+    companion object {
+        internal const val SCHEME = "supabase"
+    }
+
+}

--- a/plugins/SketchIntegration/src/commonMain/kotlin/io/github/jan/supabase/coil/SupabaseStorageFetcher.kt
+++ b/plugins/SketchIntegration/src/commonMain/kotlin/io/github/jan/supabase/coil/SupabaseStorageFetcher.kt
@@ -16,6 +16,8 @@ import io.github.jan.supabase.storage.authenticatedRequest
 
 /**
  * Adds support for fetching [StorageItem]s from Supabase Storage in Sketch.
+ * This allows you to use Supabase Storage items as image sources in Sketch.
+ * @param supabase The [SupabaseClient] instance to use for authentication. Note that fetching is not done through the Supabase client directly, but rather through an installed HTTP [Fetcher] in Sketch.
  */
 fun ComponentRegistry.Builder.supportSupabaseStorage(supabase: SupabaseClient): ComponentRegistry.Builder = apply {
     addFetcher(supabase.sketch)

--- a/plugins/SketchIntegration/src/commonTest/kotlin/io/github/jan/supabase/coil/SketchUriTest.kt
+++ b/plugins/SketchIntegration/src/commonTest/kotlin/io/github/jan/supabase/coil/SketchUriTest.kt
@@ -1,0 +1,24 @@
+package io.github.jan.supabase.coil
+
+import com.github.panpf.sketch.util.toUri
+import io.github.jan.supabase.storage.StorageItem
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SketchUriTest {
+
+    @Test
+    fun testSketchUri() {
+        val storageItem = StorageItem(
+            bucketId = "testBucket",
+            path = "test/path/to/file.jpg",
+            authenticated = true
+        )
+        val sketchUri = storageItem.asSketchUri()
+        assertEquals("supabase:///testBucket/test/path/to/file.jpg?authenticated=true", sketchUri)
+        val parsedItem = sketchUri.toUri().toStorageItem()
+        assertEquals(storageItem.bucketId, parsedItem.bucketId)
+    }
+
+
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -22,6 +22,7 @@ include("bom")
 
 // Test module
 include("test-common")
+include("test")
 
 // Serializers
 include(":serializers:Moshi")
@@ -36,6 +37,7 @@ include(":plugins:ComposeAuthUI")
 include(":plugins:Coil3Integration")
 include(":plugins:CoilIntegration")
 include(":plugins:ImageLoaderIntegration")
+include(":plugins:SketchIntegration")
 
 // Samples
 if (System.getProperty("LibrariesOnly") != "true") {
@@ -57,6 +59,7 @@ project(":plugins:ComposeAuthUI").name = "compose-auth-ui"
 project(":plugins:Coil3Integration").name = "coil3-integration"
 project(":plugins:CoilIntegration").name = "coil-integration"
 project(":plugins:ImageLoaderIntegration").name = "imageloader-integration"
+project(":plugins:SketchIntegration").name = "sketch-integration"
 rootProject.name = "supabase-kt"
 
 fun includeSample(name: String, vararg targets: String) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature (closes #947)

## What is the new behavior?

A sketch integration similar to the coil integration:
```kotlin
//Install plugin:
install(SketchIntegration)

//Add fetcher to sketch:
Sketch.Builder(it).apply {
    components {
        supportSupabaseStorage(supabase)
    }
}.build()

//Display any image:
AsyncImage(
    uri = authenticatedStorageItem("icons", "profile.png").asSketchUri(),
    contentDescription = "profile image"
)
```
