### PR TITLE
Fix Chat sample launch fails on iOS

### DIFF
--- a/sample/chat-demo-mpp/ios/chatdemoios.xcodeproj/project.pbxproj
+++ b/sample/chat-demo-mpp/ios/chatdemoios.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		6581F1552B36C0D000BA34A9 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		6581F1572B36C0D000BA34A9 /* chatdemoios.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = chatdemoios.entitlements; sourceTree = "<group>"; };
 		6581F1592B36C0D000BA34A9 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		65E1CD792E79AA2500DACC1A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -52,6 +53,7 @@
 		6581F1502B36C0CF00BA34A9 /* chatdemoios */ = {
 			isa = PBXGroup;
 			children = (
+				65E1CD792E79AA2500DACC1A /* Info.plist */,
 				6581F1512B36C0CF00BA34A9 /* chatdemoiosApp.swift */,
 				6581F1532B36C0CF00BA34A9 /* ContentView.swift */,
 				6581F1552B36C0D000BA34A9 /* Assets.xcassets */,
@@ -300,6 +302,8 @@
 				FRAMEWORK_SEARCH_PATHS = "$(SRCROOT)/../common/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)";
 				GENERATE_INFOPLIST_FILE = YES;
 				HEADER_SEARCH_PATHS = "";
+				INFOPLIST_FILE = chatdemoios/Info.plist;
+				INFOPLIST_KEY_LSApplicationCategoryType = "";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
@@ -341,6 +345,8 @@
 				FRAMEWORK_SEARCH_PATHS = "$(SRCROOT)/../common/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)";
 				GENERATE_INFOPLIST_FILE = YES;
 				HEADER_SEARCH_PATHS = "";
+				INFOPLIST_FILE = chatdemoios/Info.plist;
+				INFOPLIST_KEY_LSApplicationCategoryType = "";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;

--- a/sample/chat-demo-mpp/ios/chatdemoios/Info.plist
+++ b/sample/chat-demo-mpp/ios/chatdemoios/Info.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
## What kind of change does this PR introduce?
Add required properties for new iOS version
Fix https://github.com/supabase-community/supabase-kt/issues/935

## What is the current behavior?
Can not launch chat sample with the log below
<img width="650" height="250" alt="Screenshot 2025-09-16 at 21 12 18" src="https://github.com/user-attachments/assets/e112e6e9-723d-4932-b7db-96b64b2da720" />


## What is the new behavior?
<img width="500" height="500" alt="Screenshot 2025-09-16 at 21 24 08" src="https://github.com/user-attachments/assets/3aaaabbe-9929-4811-87d5-77dd48a866d4" />

Launch chat app successfully


## Additional context

Add any other context or screenshots.
