### PR TITLE
Add an option to require a valid user session for requests

### DIFF
--- a/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/AuthDependentPluginConfig.kt
+++ b/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/AuthDependentPluginConfig.kt
@@ -1,0 +1,13 @@
+package io.github.jan.supabase.auth
+
+/**
+ * TODO
+ */
+interface AuthDependentPluginConfig {
+
+    /**
+     * Whether to require a valid [io.github.jan.supabase.auth.user.UserSession] in the [Auth] plugin to make any request with this plugin.
+     */
+    var requireValidSession: Boolean
+
+}

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/Postgrest.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/Postgrest.kt
@@ -2,6 +2,7 @@ package io.github.jan.supabase.postgrest
 
 import io.github.jan.supabase.SupabaseClient
 import io.github.jan.supabase.SupabaseSerializer
+import io.github.jan.supabase.auth.AuthDependentPluginConfig
 import io.github.jan.supabase.exceptions.HttpRequestException
 import io.github.jan.supabase.logging.SupabaseLogger
 import io.github.jan.supabase.plugins.CustomSerializationConfig
@@ -101,7 +102,8 @@ interface Postgrest : MainPlugin<Postgrest.Config>, CustomSerializationPlugin {
     data class Config(
         var defaultSchema: String = "public",
         var propertyConversionMethod: PropertyConversionMethod = PropertyConversionMethod.CAMEL_CASE_TO_SNAKE_CASE,
-    ): MainConfig(), CustomSerializationConfig {
+        override var requireValidSession: Boolean = false,
+    ): MainConfig(), CustomSerializationConfig, AuthDependentPluginConfig {
 
         override var serializer: SupabaseSerializer? = null
 

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/Realtime.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/Realtime.kt
@@ -4,6 +4,7 @@ import io.github.jan.supabase.SupabaseClient
 import io.github.jan.supabase.SupabaseClientBuilder
 import io.github.jan.supabase.SupabaseSerializer
 import io.github.jan.supabase.annotations.SupabaseInternal
+import io.github.jan.supabase.auth.AuthDependentPluginConfig
 import io.github.jan.supabase.auth.resolveAccessToken
 import io.github.jan.supabase.logging.SupabaseLogger
 import io.github.jan.supabase.logging.w
@@ -141,7 +142,8 @@ interface Realtime : MainPlugin<Realtime.Config>, CustomSerializationPlugin {
         var connectOnSubscribe: Boolean = true,
         @property:SupabaseInternal var websocketFactory: RealtimeWebsocketFactory? = null,
         var disconnectOnNoSubscriptions: Boolean = true,
-    ): MainConfig(), CustomSerializationConfig {
+        override var requireValidSession: Boolean = false,
+    ): MainConfig(), CustomSerializationConfig, AuthDependentPluginConfig {
 
         /**
          * A custom access token provider. If this is set, the [SupabaseClient] will not be used to resolve the access token.

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/Storage.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/Storage.kt
@@ -3,6 +3,7 @@ package io.github.jan.supabase.storage
 import io.github.jan.supabase.SupabaseClient
 import io.github.jan.supabase.SupabaseSerializer
 import io.github.jan.supabase.annotations.SupabaseInternal
+import io.github.jan.supabase.auth.AuthDependentPluginConfig
 import io.github.jan.supabase.auth.authenticatedSupabaseApi
 import io.github.jan.supabase.bodyOrNull
 import io.github.jan.supabase.collections.AtomicMutableMap
@@ -120,8 +121,9 @@ interface Storage : MainPlugin<Storage.Config>, CustomSerializationPlugin {
     data class Config(
         var transferTimeout: Duration = 120.seconds,
         @PublishedApi internal var resumable: Resumable = Resumable(),
-        override var serializer: SupabaseSerializer? = null
-    ) : MainConfig(), CustomSerializationConfig {
+        override var serializer: SupabaseSerializer? = null,
+        override var requireValidSession: Boolean = false,
+    ) : MainConfig(), CustomSerializationConfig, AuthDependentPluginConfig {
 
         /**
          * @param cache the cache for caching resumable upload urls


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature (closes #970)

## What is the new behavior?

Adds an option to `Storage`, `Postgres`. `Realtime` and `Functions` configs to require the use of a valid session (so no api key as access token) 
