### PR TITLE
quote and/or escape special characters in all postrest filters

### DIFF
--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/filter/FilterOperation.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/filter/FilterOperation.kt
@@ -25,7 +25,6 @@ fun FilterOperation.escapedValue(): String =
         FilterOperator.IMATCH,
         FilterOperator.IS ->
             escapeValue(value)
-
         FilterOperator.IN ->
             if (value is List<*>) {
                 encodeAsList(value)
@@ -40,7 +39,6 @@ fun FilterOperation.escapedValue(): String =
                 is Pair<*, *> -> encodeOverlapAsRange(value)
                 else -> escapeValue(value)
             }
-
         FilterOperator.SL,
         FilterOperator.SR,
         FilterOperator.NXL,
@@ -51,8 +49,11 @@ fun FilterOperation.escapedValue(): String =
                 is List<*> -> encodeAsRange(value)
                 else -> escapeValue(value)
             }
-
-        else -> escapeValue(value) // Do these need special handling?
+        FilterOperator.FTS,
+        FilterOperator.WFTS,
+        FilterOperator.PHFTS,
+        FilterOperator.PLFTS ->
+            escapeValue(value) // Do these need special handling?
     }
 
 private fun encodeAsList(values: List<*>): String =

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/filter/FilterOperation.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/filter/FilterOperation.kt
@@ -3,9 +3,73 @@
     "UndocumentedPublicFunction",
     "UndocumentedPublicProperty"
 )
+
 package io.github.jan.supabase.postgrest.query.filter
 
 /**
  * Represents a filter operation for a column using a specific operator and a value.
  */
-data class FilterOperation(val column: String, val operator: FilterOperator, val value: Any)
+data class FilterOperation(val column: String, val operator: FilterOperator, val value: Any?)
+
+fun FilterOperation.escapedValue(): String =
+    when (operator) {
+        FilterOperator.EQ,
+        FilterOperator.NEQ,
+        FilterOperator.GT,
+        FilterOperator.GTE,
+        FilterOperator.LT,
+        FilterOperator.LTE,
+        FilterOperator.LIKE,
+        FilterOperator.ILIKE,
+        FilterOperator.MATCH,
+        FilterOperator.IMATCH,
+        FilterOperator.IS ->
+            escapeValue(value)
+
+        FilterOperator.IN ->
+            if (value is List<*>) {
+                value.joinToString(",", prefix = "(", postfix = ")") { escapeValue(it) }
+            } else {
+                escapeValue(value)
+            }
+        FilterOperator.CS,
+        FilterOperator.CD->
+            if (value is List<*>) {
+                value.joinToString(",", prefix = "{", postfix = "}") { escapeValue(it) }
+            } else {
+                escapeValue(value)
+            }
+
+        FilterOperator.OV ->
+            when (value) {
+                is List<*> -> value.joinToString(",", prefix = "{", postfix = "}") { escapeValue(it) }
+                is Pair<*, *> -> "[${escapeValue(value.first)},${escapeValue(value.second)}]"
+                else -> escapeValue(value)
+            }
+
+        FilterOperator.SL,
+        FilterOperator.SR,
+        FilterOperator.NXL,
+        FilterOperator.NXR,
+        FilterOperator.ADJ ->
+            when (value) {
+                is Pair<*, *> -> "(${escapeValue(value.first)},${escapeValue(value.second)})"
+                is List<*> -> "(${escapeValue(value[0])},${escapeValue(value[1])})"
+                else -> escapeValue(value)
+            }
+
+        else -> escapeValue(value) // Do these need special handling?
+    }
+
+private val quotedCharacters = listOf(",", ".", ":", "(", ")")
+
+internal fun escapeValue(value: Any?): String {
+    val asString = value.toString()
+        .replace("\\", "\\\\")
+        .replace("\"", "\\\"")
+    return if (quotedCharacters.any { asString.contains(it) }) {
+        "\"$asString\""
+    } else {
+        asString
+    }
+}

--- a/Postgrest/src/commonTest/kotlin/PostgrestFilterBuilderTest.kt
+++ b/Postgrest/src/commonTest/kotlin/PostgrestFilterBuilderTest.kt
@@ -26,6 +26,22 @@ class PostgrestFilterBuilderTest {
     }
 
     @Test
+    fun eq_reserved() {
+        val filter = filterToString {
+            eq("id", "2004-09-16T23:59:58.75")
+        }
+        assertEquals("id=eq.\"2004-09-16T23:59:58.75\"", filter)
+    }
+
+    @Test
+    fun eq_quoted() {
+        val filter = filterToString {
+            eq("id", "Hello, \"World\"")
+        }
+        assertEquals("id=eq.\"Hello,+\\\"World\\\"\"", filter)
+    }
+
+    @Test
     fun neq() {
         val filter = filterToString {
             neq("id", 1)
@@ -209,6 +225,17 @@ class PostgrestFilterBuilderTest {
             or { }
         }
         assertEquals("", filter)
+    }
+
+    @Test
+    fun and_escaped() {
+        val filter = filterToString {
+            and {
+                eq("id1", "foo.bar")
+                eq("id2", "bar.baz")
+            }
+        }
+        assertEquals("and=(id1.eq.\"foo.bar\",id2.eq.\"bar.baz\")", filter)
     }
 
     @Test

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/PostgresChangeFilter.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/PostgresChangeFilter.kt
@@ -3,6 +3,7 @@ package io.github.jan.supabase.realtime
 import io.github.jan.supabase.annotations.SupabaseInternal
 import io.github.jan.supabase.postgrest.query.filter.FilterOperation
 import io.github.jan.supabase.postgrest.query.filter.FilterOperator
+import io.github.jan.supabase.postgrest.query.filter.escapedValue
 
 /**
  * Used to filter postgres changes
@@ -32,15 +33,9 @@ class PostgresChangeFilter(private val event: String, private val schema: String
             FilterOperator.GT,
             FilterOperator.GTE,
             FilterOperator.LT,
-            FilterOperator.LTE ->
-                escapeValue(filter.value)
-            FilterOperator.IN -> {
-                if(filter.value is List<*>) {
-                    (filter.value as List<*>).joinToString(",", prefix = "(", postfix = ")") { escapeValue(it) }
-                } else {
-                    escapeValue(filter.value)
-                }
-            }
+            FilterOperator.LTE,
+            FilterOperator.IN ->
+                filter.escapedValue()
             else -> throw UnsupportedOperationException("Unsupported filter operator: ${filter.operator}")
         }
         this.filter = "${filter.column}=${filter.operator.name.lowercase()}.$filterValue"
@@ -59,17 +54,4 @@ class PostgresChangeFilter(private val event: String, private val schema: String
     @SupabaseInternal
     fun buildConfig() = PostgresJoinConfig(schema, table, filter, event)
 
-}
-
-private val quotedCharacters = listOf(",", ".", ":", "(", ")")
-
-private fun escapeValue(value: Any?): String {
-    val asString = value.toString()
-        .replace("\\", "\\\\")
-        .replace("\"", "\\\"")
-    return if (quotedCharacters.any { asString.contains(it) }) {
-        "\"$asString\""
-    } else {
-        asString
-    }
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

I missed escaping characters in normal request filters

## What is the new behavior?

This PR escapes those as well

## Additional context

This PR changes the behavior of `filter(FilterOperation)` so that it generates the proper encoding for a `Pair` or `List` passed with certain `FilterOperators`. I think passing either previously would have been a bug, so this shouldn't have any practical effect.
