### PR TITLE
Add presence enabled flag

### DIFF
--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/CallbackManager.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/CallbackManager.kt
@@ -26,6 +26,8 @@ sealed interface CallbackManager {
 
     fun setServerChanges(changes: List<PostgresJoinConfig>)
 
+    fun getCallbacks(): List<RealtimeCallback<*>>
+
 }
 
 internal class CallbackManagerImpl(
@@ -36,6 +38,10 @@ internal class CallbackManagerImpl(
     private var _serverChanges by atomic(listOf<PostgresJoinConfig>())
     val serverChanges: List<PostgresJoinConfig> get() = _serverChanges
     private val callbacks = AtomicMutableList<RealtimeCallback<*>>()
+
+    override fun getCallbacks(): List<RealtimeCallback<*>> {
+        return callbacks.toList()
+    }
 
     override fun addBroadcastCallback(event: String, callback: (JsonObject) -> Unit): Long {
         val id = nextId++

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/Realtime.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/Realtime.kt
@@ -75,6 +75,12 @@ interface Realtime : MainPlugin<Realtime.Config>, CustomSerializationPlugin {
     suspend fun removeChannel(channel: RealtimeChannel)
 
     /**
+     * Adds a channel to the [subscriptions] without subscribing to it.
+     */
+    @SupabaseInternal
+    fun addChannel(channel: RealtimeChannel)
+
+    /**
      * Unsubscribes and removes all channels from the [subscriptions]
      */
     suspend fun removeAllChannels()

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeChannelBuilder.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeChannelBuilder.kt
@@ -7,10 +7,12 @@ import io.github.jan.supabase.realtime.annotations.ChannelDsl
  * Used to build a realtime channel
  */
 @ChannelDsl
-class RealtimeChannelBuilder @PublishedApi internal constructor(private val topic: String) {
+class RealtimeChannelBuilder @PublishedApi internal constructor(
+    private val topic: String,
+) {
 
     private var broadcastJoinConfig = BroadcastJoinConfig(acknowledgeBroadcasts = false, receiveOwnBroadcasts = false)
-    private var presenceJoinConfig = PresenceJoinConfig("")
+    private var presenceJoinConfig = PresenceJoinConfig("", false)
 
     /**
      * Whether this channel should be private.
@@ -29,7 +31,7 @@ class RealtimeChannelBuilder @PublishedApi internal constructor(private val topi
      * @param block The presence join config
      */
     fun presence(block: PresenceJoinConfig.() -> Unit) {
-        presenceJoinConfig = PresenceJoinConfig("").apply(block)
+        presenceJoinConfig = PresenceJoinConfig("", false).apply(block)
     }
 
     @SupabaseInternal

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeImpl.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeImpl.kt
@@ -93,6 +93,10 @@ import kotlin.io.encoding.ExperimentalEncodingApi
         }
     }
 
+    override fun addChannel(channel: RealtimeChannel) {
+        _subscriptions[channel.topic] = channel
+    }
+
     override fun init() {
         scope.launch {
             supabaseClient.pluginManager.getPluginOrNull(Auth)?.sessionStatus?.collect {

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeJoinPayload.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeJoinPayload.kt
@@ -32,7 +32,7 @@ data class BroadcastJoinConfig(@SerialName("ack") var acknowledgeBroadcasts: Boo
  * @param key Used to track presence payloads. Can be e.g. a user id
  */
 @Serializable
-data class PresenceJoinConfig(var key: String)
+data class PresenceJoinConfig(var key: String, var enabled: Boolean)
 
 @SupabaseInternal
 @Serializable

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeJoinPayload.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeJoinPayload.kt
@@ -30,9 +30,10 @@ data class BroadcastJoinConfig(@SerialName("ack") var acknowledgeBroadcasts: Boo
 
 /**
  * @param key Used to track presence payloads. Can be e.g. a user id
+ * @param enabled Whether presence is enabled for this channel
  */
 @Serializable
-data class PresenceJoinConfig(var key: String, var enabled: Boolean)
+data class PresenceJoinConfig(var key: String, internal var enabled: Boolean)
 
 @SupabaseInternal
 @Serializable

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/event/RCloseEvent.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/event/RCloseEvent.kt
@@ -13,6 +13,7 @@ data object RCloseEvent : RealtimeEvent {
     override suspend fun handle(channel: RealtimeChannel, message: RealtimeMessage) {
         channel.realtime.removeChannel(channel)
         Realtime.logger.d { "Unsubscribed from channel ${message.topic}" }
+        channel.updateStatus(RealtimeChannel.Status.UNSUBSCRIBED)
     }
 
     override fun appliesTo(message: RealtimeMessage): Boolean {

--- a/Realtime/src/commonTest/kotlin/CallbackManagerTest.kt
+++ b/Realtime/src/commonTest/kotlin/CallbackManagerTest.kt
@@ -4,6 +4,7 @@ import io.github.jan.supabase.realtime.HasRecord
 import io.github.jan.supabase.realtime.PostgresAction
 import io.github.jan.supabase.realtime.PostgresJoinConfig
 import io.github.jan.supabase.realtime.Presence
+import io.github.jan.supabase.realtime.RealtimeCallback
 import io.github.jan.supabase.serializer.KotlinXSerializer
 import kotlinx.datetime.Clock
 import kotlinx.serialization.json.JsonObject
@@ -34,6 +35,18 @@ class CallbackManagerTest {
         called = false
         cm.triggerBroadcast(expectedEvent, expectedPayload)
         assertFalse { called }
+    }
+
+    @Test
+    fun testGetCallbacks() {
+        val cm = CallbackManagerImpl()
+        val expectedEvent = "event"
+        cm.addBroadcastCallback(expectedEvent) {
+            //...
+        }
+        val callbacks = cm.getCallbacks()
+        assertTrue { callbacks.isNotEmpty() }
+        assertTrue { callbacks.any { it is RealtimeCallback.BroadcastCallback && it.event == expectedEvent } }
     }
 
     @Test

--- a/Realtime/src/commonTest/kotlin/RealtimeTestUtils.kt
+++ b/Realtime/src/commonTest/kotlin/RealtimeTestUtils.kt
@@ -2,8 +2,10 @@ import io.github.jan.supabase.auth.Auth
 import io.github.jan.supabase.auth.user.UserSession
 import io.github.jan.supabase.putJsonObject
 import io.github.jan.supabase.realtime.Presence
+import io.github.jan.supabase.realtime.RealtimeChannel
 import io.github.jan.supabase.realtime.RealtimeChannel.Companion.CHANNEL_EVENT_PRESENCE_DIFF
 import io.github.jan.supabase.realtime.RealtimeChannel.Companion.CHANNEL_EVENT_SYSTEM
+import io.github.jan.supabase.realtime.RealtimeJoinPayload
 import io.github.jan.supabase.realtime.RealtimeMessage
 import io.github.jan.supabase.realtime.RealtimeTopic
 import kotlinx.coroutines.channels.ReceiveChannel
@@ -17,8 +19,10 @@ import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.decodeFromJsonElement
 import kotlinx.serialization.json.encodeToJsonElement
 import kotlinx.serialization.json.put
+import kotlin.test.assertEquals
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.seconds
 
@@ -28,9 +32,25 @@ suspend fun Auth.importAuthTokenValid(token: String) {
     importSession(UserSession(token, "", expiresAt = Clock.System.now() + 1.hours, expiresIn = 1.hours.inWholeSeconds, tokenType = ""))
 }
 
-suspend fun handleSubscribe(incoming: ReceiveChannel<RealtimeMessage>, outgoing: SendChannel<RealtimeMessage>, channelId: String) {
-    incoming.receive()
+suspend fun handleSubscribe(
+    incoming: ReceiveChannel<RealtimeMessage>,
+    outgoing: SendChannel<RealtimeMessage>,
+    channelId: String,
+    expectEnabledPresence: Boolean = false
+) {
+    val payload = Json.decodeFromJsonElement<RealtimeJoinPayload>(incoming.receive().payload)
+    assertEquals(expectEnabledPresence, payload.config.presence.enabled)
     outgoing.send(RealtimeMessage(RealtimeTopic.withChannelId(channelId), CHANNEL_EVENT_SYSTEM, buildJsonObject { put("status", "ok") }, ""))
+}
+
+suspend fun handleUnsubscribe(
+    incoming: ReceiveChannel<RealtimeMessage>,
+    outgoing: SendChannel<RealtimeMessage>,
+    channelId: String
+) {
+    val message = incoming.receive()
+    assertEquals(RealtimeTopic.withChannelId(channelId), message.topic)
+    outgoing.send(RealtimeMessage(RealtimeTopic.withChannelId(channelId), RealtimeChannel.CHANNEL_EVENT_CLOSE, buildJsonObject {  }, ""))
 }
 
 suspend fun SendChannel<RealtimeMessage>.sendBroadcast(channelId: String, event: String, message: JsonObject) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature (closes #989)

## What is the new behavior?

Adds the `enabled` flag to enable/disable presences. This flag will automatically be set depending if you have presence callbacks or not.
This PR also fixes an issue where the `UNSUBSCRIBED` status is not set