### PR TITLE
Teardown channels after disconnecting from realtime

### DIFF
--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/CallbackManager.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/CallbackManager.kt
@@ -46,6 +46,8 @@ interface CallbackManager {
 
     fun setServerChanges(changes: List<PostgresJoinConfig>)
 
+    fun reset()
+
 }
 
 private typealias BroadcastMap = PersistentMap<String, PersistentList<RealtimeCallback.BroadcastCallback>>
@@ -67,6 +69,15 @@ internal class CallbackManagerImpl(
     private val broadcastEventId = AtomicReference<PersistentMap<Int, String>>(persistentHashMapOf())
 
     private val postgresCallbacks = AtomicReference<PostgresMap>(persistentHashMapOf())
+
+    override fun reset() {
+        postgresCallbacks.store(persistentHashMapOf())
+        broadcastEventId.store(persistentHashMapOf())
+        broadcastCallbacks.store(persistentHashMapOf())
+        presenceCallbacks.store(persistentHashMapOf())
+        _serverChanges.store(emptyList())
+        nextId.store(0)
+    }
 
     override fun addBroadcastCallback(event: String, callback: (JsonObject) -> Unit): RealtimeCallbackId.Broadcast {
         val id = nextId.fetchAndIncrement()

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeChannel.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeChannel.kt
@@ -113,6 +113,9 @@ interface RealtimeChannel {
     @SupabaseInternal
     suspend fun scheduleRejoin()
 
+    @SupabaseInternal
+    fun teardown()
+
     /**
      * Represents the status of a channel
      */

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeChannelImpl.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeChannelImpl.kt
@@ -58,6 +58,11 @@ internal class RealtimeChannelImpl(
     private fun shouldEnablePresence(): Boolean =
         userPresenceEnabled || callbackManager.hasPresenceCallback()
 
+    override fun teardown() {
+        updateStatus(RealtimeChannel.Status.UNSUBSCRIBED)
+        callbackManager.reset()
+    }
+
     @OptIn(SupabaseInternal::class)
     override suspend fun subscribe(blockUntilSubscribed: Boolean) {
         if(realtimeImpl.status.value != Realtime.Status.CONNECTED) {

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeImpl.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeImpl.kt
@@ -158,6 +158,9 @@ import kotlin.time.Clock
         ws?.disconnect()
         ws = null
         heartbeatJob?.cancel()
+        for ((_, channel) in subscriptions) {
+            channel.teardown()
+        }
         _status.value = Realtime.Status.DISCONNECTED
     }
 

--- a/Realtime/src/commonTest/kotlin/RealtimeTest.kt
+++ b/Realtime/src/commonTest/kotlin/RealtimeTest.kt
@@ -1,5 +1,6 @@
 import io.github.jan.supabase.auth.jwt.JWTUtils
 import io.github.jan.supabase.realtime.Realtime
+import io.github.jan.supabase.realtime.RealtimeChannel
 import io.github.jan.supabase.realtime.RealtimeImpl
 import io.github.jan.supabase.realtime.RealtimeMessage
 import io.github.jan.supabase.realtime.channel
@@ -27,6 +28,28 @@ class RealtimeTest {
                     assertEquals(Realtime.Status.CONNECTED, it.realtime.status.value)
                     it.realtime.disconnect()
                     assertEquals(Realtime.Status.DISCONNECTED, it.realtime.status.value)
+                }
+            )
+        }
+    }
+
+    @Test
+    fun testTeardown() {
+        runTest {
+            createTestClient(
+                wsHandler = { r, _ ->
+                    r.receive()
+                },
+                supabaseHandler = {
+                    val channel = it.realtime.channel("test")
+                    assertEquals(Realtime.Status.DISCONNECTED, it.realtime.status.value)
+                    it.realtime.connect()
+                    assertEquals(Realtime.Status.CONNECTED, it.realtime.status.value)
+                    channel.subscribe()
+                    assertEquals(RealtimeChannel.Status.SUBSCRIBING, channel.status.value)
+                    it.realtime.disconnect()
+                    assertEquals(Realtime.Status.DISCONNECTED, it.realtime.status.value)
+                    assertEquals(RealtimeChannel.Status.UNSUBSCRIBED, channel.status.value)
                 }
             )
         }


### PR DESCRIPTION
# What kind of change does this PR introduce?

Feature (closes #1176)

**Teardown and Cleanup Improvements:**

* Added a `teardown` method to the `RealtimeChannel` interface and implemented it in `RealtimeChannelImpl` to reset status and callbacks when a channel is torn down.
* Updated the `disconnect` method in `RealtimeImpl` to call `teardown` on all active channel subscriptions, ensuring all resources are properly cleaned up on disconnect.

**Callback Management:**

* Added a `reset` method to the `CallbackManager` interface and its implementation to clear all stored callbacks and related state, which is invoked during channel teardown. 

**Testing Enhancements:**

* Added a new test `testTeardown` in `RealtimeTest.kt` to verify that disconnecting the realtime client properly unsubscribes channels and resets their state. 