### PR TITLE
Fix serialization exception occurring when `PostgrestRestException#details` is not a String

### DIFF
--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/PostgrestErrorResponse.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/PostgrestErrorResponse.kt
@@ -1,11 +1,12 @@
 package io.github.jan.supabase.postgrest
 
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
 
 @Serializable
 internal data class PostgrestErrorResponse(
     val message: String,
     val hint: String? = null,
-    val details: String? = null,
+    val details: JsonElement? = null,
     val code: String? = null,
 )

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/exception/PostgrestRestException.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/exception/PostgrestRestException.kt
@@ -2,6 +2,7 @@ package io.github.jan.supabase.postgrest.exception
 
 import io.github.jan.supabase.exceptions.RestException
 import io.ktor.client.statement.HttpResponse
+import kotlinx.serialization.json.JsonElement
 
 /**
  * Exception thrown when a Postgrest request fails
@@ -14,7 +15,10 @@ import io.ktor.client.statement.HttpResponse
 class PostgrestRestException(
     message: String,
     val hint: String?,
-    val details: String?,
+    val details: JsonElement?,
     val code: String?,
     response: HttpResponse
-): RestException(message, hint ?: details, response)
+): RestException(message, """
+    |Hint: $hint
+    |Details: $details
+""".trimIndent(), response)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (closes #954)

## What is the current behavior?

`PostgrestRestException#details` can only be a String, leading to #954 

## What is the new behavior?

`PostgrestRestException#details` can now be any `JsonElement` type