### PR TITLE
Remove AtomicFu, split callbacks in the CallbackManager

### DIFF
--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/CallbackManager.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/CallbackManager.kt
@@ -2,15 +2,31 @@ package io.github.jan.supabase.realtime
 
 import io.github.jan.supabase.SupabaseSerializer
 import io.github.jan.supabase.annotations.SupabaseInternal
-import io.github.jan.supabase.collections.AtomicMutableList
 import io.github.jan.supabase.serializer.KotlinXSerializer
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.PersistentMap
+import kotlinx.collections.immutable.persistentHashMapOf
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.plus
 import kotlinx.serialization.json.JsonObject
 import kotlin.concurrent.atomics.AtomicInt
 import kotlin.concurrent.atomics.AtomicReference
 import kotlin.concurrent.atomics.fetchAndIncrement
+import kotlin.concurrent.atomics.update
 
 @SupabaseInternal
-sealed interface CallbackManager {
+sealed class RealtimeCallbackId(val id: Int) {
+
+    class Postgres(id: Int) : RealtimeCallbackId(id)
+
+    class Presence(id: Int) : RealtimeCallbackId(id)
+
+    class Broadcast(id: Int) : RealtimeCallbackId(id)
+
+}
+
+@SupabaseInternal
+interface CallbackManager {
 
     fun triggerPostgresChange(ids: List<Int>, data: PostgresAction)
 
@@ -18,72 +34,113 @@ sealed interface CallbackManager {
 
     fun triggerPresenceDiff(joins: Map<String, Presence>, leaves: Map<String, Presence>)
 
-    fun addBroadcastCallback(event: String, callback: (JsonObject) -> Unit): Int
+    fun hasPresenceCallback(): Boolean
 
-    fun addPostgresCallback(filter: PostgresJoinConfig, callback: (PostgresAction) -> Unit): Int
+    fun addBroadcastCallback(event: String, callback: (JsonObject) -> Unit): RealtimeCallbackId.Broadcast
 
-    fun addPresenceCallback(callback: (PresenceAction) -> Unit): Int
+    fun addPostgresCallback(filter: PostgresJoinConfig, callback: (PostgresAction) -> Unit): RealtimeCallbackId.Postgres
 
-    fun removeCallbackById(id: Int)
+    fun addPresenceCallback(callback: (PresenceAction) -> Unit): RealtimeCallbackId.Presence
+
+    fun removeCallbackById(id: RealtimeCallbackId)
 
     fun setServerChanges(changes: List<PostgresJoinConfig>)
 
-    fun getCallbacks(): List<RealtimeCallback<*>>
-
 }
 
-internal class CallbackManagerImpl(
+typealias BroadcastMap = PersistentMap<String, PersistentList<RealtimeCallback.BroadcastCallback>>
+
+
+class CallbackManagerImpl(
     private val serializer: SupabaseSerializer = KotlinXSerializer()
 ) : CallbackManager {
 
     private val nextId = AtomicInt(0)
     private val _serverChanges = AtomicReference(listOf<PostgresJoinConfig>())
     val serverChanges: List<PostgresJoinConfig> get() = _serverChanges.load()
-    private val callbacks = AtomicMutableList<RealtimeCallback<*>>()
 
-    override fun getCallbacks(): List<RealtimeCallback<*>> {
-        return callbacks.toList()
+    private val presenceCallbacks = AtomicReference<PersistentMap<Int, RealtimeCallback.PresenceCallback>>(persistentHashMapOf())
+
+    private val broadcastCallbacks = AtomicReference<BroadcastMap>(persistentHashMapOf())
+    private val broadcastEventId = AtomicReference<PersistentMap<Int, String>>(persistentHashMapOf())
+
+    private val postgresCallbacks = AtomicReference<PersistentMap<Int, RealtimeCallback.PostgresCallback>>(persistentHashMapOf())
+
+    override fun addBroadcastCallback(event: String, callback: (JsonObject) -> Unit): RealtimeCallbackId.Broadcast {
+        val id = nextId.fetchAndIncrement()
+        broadcastCallbacks.update {
+            val current = it[event] ?: persistentListOf()
+            it.put(event, current + RealtimeCallback.BroadcastCallback(callback, event, id))
+        }
+        broadcastEventId.update {
+            it.put(id, event)
+        }
+        return RealtimeCallbackId.Broadcast(id)
     }
 
-    override fun addBroadcastCallback(event: String, callback: (JsonObject) -> Unit): Int {
+    override fun addPostgresCallback(filter: PostgresJoinConfig, callback: (PostgresAction) -> Unit): RealtimeCallbackId.Postgres {
         val id = nextId.fetchAndIncrement()
-        callbacks += RealtimeCallback.BroadcastCallback(callback, event, id)
-        return id
-    }
-
-    override fun addPostgresCallback(filter: PostgresJoinConfig, callback: (PostgresAction) -> Unit): Int {
-        val id = nextId.fetchAndIncrement()
-        callbacks += RealtimeCallback.PostgresCallback(callback, filter, id)
-        return id
+        postgresCallbacks.update {
+            it.put(id, RealtimeCallback.PostgresCallback(callback, filter, id))
+        }
+        return RealtimeCallbackId.Postgres(id)
     }
 
     override fun triggerPostgresChange(ids: List<Int>, data: PostgresAction) {
         val filter = serverChanges.filter { it.id in ids }
-        val postgresCallbacks = callbacks.filterIsInstance<RealtimeCallback.PostgresCallback>()
         val callbacks =
-            postgresCallbacks.filter { cc -> filter.any { sc -> cc.filter == sc } }
+            postgresCallbacks.load().values.filter { cc -> filter.any { sc -> cc.filter == sc } }
         callbacks.forEach { it.callback(data) }
     }
 
     override fun triggerBroadcast(event: String, data: JsonObject) {
-        val broadcastCallbacks = callbacks.filterIsInstance<RealtimeCallback.BroadcastCallback>()
-        val callbacks = broadcastCallbacks.filter { it.event == event }
-        callbacks.forEach { it.callback(data) }
+        broadcastCallbacks.load()[event]?.forEach { it.callback(data) }
     }
 
     override fun triggerPresenceDiff(joins: Map<String, Presence>, leaves: Map<String, Presence>) {
-        val presenceCallbacks = callbacks.filterIsInstance<RealtimeCallback.PresenceCallback>()
-        presenceCallbacks.forEach { it.callback(PresenceActionImpl(serializer, joins, leaves)) }
+        presenceCallbacks.load().values.forEach { it.callback(PresenceActionImpl(serializer, joins, leaves)) }
     }
 
-    override fun addPresenceCallback(callback: (PresenceAction) -> Unit): Int {
+    override fun hasPresenceCallback(): Boolean {
+        return presenceCallbacks.load().isNotEmpty()
+    }
+
+    override fun addPresenceCallback(callback: (PresenceAction) -> Unit):  RealtimeCallbackId.Presence {
         val id = nextId.fetchAndIncrement()
-        callbacks += RealtimeCallback.PresenceCallback(callback, id)
-        return id
+        presenceCallbacks.update {
+            it.put(id, RealtimeCallback.PresenceCallback(callback, id))
+        }
+        return RealtimeCallbackId.Presence(id)
     }
 
-    override fun removeCallbackById(id: Int) {
-        callbacks.indexOfFirst { it.id == id }.takeIf { it != -1 }?.let { callbacks.removeAt(it) }
+    fun removeBroadcastCallbackById(id: Int) {
+        val event = broadcastEventId.load()[id] ?: return
+        broadcastCallbacks.update {
+            it.put(event, it[event]?.removeAll { c -> c.id == id } ?: persistentListOf())
+        }
+        broadcastEventId.update {
+            it.remove(id)
+        }
+    }
+
+    fun removePresenceCallbackById(id: Int) {
+        presenceCallbacks.update {
+            it.remove(id)
+        }
+    }
+
+    fun removePostgresCallbackById(id: Int) {
+        postgresCallbacks.update {
+            it.remove(id)
+        }
+    }
+
+    override fun removeCallbackById(id: RealtimeCallbackId) {
+        when (id) {
+            is RealtimeCallbackId.Broadcast -> removeBroadcastCallbackById(id.id)
+            is RealtimeCallbackId.Presence -> removePresenceCallbackById(id.id)
+            is RealtimeCallbackId.Postgres -> removePostgresCallbackById(id.id)
+        }
     }
 
     override fun setServerChanges(changes: List<PostgresJoinConfig>) {

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/PresenceAction.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/PresenceAction.kt
@@ -96,7 +96,8 @@ sealed interface PresenceAction {
 
 }
 
-@PublishedApi internal class PresenceActionImpl(
+//@PublishedApi
+class PresenceActionImpl(
     @PublishedApi internal val serializer: SupabaseSerializer,
     override val joins: Map<String, Presence>,
     override val leaves: Map<String, Presence>

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeChannelImpl.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeChannelImpl.kt
@@ -64,7 +64,7 @@ internal class RealtimeChannelImpl(
         Realtime.logger.d { "Subscribing to channel $topic" }
         val currentJwt = accessToken()
         val postgrestChanges = clientChanges.toList()
-        val hasPresenceCallback = callbackManager.getCallbacks().filterIsInstance<RealtimeCallback.PresenceCallback>().isNotEmpty()
+        val hasPresenceCallback = callbackManager.hasPresenceCallback()
         presenceJoinConfig.enabled = hasPresenceCallback
         val joinConfig = RealtimeJoinPayload(RealtimeJoinConfig(broadcastJoinConfig, presenceJoinConfig, postgrestChanges, isPrivate))
         val joinConfigObject = buildJsonObject {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlin = "2.2.20-RC2"
+kotlin = "2.2.20"
 accompanist-permissions = "0.37.3"
 ktor = "3.2.3"
 dokka = "2.0.0"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Improvement

## What is the current behavior?

- AtomicFU is used, which isn't needed anymore because atomic operations have mostly been added to the stdlib.
- All callbacks (broadcast, presence, postgres) are stored in a single list

## What is the new behavior?

- AtomicFU removed (which also allows merging #1013) and atomic references from the stdlib are used
- Split callbacks in three different lists / maps.
- For broadcast callback a map is used, a callback list is stored under the respective event name
- For presence callbacks a map is used, callbacks are mapped by their callback id for easy removal
- Same with postgres callbacks

