### PR TITLE
Separate sub-APIs from parent APIs

### DIFF
--- a/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/AuthImpl.kt
+++ b/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/AuthImpl.kt
@@ -116,7 +116,7 @@ internal class AuthImpl(
     @OptIn(SupabaseInternal::class)
     internal val userApi = if(config.requireValidSession) supabaseClient.authenticatedSupabaseApi(this) else publicApi
     override val admin: AdminApi = AdminApiImpl(publicApi)
-    override val mfa: MfaApi = MfaApiImpl(this)
+    override val mfa: MfaApi = MfaApiImpl(userApi.resolve("factors"), this)
     var sessionJob: Job? = null
     var refreshInformation: SessionRefreshInformation? = null
     override val isAutoRefreshRunning: Boolean

--- a/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/mfa/MfaApi.kt
+++ b/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/mfa/MfaApi.kt
@@ -1,7 +1,7 @@
 package io.github.jan.supabase.auth.mfa
 
 import io.github.jan.supabase.auth.Auth
-import io.github.jan.supabase.auth.AuthImpl
+import io.github.jan.supabase.auth.api.AuthenticatedSupabaseApi
 import io.github.jan.supabase.auth.jwt.JWTUtils
 import io.github.jan.supabase.auth.providers.builtin.Phone
 import io.github.jan.supabase.auth.status.SessionStatus
@@ -100,7 +100,8 @@ interface MfaApi {
 
 @Suppress("DEPRECATION")
 internal class MfaApiImpl(
-    val auth: AuthImpl
+    private val api: AuthenticatedSupabaseApi,
+    private val auth: Auth
 ) : MfaApi {
 
     override val status: MfaStatus
@@ -127,10 +128,8 @@ internal class MfaApiImpl(
     override val verifiedFactors: List<UserMfaFactor>
         get() = auth.currentUserOrNull()?.factors?.filter(UserMfaFactor::isVerified) ?: emptyList()
 
-    val api = auth.userApi
-
     override suspend fun <Config, Response> enroll(factorType: FactorType<Config, Response>, friendlyName: String?, config: Config.() -> Unit): MfaFactor<Response> {
-        val result = api.postJson("factors", buildJsonObject {
+        val result = api.postJson("", buildJsonObject {
             put("factor_type", factorType.value)
             putJsonObject(factorType.encodeConfig(config))
             friendlyName?.let { put("friendly_name", it) }
@@ -145,7 +144,7 @@ internal class MfaApiImpl(
     }
 
     override suspend fun createChallenge(factorId: String, channel: Phone.Channel?): MfaChallenge {
-        val result = api.postJson("factors/$factorId/challenge", buildJsonObject {
+        val result = api.postJson("$factorId/challenge", buildJsonObject {
             if (channel != null) {
                 put("channel", channel.value)
             }
@@ -159,7 +158,7 @@ internal class MfaApiImpl(
         code: String,
         saveSession: Boolean
     ): UserSession {
-        val result = api.postJson("factors/$factorId/verify", buildJsonObject {
+        val result = api.postJson("$factorId/verify", buildJsonObject {
             put("code", code)
             put("challenge_id", challengeId)
         })
@@ -171,7 +170,7 @@ internal class MfaApiImpl(
     }
 
     override suspend fun unenroll(factorId: String) {
-        api.delete("factors/$factorId")
+        api.delete("$factorId")
     }
 
     override fun getAuthenticatorAssuranceLevel(jwt: String?): MfaLevel {

--- a/Auth/src/commonTest/kotlin/MfaApiTest.kt
+++ b/Auth/src/commonTest/kotlin/MfaApiTest.kt
@@ -50,7 +50,7 @@ class MfaApiTest {
         val client = createMockedSupabaseClient(
             configuration = configuration
         ) {
-            assertPathIs("/factors", it.url.pathAfterVersion())
+            assertPathIs("/factors/", it.url.pathAfterVersion())
             assertMethodIs(HttpMethod.Post, it.method)
             val body = it.body.toJsonElement().jsonObject
             assertEquals(friendlyName, body["friendly_name"]?.jsonPrimitive?.content)
@@ -84,7 +84,7 @@ class MfaApiTest {
         val client = createMockedSupabaseClient(
             configuration = configuration
         ) {
-            assertPathIs("/factors", it.url.pathAfterVersion())
+            assertPathIs("/factors/", it.url.pathAfterVersion())
             assertMethodIs(HttpMethod.Post, it.method)
             val body = it.body.toJsonElement().jsonObject
             assertEquals(friendlyName, body["friendly_name"]?.jsonPrimitive?.content)

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/BucketApiImpl.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/BucketApiImpl.kt
@@ -1,5 +1,6 @@
 package io.github.jan.supabase.storage
 
+import io.github.jan.supabase.auth.api.AuthenticatedSupabaseApi
 import io.github.jan.supabase.exceptions.RestException
 import io.github.jan.supabase.putJsonObject
 import io.github.jan.supabase.safeBody
@@ -36,12 +37,13 @@ import kotlin.time.Duration
 
 internal class BucketApiImpl(
     override val bucketId: String,
-    val storage: StorageImpl,
+    val storage: Storage,
+    api: AuthenticatedSupabaseApi,
     resumableCache: ResumableCache
 ) : BucketApi {
 
     private var headers = Headers.Empty
-    private val api = storage.api.withDefaultRequest {
+    private val api = api.withDefaultRequest {
         headers.appendAll(this@BucketApiImpl.headers)
     }
 
@@ -78,7 +80,7 @@ internal class BucketApiImpl(
     }
 
     override suspend fun createSignedUploadUrl(path: String, upsert: Boolean): UploadSignedUrl {
-        val result = api.post("object/upload/sign/$bucketId/$path") {
+        val result = api.post("upload/sign/$bucketId/$path") {
             header(UPSERT_HEADER, upsert.toString())
         }
         val urlPath = result.safeBody<JsonObject>()["url"]?.jsonPrimitive?.content?.substring(1)
@@ -102,7 +104,7 @@ internal class BucketApiImpl(
         )
 
     override suspend fun delete(paths: Collection<String>) {
-        api.deleteJson("object/$bucketId", buildJsonObject {
+        api.deleteJson("$bucketId", buildJsonObject {
             putJsonArray("prefixes") {
                 paths.forEach(this::add)
             }
@@ -110,7 +112,7 @@ internal class BucketApiImpl(
     }
 
     override suspend fun move(from: String, to: String, destinationBucket: String?) {
-        api.postJson("object/move", buildJsonObject {
+        api.postJson("move", buildJsonObject {
             put("bucketId", bucketId)
             put("sourceKey", from)
             put("destinationKey", to)
@@ -119,7 +121,7 @@ internal class BucketApiImpl(
     }
 
     override suspend fun copy(from: String, to: String, destinationBucket: String?) {
-        api.postJson("object/copy", buildJsonObject {
+        api.postJson("copy", buildJsonObject {
             put("bucketId", bucketId)
             put("sourceKey", from)
             put("destinationKey", to)
@@ -133,7 +135,7 @@ internal class BucketApiImpl(
         transform: ImageTransformation.() -> Unit
     ): String {
         val transformation = ImageTransformation().apply(transform)
-        val body = api.postJson("object/sign/$bucketId/$path", buildJsonObject {
+        val body = api.postJson("sign/$bucketId/$path", buildJsonObject {
             put("expiresIn", expiresIn.inWholeSeconds)
             val transform = buildJsonObject {
                 putImageTransformation(transformation)
@@ -150,7 +152,7 @@ internal class BucketApiImpl(
         expiresIn: Duration,
         paths: Collection<String>
     ): List<SignedUrl> {
-        val body = api.postJson("object/sign/$bucketId", buildJsonObject {
+        val body = api.postJson("sign/$bucketId", buildJsonObject {
             putJsonArray("paths") {
                 paths.forEach(this::add)
             }
@@ -241,20 +243,20 @@ internal class BucketApiImpl(
         prefix: String,
         filter: StorageListFilter.Files.() -> Unit
     ): List<FileObject> {
-        return api.postJson("object/list/$bucketId", buildJsonObject {
+        return api.postJson("list/$bucketId", buildJsonObject {
             put("prefix", prefix)
             putJsonObject(StorageListFilter.Files().apply(filter).buildBody())
         }).safeBody()
     }
 
     override suspend fun info(path: String): FileObjectV2 {
-        val response = api.get("object/info/$bucketId/$path")
+        val response = api.get("info/$bucketId/$path")
         return response.safeBody<FileObjectV2>().copy(serializer = storage.serializer)
     }
 
     override suspend fun exists(path: String): Boolean {
         try {
-            api.request("object/$bucketId/$path") {
+            api.request("$bucketId/$path") {
                 method = HttpMethod.Head
             }
             return true
@@ -264,9 +266,9 @@ internal class BucketApiImpl(
         }
     }
 
-    private fun defaultUploadUrl(path: String) = "object/$bucketId/$path"
+    private fun defaultUploadUrl(path: String) = "$bucketId/$path"
 
-    private fun uploadToSignedUrlUrl(path: String, token: String) = "object/upload/sign/$bucketId/$path?token=$token"
+    private fun uploadToSignedUrlUrl(path: String, token: String) = "upload/sign/$bucketId/$path?token=$token"
 
     internal suspend fun uploadOrUpdate(
         method: HttpMethod,

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/Storage.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/Storage.kt
@@ -278,7 +278,7 @@ internal class StorageImpl(override val supabaseClient: SupabaseClient, override
         api.post("bucket/$bucketId/empty")
     }
 
-    override fun get(bucketId: String): BucketApi = BucketApiImpl(bucketId, this, config.resumable.cache ?: createDefaultResumableCache())
+    override fun get(bucketId: String): BucketApi = BucketApiImpl(bucketId, this, api.resolve("object"), config.resumable.cache ?: createDefaultResumableCache())
 
     override suspend fun parseErrorResponse(response: HttpResponse): RestException {
         val statusCode = response.status


### PR DESCRIPTION
## What kind of change does this PR introduce?

Improvement (closes #1198)

## What is the current behavior?

Getting the API via `pluginImpl.api` which is not ideal

## What is the new behavior?

Separate API in the constructor of the corresponding sub API

## Additional context

Sub API = MfaApi, BucketApi, AdminApi, etc.
