### PR TITLE
Add overloads for Postgrest insert, upsert and update requests

### DIFF
--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/PostgrestQueryBuilder.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/PostgrestQueryBuilder.kt
@@ -17,6 +17,7 @@ import io.github.jan.supabase.postgrest.request.SelectRequest
 import io.github.jan.supabase.postgrest.request.UpdateRequest
 import io.github.jan.supabase.postgrest.result.PostgrestResult
 import io.ktor.client.plugins.HttpRequestTimeoutException
+import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 
@@ -65,18 +66,17 @@ class PostgrestQueryBuilder(
      *
      * By default, upserted rows are not returned. To return it, call `[PostgrestRequestBuilder.select]`.
      *
-     * @param values The values to insert, will automatically get serialized into json.
+     * @param body The request body as an array of json object.
      * @param request Additional configurations for the request including filters
      * @throws PostgrestRestException if receiving an error response
      * @throws HttpRequestTimeoutException if the request timed out
      * @throws HttpRequestException on network related issues
      */
-    suspend inline fun <reified T : Any> upsert(
-        values: List<T>,
+    suspend inline fun upsert(
+        body: JsonArray,
         request: UpsertRequestBuilder.() -> Unit = {}
     ): PostgrestResult {
         val requestBuilder = UpsertRequestBuilder(postgrest.config.propertyConversionMethod).apply(request)
-        val body = postgrest.serializer.encodeToJsonElement(values).jsonArray
         val columns = body.map { it.jsonObject.keys }.flatten().distinct()
         if(columns.isNotEmpty()) requestBuilder.params["columns"] = listOf(columns.joinToString(","))
         requestBuilder.onConflict?.let {
@@ -105,6 +105,29 @@ class PostgrestQueryBuilder(
      *
      * By default, upserted rows are not returned. To return it, call `[PostgrestRequestBuilder.select]`.
      *
+     * @param values The values to insert, will automatically get serialized into json.
+     * @param request Additional configurations for the request including filters
+     * @throws PostgrestRestException if receiving an error response
+     * @throws HttpRequestTimeoutException if the request timed out
+     * @throws HttpRequestException on network related issues
+     */
+    suspend inline fun <reified T : Any> upsert(
+        values: List<T>,
+        request: UpsertRequestBuilder.() -> Unit = {}
+    ): PostgrestResult = upsert(
+        body = postgrest.serializer.encodeToJsonElement(values).jsonArray,
+        request = request
+    )
+
+    /**
+     * Perform an UPSERT on the table or view. Depending on the column(s) passed
+     * to [UpsertRequestBuilder.onConflict], [upsert] allows you to perform the equivalent of
+     * `[insert] if a row with the corresponding onConflict columns doesn't
+     * exist, or if it does exist, perform an alternative action depending on
+     * [UpsertRequestBuilder.ignoreDuplicates].
+     *
+     * By default, upserted rows are not returned. To return it, call `[PostgrestRequestBuilder.select]`.
+     *
      * @param value The value to insert, will automatically get serialized into json.
      * @param request Additional filtering to apply to the query
      * @throws PostgrestRestException if receiving an error response
@@ -119,18 +142,17 @@ class PostgrestQueryBuilder(
     /**
      * Executes an insert operation on the [table]
      *
-     * @param values The values to insert, will automatically get serialized into json.
+     * @param body The request body as an array of json object.
      * @param request Additional filtering to apply to the query
      * @throws PostgrestRestException if receiving an error response
      * @throws HttpRequestTimeoutException if the request timed out
      * @throws HttpRequestException on network related issues
      */
-    suspend inline fun <reified T : Any> insert(
-        values: List<T>,
+    suspend inline fun insert(
+        body: JsonArray,
         request: InsertRequestBuilder.() -> Unit = {}
     ): PostgrestResult {
         val requestBuilder = InsertRequestBuilder(postgrest.config.propertyConversionMethod).apply(request)
-        val body = postgrest.serializer.encodeToJsonElement(values).jsonArray
         val columns = body.map { it.jsonObject.keys }.flatten().distinct()
         if(columns.isNotEmpty()) requestBuilder.params["columns"] = listOf(columns.joinToString(","))
         val insertRequest = InsertRequest(
@@ -144,6 +166,23 @@ class PostgrestQueryBuilder(
         )
         return RestRequestExecutor.execute(postgrest = postgrest, path = table, request = insertRequest)
     }
+
+    /**
+     * Executes an insert operation on the [table]
+     *
+     * @param values The values to insert, will automatically get serialized into json.
+     * @param request Additional filtering to apply to the query
+     * @throws PostgrestRestException if receiving an error response
+     * @throws HttpRequestTimeoutException if the request timed out
+     * @throws HttpRequestException on network related issues
+     */
+    suspend inline fun <reified T : Any> insert(
+        values: List<T>,
+        request: InsertRequestBuilder.() -> Unit = {}
+    ): PostgrestResult = insert(
+        body = postgrest.serializer.encodeToJsonElement(values).jsonArray,
+        request = request
+    )
 
     /**
      * Executes an insert operation on the [table]


### PR DESCRIPTION
This PR adds overloads for `Postgrest` insert, upsert and update requests that accept a `JsonArray` for the insert-based requests and a `JsonElement` for the update one.

## What kind of change does this PR introduce?

- Feature
- Documentation update

## What is the current behavior?

Currently, callers must use overloads that accept a serializable object (or a list of serializable objects). These are then serialized inside the request function body.

## What is the new behavior?

With this change, callers can pass a `JsonArray` directly to insert and upsert requests and a `JsonElement` to the update request.
This avoids unnecessary serialization when the request body is already prepared.

## Additional context

These overloads are especially useful in cases where request function calls are generated or automated, and no DTOs are being used — such as in my own use case.
