### PR TITLE
improve postgrest error messages

### DIFF
--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/exception/PostgrestRestException.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/exception/PostgrestRestException.kt
@@ -19,6 +19,7 @@ class PostgrestRestException(
     val code: String?,
     response: HttpResponse
 ): RestException(message, """
-    |Hint: $hint
-    |Details: $details
+    Code: $code
+    Hint: $hint
+    Details: $details
 """.trimIndent(), response)

--- a/Supabase/src/commonMain/kotlin/io/github/jan/supabase/exceptions/RestException.kt
+++ b/Supabase/src/commonMain/kotlin/io/github/jan/supabase/exceptions/RestException.kt
@@ -16,7 +16,7 @@ import io.ktor.client.statement.request
  * @see UnknownRestException
  */
 open class RestException(val error: String, val description: String?, val response: HttpResponse): Exception("""
-        $error${description?.let { " ($it)" } ?: ""}
+        $error${description?.let { "\n$it" } ?: ""}
         URL: ${response.request.url}
         Headers: ${response.request.headers.entries()}
         Http Method: ${response.request.method.value}


### PR DESCRIPTION
This improves the output from PostgrestResponseException. It might make exceptions generated by storage look a bit different. The way that RestException generates the message makes these a bit hard to reconcile.