### PR TITLE
Do not escape numbers in Postgrest & escape `filterNot`

### DIFF
--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/filter/FilterOperation.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/filter/FilterOperation.kt
@@ -77,7 +77,7 @@ internal fun escapeValue(value: Any?): String {
     val asString = value.toString()
         .replace("\\", "\\\\")
         .replace("\"", "\\\"")
-    return if (quotedCharacters.any { asString.contains(it) }) {
+    return if (value !is Number && quotedCharacters.any { asString.contains(it) }) {
         "\"$asString\""
     } else {
         asString

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/filter/PostgrestFilterBuilder.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/filter/PostgrestFilterBuilder.kt
@@ -21,15 +21,15 @@ class PostgrestFilterBuilder(
     /**
      * Adds a negated filter to the query
      */
-    fun filterNot(column: String, operator: FilterOperator, value: Any?) {
-        val columnValue = params[column] ?: emptyList()
-        _params[column] = columnValue + listOf("not.${operator.identifier}.$value")
-    }
+    fun filterNot(column: String, operator: FilterOperator, value: Any?) = filterNot(FilterOperation(column, operator, value))
 
     /**
      * Adds a negated filter to the query
      */
-    fun filterNot(operation: FilterOperation) = filterNot(operation.column, operation.operator, operation.value)
+    fun filterNot(operation: FilterOperation) {
+        val columnValue = params[operation.column] ?: emptyList()
+        _params[operation.column] = columnValue + listOf("not.${operation.operator.identifier}.${operation.escapedValue()}")
+    }
 
     /**
      * Adds a filter to the query

--- a/Postgrest/src/commonTest/kotlin/PostgrestFilterBuilderTest.kt
+++ b/Postgrest/src/commonTest/kotlin/PostgrestFilterBuilderTest.kt
@@ -18,6 +18,14 @@ data class TestData(@SerialName("created_at") val createdAt: Instant)
 class PostgrestFilterBuilderTest {
 
     @Test
+    fun filterFloat() {
+        val filter = filterToString {
+            eq("id", 1.0)
+        }
+        assertEquals("id=eq.1.0", filter)
+    }
+
+    @Test
     fun eq() {
         val filter = filterToString {
             eq("id", 1)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (closes #1083)

## What is the current behavior?

Numbers are getting quoted/escaped since they contain a `.`. Also: missing escape quotes in the `filterNot` method

## What is the new behavior?

Numbers are no longer quoted and `filterNot` values are getting escaped

## Additional context

Add any other context or screenshots.
