### PR TITLE
Add support for linkIdentity with OIDC

### DIFF
--- a/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/Auth.kt
+++ b/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/Auth.kt
@@ -198,11 +198,9 @@ interface Auth : MainPlugin<AuthConfig>, CustomSerializationPlugin {
      * }
      * ```
      *
-     * This method works similar to signing in with OAuth providers. Refer to the [documentation](https://supabase.com/docs/reference/kotlin/initializing) to learn how to handle OAuth and OTP links.
      * @param provider One of the [IDTokenProvider] providers.
      * @param idToken The ID token to use
      * @param config Extra configuration
-     * @return The OAuth url to open in the browser if [ExternalAuthConfigDefaults.automaticallyOpenUrl] is false, otherwise null.
      * @throws RestException or one of its subclasses if receiving an error response. If the error response contains a error code, an [AuthRestException] will be thrown which can be used to easier identify the problem.
      * @throws HttpRequestTimeoutException if the request timed out
      * @throws HttpRequestException on network related issues

--- a/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/Auth.kt
+++ b/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/Auth.kt
@@ -11,8 +11,10 @@ import io.github.jan.supabase.auth.mfa.MfaApi
 import io.github.jan.supabase.auth.providers.AuthProvider
 import io.github.jan.supabase.auth.providers.ExternalAuthConfigDefaults
 import io.github.jan.supabase.auth.providers.Google
+import io.github.jan.supabase.auth.providers.IDTokenProvider
 import io.github.jan.supabase.auth.providers.OAuthProvider
 import io.github.jan.supabase.auth.providers.builtin.Email
+import io.github.jan.supabase.auth.providers.builtin.IDToken
 import io.github.jan.supabase.auth.providers.builtin.Phone
 import io.github.jan.supabase.auth.providers.builtin.SSO
 import io.github.jan.supabase.auth.status.SessionSource
@@ -164,7 +166,13 @@ interface Auth : MainPlugin<AuthConfig>, CustomSerializationPlugin {
     /**
      * Links an OAuth Identity to an existing user.
      *
-     * This methods works similar to signing in with OAuth providers. Refer to the [documentation](https://supabase.com/docs/reference/kotlin/initializing) to learn how to handle OAuth and OTP links.
+     * Example:
+     * ```kotlin
+     * val url = supabase.auth.linkIdentity(Google)
+     * // Open the url in the browser, but this will happen automatically if [ExternalAuthConfigDefaults.automaticallyOpenUrl] is true (which it is by default)
+     * ```
+     *
+     * This method works similar to signing in with OAuth providers. Refer to the [documentation](https://supabase.com/docs/reference/kotlin/initializing) to learn how to handle OAuth and OTP links.
      * @param provider The OAuth provider
      * @param redirectUrl The redirect url to use. If you don't specify this, the platform specific will be used, like deeplinks on android.
      * @param config Extra configuration
@@ -178,6 +186,32 @@ interface Auth : MainPlugin<AuthConfig>, CustomSerializationPlugin {
         redirectUrl: String? = defaultRedirectUrl(),
         config: ExternalAuthConfigDefaults.() -> Unit = {}
     ): String?
+
+    /**
+     * Links an identity to the current user using an ID token.
+     *
+     * Example:
+     * ```kotlin
+     * supabase.auth.linkIdentityWithIdToken(provider = Google, idToken = "idToken") {
+     *     // Optional nonce
+     *     nonce = "nonce"
+     * }
+     * ```
+     *
+     * This method works similar to signing in with OAuth providers. Refer to the [documentation](https://supabase.com/docs/reference/kotlin/initializing) to learn how to handle OAuth and OTP links.
+     * @param provider One of the [IDTokenProvider] providers.
+     * @param idToken The ID token to use
+     * @param config Extra configuration
+     * @return The OAuth url to open in the browser if [ExternalAuthConfigDefaults.automaticallyOpenUrl] is false, otherwise null.
+     * @throws RestException or one of its subclasses if receiving an error response. If the error response contains a error code, an [AuthRestException] will be thrown which can be used to easier identify the problem.
+     * @throws HttpRequestTimeoutException if the request timed out
+     * @throws HttpRequestException on network related issues
+     */
+    suspend fun linkIdentityWithIdToken(
+        provider: IDTokenProvider,
+        idToken: String,
+        config: (IDToken.Config).() -> Unit = {}
+    )
 
     /**
      * Unlinks an OAuth Identity from an existing user.

--- a/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/AuthImpl.kt
+++ b/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/AuthImpl.kt
@@ -13,7 +13,9 @@ import io.github.jan.supabase.auth.mfa.MfaApi
 import io.github.jan.supabase.auth.mfa.MfaApiImpl
 import io.github.jan.supabase.auth.providers.AuthProvider
 import io.github.jan.supabase.auth.providers.ExternalAuthConfigDefaults
+import io.github.jan.supabase.auth.providers.IDTokenProvider
 import io.github.jan.supabase.auth.providers.OAuthProvider
+import io.github.jan.supabase.auth.providers.builtin.IDToken
 import io.github.jan.supabase.auth.providers.builtin.OTP
 import io.github.jan.supabase.auth.providers.builtin.SSO
 import io.github.jan.supabase.auth.status.RefreshFailureCause
@@ -183,6 +185,16 @@ internal class AuthImpl(
             }
         )
         return null
+    }
+
+    override suspend fun linkIdentityWithIdToken(
+        provider: IDTokenProvider,
+        idToken: String,
+        config: (IDToken.Config) -> Unit
+    ) {
+        val body = IDToken.Config(idToken = idToken, provider = provider, linkIdentity = true).apply(config)
+        val result = api.postJson("token?grant_type=id_token", body)
+        importSession(result.safeBody(), source = SessionSource.UserIdentitiesChanged(result.safeBody()))
     }
 
     override suspend fun unlinkIdentity(identityId: String, updateLocalUser: Boolean) {

--- a/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/providers/builtin/IDToken.kt
+++ b/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/providers/builtin/IDToken.kt
@@ -1,5 +1,6 @@
 package io.github.jan.supabase.auth.providers.builtin
 
+import io.github.jan.supabase.annotations.SupabaseInternal
 import io.github.jan.supabase.auth.providers.Apple
 import io.github.jan.supabase.auth.providers.Azure
 import io.github.jan.supabase.auth.providers.Facebook
@@ -39,7 +40,8 @@ data object IDToken : DefaultAuthProvider<IDToken.Config, UserInfo> {
         @SerialName("id_token") var idToken: String = "",
         var provider: IDTokenProvider? = null,
         @SerialName("access_token") var accessToken: String? = null,
-        var nonce: String? = null
+        var nonce: String? = null,
+        @property:SupabaseInternal var linkIdentity: Boolean = false
     ) : DefaultAuthProvider.Config()
 
     @OptIn(ExperimentalSerializationApi::class)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the new behavior?

- Adds the `Auth#linkIdentityWithIdToken` method

## Additional context

https://github.com/supabase/supabase-swift/pull/776
- I'll also add this functionality to compose auth for MP Native Auth
