### PR TITLE
make filter values comply with postrest rules

### DIFF
--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/PostgresChangeFilter.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/PostgresChangeFilter.kt
@@ -27,12 +27,18 @@ class PostgresChangeFilter(private val event: String, private val schema: String
      */
     fun filter(filter: FilterOperation) {
         val filterValue = when(filter.operator) {
-            FilterOperator.EQ, FilterOperator.NEQ, FilterOperator.GT, FilterOperator.GTE, FilterOperator.LT, FilterOperator.LTE -> filter.value.toString()
+            FilterOperator.EQ,
+            FilterOperator.NEQ,
+            FilterOperator.GT,
+            FilterOperator.GTE,
+            FilterOperator.LT,
+            FilterOperator.LTE ->
+                escapeValue(filter.value)
             FilterOperator.IN -> {
                 if(filter.value is List<*>) {
-                    (filter.value as List<*>).joinToString(",", prefix = "(", postfix = ")") { it.toString() }
+                    (filter.value as List<*>).joinToString(",", prefix = "(", postfix = ")") { escapeValue(it) }
                 } else {
-                    filter.value.toString()
+                    escapeValue(filter.value)
                 }
             }
             else -> throw UnsupportedOperationException("Unsupported filter operator: ${filter.operator}")
@@ -53,4 +59,17 @@ class PostgresChangeFilter(private val event: String, private val schema: String
     @SupabaseInternal
     fun buildConfig() = PostgresJoinConfig(schema, table, filter, event)
 
+}
+
+private val quotedCharacters = listOf(",", ".", ":", "(", ")")
+
+private fun escapeValue(value: Any?): String {
+    val asString = value.toString()
+        .replace("\\", "\\\\")
+        .replace("\"", "\\\"")
+    return if (quotedCharacters.any { asString.contains(it) }) {
+        "\"$asString\""
+    } else {
+        asString
+    }
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix for #1035

## What is the current behavior?

Values are passed through without being modified.

## What is the new behavior?

Values have backslashes and quotes added a backslash before, and values containing reserved characters are wrapped in quotes.

## Additional context

URL grammar is specified here: https://docs.postgrest.org/en/v13/references/api/url_grammar.html#reserved-chars

It's not clear if strings containing a backslash or quote need to be quoted.
