### PR TITLE
only escape filters inside logical expressions and `in` lists

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
       - 'master'
 
 concurrency:
-  group: environment-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/detekt.yml
+++ b/.github/workflows/detekt.yml
@@ -9,7 +9,7 @@ on:
       - '*'
 
 concurrency:
-  group: environment-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/samples.yml
+++ b/.github/workflows/samples.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - 'master'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
       - 'master'
 
 concurrency:
-  group: environment-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## What kind of change does this PR introduce?

stops quoting filter values when not in a logical expression. fixes #1089

## What is the current behavior?

`eq("phrase", "Hi, Jim")` would quote the value

## What is the new behavior?

The value would only be quoted when inside an `and`/`or`

## Additional context

I'm really sorry about the mistake in the initial PR. All of my testing was in values in `and`. From just reading the docs, it was hard to understand that values cannot be in quotes at any time, but only when in `and`/`or`/`in`.
