### PR TITLE
Add an option to disable automatic url checking in WASM, JS

### DIFF
--- a/Auth/build.gradle.kts
+++ b/Auth/build.gradle.kts
@@ -22,6 +22,10 @@ kotlin {
                 withLinux()
                 withMingw()
             }
+            group("web") {
+                withJs()
+                withWasmJs()
+            }
             group("nonDesktop") {
                 //withAndroidTarget() android has its own implementation
                 withIos()

--- a/Auth/src/jsMain/kotlin/io/github/jan/supabase/auth/AuthConfig.kt
+++ b/Auth/src/jsMain/kotlin/io/github/jan/supabase/auth/AuthConfig.kt
@@ -5,4 +5,4 @@ import io.github.jan.supabase.plugins.CustomSerializationConfig
 /**
  * The configuration for [Auth]
  */
-actual class AuthConfig : CustomSerializationConfig, AuthConfigDefaults()
+actual class AuthConfig : CustomSerializationConfig, WebAuthConfig()

--- a/Auth/src/jsMain/kotlin/io/github/jan/supabase/auth/setupPlatform.kt
+++ b/Auth/src/jsMain/kotlin/io/github/jan/supabase/auth/setupPlatform.kt
@@ -3,6 +3,7 @@ package io.github.jan.supabase.auth
 import io.github.jan.supabase.annotations.SupabaseInternal
 import io.github.jan.supabase.auth.status.SessionSource
 import io.github.jan.supabase.logging.d
+import io.github.jan.supabase.logging.w
 import io.ktor.util.PlatformUtils.IS_BROWSER
 import kotlinx.browser.window
 import kotlinx.coroutines.launch
@@ -38,7 +39,12 @@ actual fun Auth.setupPlatform() {
             Auth.logger.d { "Found PCKE code: $code" }
             authScope.launch {
                 val session = exchangeCodeForSession(code)
-                importSession(session, source = SessionSource.External)
+                try {
+                    val session = exchangeCodeForSession(code)
+                    importSession(session, source = SessionSource.External)
+                } catch(e: Exception) {
+                    Auth.logger.w(e) { "Failed to exchange PCKE code for session" }
+                }
             }
             clean = true
         }
@@ -48,14 +54,20 @@ actual fun Auth.setupPlatform() {
         }
     }
 
-    if(IS_BROWSER) {
-        Auth.logger.d { "Checking for hash..." }
-        checkForHash()
-        Auth.logger.d { "Checking for PCKE code..." }
-        checkForPCKECode()
-        Auth.logger.d { "Registering hash change listener..." }
-        window.onhashchange = {
-            checkForHash()
+    if(IS_BROWSER && !config.disableUrlChecking) {
+        when(config.flowType) {
+            FlowType.PKCE -> {
+                Auth.logger.d { "Using PCKE flow type, checking for PCKE code..." }
+                checkForPCKECode()
+            }
+            FlowType.IMPLICIT -> {
+                Auth.logger.d { "Using IMPLICIT flow type, checking for hash..." }
+                checkForHash()
+                Auth.logger.d { "Registering hash change listener..." }
+                window.onhashchange = {
+                    checkForHash()
+                }
+            }
         }
     }
 }

--- a/Auth/src/wasmJsMain/kotlin/io/github/jan/supabase/auth/AuthConfig.kt
+++ b/Auth/src/wasmJsMain/kotlin/io/github/jan/supabase/auth/AuthConfig.kt
@@ -5,4 +5,4 @@ import io.github.jan.supabase.plugins.CustomSerializationConfig
 /**
  * The configuration for [Auth]
  */
-actual class AuthConfig: CustomSerializationConfig, AuthConfigDefaults()
+actual class AuthConfig: CustomSerializationConfig, WebAuthConfig()

--- a/Auth/src/wasmJsMain/kotlin/io/github/jan/supabase/auth/setupPlatform.kt
+++ b/Auth/src/wasmJsMain/kotlin/io/github/jan/supabase/auth/setupPlatform.kt
@@ -3,6 +3,7 @@ package io.github.jan.supabase.auth
 import io.github.jan.supabase.annotations.SupabaseInternal
 import io.github.jan.supabase.auth.status.SessionSource
 import io.github.jan.supabase.logging.d
+import io.github.jan.supabase.logging.w
 import io.ktor.util.PlatformUtils.IS_BROWSER
 import kotlinx.browser.window
 import kotlinx.coroutines.launch
@@ -36,8 +37,12 @@ actual fun Auth.setupPlatform() {
             val code = url.searchParams.get("code") ?: return
             Auth.logger.d { "Found PCKE code: $code" }
             authScope.launch {
-                val session = exchangeCodeForSession(code)
-                importSession(session, source = SessionSource.External)
+                try {
+                    val session = exchangeCodeForSession(code)
+                    importSession(session, source = SessionSource.External)
+                } catch(e: Exception) {
+                    Auth.logger.w(e) { "Failed to exchange PCKE code for session" }
+                }
             }
             clean = true
         }
@@ -47,14 +52,20 @@ actual fun Auth.setupPlatform() {
         }
     }
 
-    if(IS_BROWSER) {
-        Auth.logger.d { "Checking for hash..." }
-        checkForHash()
-        Auth.logger.d { "Checking for PCKE code..." }
-        checkForPCKECode()
-        Auth.logger.d { "Registering hash change listener..." }
-        window.onhashchange = {
-            checkForHash()
+    if(IS_BROWSER && !config.disableUrlChecking) {
+        when(config.flowType) {
+            FlowType.PKCE -> {
+                Auth.logger.d { "Using PCKE flow type, checking for PCKE code..." }
+                checkForPCKECode()
+            }
+            FlowType.IMPLICIT -> {
+                Auth.logger.d { "Using IMPLICIT flow type, checking for hash..." }
+                checkForHash()
+                Auth.logger.d { "Registering hash change listener..." }
+                window.onhashchange = {
+                    checkForHash()
+                }
+            }
         }
     }
 }

--- a/Auth/src/webMain/kotlin/io/github/jan/supabase/auth/WebAuthConfig.kt
+++ b/Auth/src/webMain/kotlin/io/github/jan/supabase/auth/WebAuthConfig.kt
@@ -1,0 +1,14 @@
+package io.github.jan.supabase.auth
+
+/**
+ * The configuration for [Auth] in web applications.
+ */
+open class WebAuthConfig: AuthConfigDefaults() {
+
+    /**
+     * Whether to disable automatic URL checking for PKCE codes, error codes, and session tokens.
+     */
+    var disableUrlChecking: Boolean = false
+
+
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature (closes #957)

## What is the new behavior?

Adds an option to disable automatic url checking for Web targets, a try-catch block for parsing PKCE codes and only looks for PKCE codes when using the PKCE flow (and vice-versa, only look for session tokens when using the IMPLICIT flow)