### PR TITLE
Improve docs to put more context of the parameter when a function is renamed

### DIFF
--- a/Functions/src/commonMain/kotlin/io/github/jan/supabase/functions/Functions.kt
+++ b/Functions/src/commonMain/kotlin/io/github/jan/supabase/functions/Functions.kt
@@ -60,7 +60,7 @@ class Functions(override val config: Config, override val supabaseClient: Supaba
 
     /**
      * Invokes a remote edge function. The authorization token is automatically added to the request.
-     * @param function The function to invoke
+     * @param function The function to invoke. If name of the function is renamed, use the slug after URL
      * @param builder The request builder to configure the request
      * @param region The region where the function is invoked
      * @throws RestException or one of its subclasses if receiving an error response
@@ -77,7 +77,7 @@ class Functions(override val config: Config, override val supabaseClient: Supaba
     /**
      * Invokes a remote edge function. The authorization token is automatically added to the request.
      * Note, if you want to serialize [body] to json, you need to add the [HttpHeaders.ContentType] header yourself.
-     * @param function The function to invoke
+     * @param function The function to invoke. If name of the function is renamed, use the slug after URL
      * @param body The body of the request
      * @param headers Headers to add to the request
      * @param region The region where the function is invoked
@@ -93,7 +93,7 @@ class Functions(override val config: Config, override val supabaseClient: Supaba
 
     /**
      * Invokes a remote edge function. The authorization token is automatically added to the request.
-     * @param function The function to invoke
+     * @param function The function to invoke. If name of the function is renamed, use the slug after URL
      * @param headers Headers to add to the request
      * @param region The region where the function is invoked
      * @throws RestException or one of its subclasses if receiving an error response
@@ -107,7 +107,7 @@ class Functions(override val config: Config, override val supabaseClient: Supaba
 
     /**
      * Builds an [EdgeFunction] which can be invoked multiple times
-     * @param function The function name
+     * @param function The function name. If name of the function is renamed, use the slug after URL
      * @param headers Headers to add to the requests when invoking the function
      * @param region The region where the function is invoked
      */


### PR DESCRIPTION
## What kind of change does this PR introduce?
Improve docs to put more context of the parameter when a function is renamed

## What is the current behavior?
https://github.com/supabase-community/supabase-kt/issues/992

## What is the new behavior?
Improve docs to put more context of the parameter when a function is renamed

## Additional context
Below is example of a renamed Edge Funcion
<img width="650" alt="Screenshot 2025-07-01 at 22 17 39" src="https://github.com/user-attachments/assets/997de34a-e4e1-4001-9ccf-7fbada309e36" />
