### PR TITLE
Add `onError` parameter to `handleDeeplink` methods

### DIFF
--- a/Auth/src/appleMain/kotlin/io/github/jan/supabase/auth/Apple.kt
+++ b/Auth/src/appleMain/kotlin/io/github/jan/supabase/auth/Apple.kt
@@ -14,8 +14,13 @@ import platform.Foundation.NSURLQueryItem
  * This handles the deeplinks for the implicit and the PKCE flow.
  * @param url The url from the ios app delegate
  * @param onSessionSuccess The callback when the session was successfully imported
+ * @param onError Callback invoked if an error occurs during the [Auth.exchangeCodeForSession] call.
  */
-fun SupabaseClient.handleDeeplinks(url: NSURL, onSessionSuccess: (UserSession) -> Unit = {}) {
+fun SupabaseClient.handleDeeplinks(
+    url: NSURL,
+    onSessionSuccess: (UserSession) -> Unit = {},
+    onError: (Throwable) -> Unit = {}
+) {
     if (url.scheme != auth.config.scheme || url.host != auth.config.host) {
         Auth.logger.d { "Received deeplink with wrong scheme or host" }
         return
@@ -39,8 +44,12 @@ fun SupabaseClient.handleDeeplinks(url: NSURL, onSessionSuccess: (UserSession) -
             val code = getQueryItem(components, "code") ?: return
             val scope = (auth as AuthImpl).authScope
             scope.launch {
-                auth.exchangeCodeForSession(code)
-                onSessionSuccess(auth.currentSessionOrNull() ?: error("No session available"))
+                try {
+                    this@handleDeeplinks.auth.exchangeCodeForSession(code)
+                    onSessionSuccess(this@handleDeeplinks.auth.currentSessionOrNull() ?: error("No session available"))
+                } catch (e: Throwable) {
+                    onError(e)
+                }
             }
         }
     }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix/Feature (closes #1135)

## What is the current behavior?

When an exception is thrown during `exchangeCodeForSession()` in `handleDeeplinks()` (for iOS & Android) it is uncatchable as its thrown in another coroutine scope.

## What is the new behavior?

New `onError` parameter for `handleDeeplinks()` propagating this exception.