### PR TITLE
do not rewrite signed URL to render endpoint for empty transform object

### DIFF
--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/BucketApiImpl.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/BucketApiImpl.kt
@@ -30,7 +30,6 @@ import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonArray
-import kotlinx.serialization.json.putJsonObject
 import kotlin.io.encoding.Base64
 import kotlin.io.encoding.ExperimentalEncodingApi
 import kotlin.time.Duration
@@ -136,8 +135,11 @@ internal class BucketApiImpl(
         val transformation = ImageTransformation().apply(transform)
         val body = api.postJson("object/sign/$bucketId/$path", buildJsonObject {
             put("expiresIn", expiresIn.inWholeSeconds)
-            putJsonObject("transform") {
+            val transform = buildJsonObject {
                 putImageTransformation(transformation)
+            }
+            if(transform.isNotEmpty()) {
+                put("transform", transform)
             }
         }).safeBody<JsonObject>()
         return storage.resolveUrl(body["signedURL"]?.jsonPrimitive?.content?.substring(1)

--- a/Storage/src/commonTest/kotlin/BucketApiTest.kt
+++ b/Storage/src/commonTest/kotlin/BucketApiTest.kt
@@ -324,6 +324,39 @@ class BucketApiTest {
     }
 
     @Test
+    fun testCreateSignedUrlEmptyTransform() {
+        runTest {
+            val expectedPath = "folder/data.png"
+            val expectedExpiresIn = 120.seconds
+            val expectedUrl = "/object/sign/$bucketId/folder/data.png?token=12345"
+            val client = createMockedSupabaseClient(configuration = configureClient) {
+                assertMethodIs(HttpMethod.Post, it.method)
+                assertPathIs("/object/sign/$bucketId/$expectedPath", it.url.pathAfterVersion())
+                val content = it.body.toJsonElement().jsonObject
+                assertNull(content["transform"]?.jsonObject)
+                assertEquals(
+                    expectedExpiresIn,
+                    content["expiresIn"]?.jsonPrimitive?.long?.seconds,
+                    "Expires in should be $expectedExpiresIn"
+                )
+                respond(
+                    content = """
+                    { 
+                        "signedURL": "$expectedUrl"
+                    }
+                    """.trimIndent(),
+                    headers = headersOf(
+                        HttpHeaders.ContentType,
+                        ContentType.Application.Json.toString()
+                    )
+                )
+            }
+            val url = client.storage[bucketId].createSignedUrl(expectedPath, expectedExpiresIn)
+            assertEquals(client.storage.resolveUrl(expectedUrl.substring(1)), url, "URL should be $expectedUrl")
+        }
+    }
+
+    @Test
     fun testCreateSignedUrls() {
         runTest {
             val expectedPaths = listOf("folder/data.png", "folder/data2.png", "folder/data3.png")


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (closes #1209 

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
