### PR TITLE
Fix indentation on error lines

### DIFF
--- a/Supabase/src/commonMain/kotlin/io/github/jan/supabase/exceptions/RestException.kt
+++ b/Supabase/src/commonMain/kotlin/io/github/jan/supabase/exceptions/RestException.kt
@@ -17,12 +17,14 @@ import io.ktor.client.statement.request
  * @see NotFoundRestException
  * @see UnknownRestException
  */
-open class RestException(val error: String, val description: String?, val response: HttpResponse): Exception("""
-        $error${description?.let { "\n$it" } ?: ""}
-        URL: ${maskUrl(response.request.url)}
-        Headers: ${maskHeaders(response.request.headers)}
-        Http Method: ${response.request.method.value}
-""".trimIndent()) {
+open class RestException(val error: String, val description: String?, val response: HttpResponse):
+    Exception(
+        error
+                + (description?.let { "\n$it" } ?: "")
+                + "\nURL: ${maskUrl(response.request.url)}"
+                + "\nHeaders: ${maskHeaders(response.request.headers)}"
+                + "\nHttp Method: ${response.request.method.value}"
+    ) {
 
     /**
      * The status code of the response


### PR DESCRIPTION
separate error lines because trimIndent doesn't work with variables containing multiple lines

## What kind of change does this PR introduce?

Minor text layout fix. Sorry, this is very nitpicky. I was reading logs and noticed the incorrect indentation.


