### PR TITLE
Add support for custom OAuth provider

### DIFF
--- a/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/admin/AdminApi.kt
+++ b/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/admin/AdminApi.kt
@@ -4,10 +4,11 @@ import io.github.jan.supabase.annotations.SupabaseInternal
 import io.github.jan.supabase.auth.Auth
 import io.github.jan.supabase.auth.SignOutScope
 import io.github.jan.supabase.auth.admin.custom.provider.CustomProvidersApi
-import io.github.jan.supabase.auth.api.AuthenticatedSupabaseApi
-import io.github.jan.supabase.auth.user.UserInfo
+import io.github.jan.supabase.auth.admin.custom.provider.CustomProvidersApiImpl
 import io.github.jan.supabase.auth.admin.oauth.OAuthClientApi
 import io.github.jan.supabase.auth.admin.oauth.OAuthClientApiImpl
+import io.github.jan.supabase.auth.api.AuthenticatedSupabaseApi
+import io.github.jan.supabase.auth.user.UserInfo
 import io.github.jan.supabase.auth.user.UserMfaFactor
 import io.github.jan.supabase.putJsonObject
 import io.github.jan.supabase.safeBody
@@ -27,6 +28,9 @@ import kotlinx.serialization.json.put
  */
 interface AdminApi {
 
+    /**
+     * Contains all custom OIDC/OAuth provider administration methods
+     */
     val customProviders: CustomProvidersApi
 
     /**
@@ -111,6 +115,7 @@ interface AdminApi {
 internal class AdminApiImpl(val api: AuthenticatedSupabaseApi) : AdminApi {
 
     override val oauth: OAuthClientApi = OAuthClientApiImpl(api)
+    override val customProviders: CustomProvidersApi = CustomProvidersApiImpl(api.resolve("admin/custom-providers"))
 
     override suspend fun signOut(jwt: String, scope: SignOutScope) {
         api.post("logout") {

--- a/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/admin/AdminApi.kt
+++ b/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/admin/AdminApi.kt
@@ -3,6 +3,7 @@ package io.github.jan.supabase.auth.admin
 import io.github.jan.supabase.annotations.SupabaseInternal
 import io.github.jan.supabase.auth.Auth
 import io.github.jan.supabase.auth.SignOutScope
+import io.github.jan.supabase.auth.admin.custom.provider.CustomProvidersApi
 import io.github.jan.supabase.auth.api.AuthenticatedSupabaseApi
 import io.github.jan.supabase.auth.user.UserInfo
 import io.github.jan.supabase.auth.admin.oauth.OAuthClientApi
@@ -25,6 +26,8 @@ import kotlinx.serialization.json.put
  * The admin interface for the supabase auth module. Service role access token is required. Import it via [Auth.importAuthToken]. Never share it publicly
  */
 interface AdminApi {
+
+    val customProviders: CustomProvidersApi
 
     /**
      * The OAuth client management API

--- a/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/admin/custom/provider/CustomOAuthProvider.kt
+++ b/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/admin/custom/provider/CustomOAuthProvider.kt
@@ -1,0 +1,71 @@
+package io.github.jan.supabase.auth.admin.custom.provider
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonObject
+
+/**
+ * @param id Unique identifier (UUID)
+ * @param providerType Provider type
+ * @param identifier Provider identifier (e.g. `custom:mycompany`)
+ * @param name Human-readable name
+ * @param clientId OAuth client ID
+ * @param acceptableClientIds Additional client IDs accepted during token validation
+ * @param scopes OAuth scopes requested during authorization
+ * @param pkceEnabled Whether PKCE is enabled
+ * @param attributeMapping Mapping of provider attributes to Supabase user attributes
+ * @param authorizationParams Additional parameters sent with the authorization request
+ * @param enabled Whether the provider is enabled
+ * @param emailOptional Whether email is optional for this provider
+ * @param issuer OIDC issuer URL
+ * @param discoveryUrl OIDC discovery URL
+ * @param skipNonceCheck Whether to skip nonce check (OIDC)
+ * @param authorizationUrl OAuth2 authorization URL
+ * @param tokenUrl OAuth2 token URL
+ * @param userinfoUrl OAuth2 userinfo URL
+ * @param jwksUri JWKS URI for token verification
+ * @param discoveryDocument OIDC discovery document (OIDC providers only)
+ * @param createdAt Timestamp when the provider was created
+ * @param updatedAt Timestamp when the provider was last updated
+ */
+@Serializable
+data class CustomOAuthProvider(
+    val id: String,
+    @SerialName("provider_type")
+    val providerType: CustomProviderType,
+    val identifier: String,
+    val name: String,
+    @SerialName("client_id")
+    val clientId: String,
+    @SerialName("acceptable_client_ids")
+    val acceptableClientIds: List<String>? = null,
+    val scopes: List<String>? = null,
+    @SerialName("pkce_enabled")
+    val pkceEnabled: Boolean? = null,
+    @SerialName("attribute_mapping")
+    val attributeMapping: JsonObject? = null,
+    @SerialName("authorization_params")
+    val authorizationParams: Map<String, String>? = null,
+    val enabled: Boolean? = null,
+    @SerialName("email_optional")
+    val emailOptional: Boolean? = null,
+    val issuer: String? = null,
+    @SerialName("discovery_url")
+    val discoveryUrl: String? = null,
+    @SerialName("skip_nonce_check")
+    val skipNonceCheck: Boolean? = null,
+    @SerialName("authorization_url")
+    val authorizationUrl: String? = null,
+    @SerialName("token_url")
+    val tokenUrl: String? = null,
+    @SerialName("userinfo_url")
+    val userinfoUrl: String? = null,
+    @SerialName("jwks_uri")
+    val jwksUri: String? = null,
+    @SerialName("discovery_document")
+    val discoveryDocument: OIDCDiscoveryDocument? = null,
+    @SerialName("created_at")
+    val createdAt: String,
+    @SerialName("updated_at")
+    val updatedAt: String
+)

--- a/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/admin/custom/provider/CustomOAuthProvider.kt
+++ b/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/admin/custom/provider/CustomOAuthProvider.kt
@@ -3,6 +3,7 @@ package io.github.jan.supabase.auth.admin.custom.provider
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonObject
+import kotlin.time.Instant
 
 /**
  * @param id Unique identifier (UUID)
@@ -65,7 +66,7 @@ data class CustomOAuthProvider(
     @SerialName("discovery_document")
     val discoveryDocument: OIDCDiscoveryDocument? = null,
     @SerialName("created_at")
-    val createdAt: String,
+    val createdAt: Instant,
     @SerialName("updated_at")
-    val updatedAt: String
+    val updatedAt: Instant
 )

--- a/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/admin/custom/provider/CustomProviderBuilder.kt
+++ b/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/admin/custom/provider/CustomProviderBuilder.kt
@@ -139,6 +139,25 @@ class CustomProviderBuilder {
         requireNotNull(clientSecret) {
             "Client secret must be set"
         }
+        when(providerType) {
+            CustomProviderType.OAUTH2 -> {
+                requireNotNull(authorizationUrl) {
+                    "Authorization url must be set"
+                }
+                requireNotNull(tokenUrl) {
+                    "Token url must be set"
+                }
+                requireNotNull(userinfoUrl) {
+                    "userInfoUrl must be set"
+                }
+            }
+            CustomProviderType.OIDC -> {
+                requireNotNull(issuer) {
+                    "issuer must be set"
+                }
+            }
+            null -> TODO()
+        }
     }
 
 }

--- a/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/admin/custom/provider/CustomProviderBuilder.kt
+++ b/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/admin/custom/provider/CustomProviderBuilder.kt
@@ -10,8 +10,6 @@ import kotlinx.serialization.json.JsonObject
 @Serializable
 class CustomProviderBuilder {
 
-    // required:
-
     /**
      * Provider type
      */
@@ -39,8 +37,6 @@ class CustomProviderBuilder {
      */
     @SerialName("client_secret")
     var clientSecret: String? = null
-
-    // optional:
 
     /**
      * Additional client IDs accepted during token validation
@@ -124,9 +120,6 @@ class CustomProviderBuilder {
     var jwksUri: String? = null
 
     internal fun checkRequired() {
-        requireNotNull(providerType) {
-            "Provider type must be set"
-        }
         requireNotNull(identifier) {
             "Identifier must be set"
         }
@@ -139,7 +132,9 @@ class CustomProviderBuilder {
         requireNotNull(clientSecret) {
             "Client secret must be set"
         }
-        when(providerType) {
+        when(requireNotNull(providerType) {
+            "Provider type must be set"
+        }) {
             CustomProviderType.OAUTH2 -> {
                 requireNotNull(authorizationUrl) {
                     "Authorization url must be set"
@@ -156,7 +151,6 @@ class CustomProviderBuilder {
                     "issuer must be set"
                 }
             }
-            null -> TODO()
         }
     }
 

--- a/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/admin/custom/provider/CustomProviderBuilder.kt
+++ b/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/admin/custom/provider/CustomProviderBuilder.kt
@@ -8,38 +8,137 @@ import kotlinx.serialization.json.JsonObject
  * Parameters for creating a new custom provider.
  */
 @Serializable
-data class CustomProviderBuilder(
+class CustomProviderBuilder {
+
+    // required:
+
+    /**
+     * Provider type
+     */
     @SerialName("provider_type")
-    var providerType: CustomProviderType,
-    var identifier: String,
-    var name: String,
+    var providerType: CustomProviderType? = null
+
+    /**
+     * Provider identifier (e.g. `custom:mycompany`)
+     */
+    var identifier: String? = null
+
+    /**
+     * Human-readable name
+     */
+    var name: String? = null
+
+    /**
+     * OAuth client ID
+     */
     @SerialName("client_id")
-    var clientId: String,
+    var clientId: String? = null
+
+    /**
+     * OAuth client secret (write-only, not returned in responses)
+     */
     @SerialName("client_secret")
-    var clientSecret: String,
+    var clientSecret: String? = null
+
+    // optional:
+
+    /**
+     * Additional client IDs accepted during token validation
+     */
     @SerialName("acceptable_client_ids")
-    var acceptableClientIds: List<String>? = null,
-    var scopes: List<String>? = null,
+    var acceptableClientIds: List<String>? = null
+
+    /**
+     * OAuth scopes requested during authorization
+     */
+    var scopes: List<String>? = null
+
+    /**
+     * Whether PKCE is enabled
+     */
     @SerialName("pkce_enabled")
-    var pkceEnabled: Boolean? = null,
+    var pkceEnabled: Boolean? = null
+
+    /**
+     * Mapping of provider attributes to Supabase user attributes
+     */
     @SerialName("attribute_mapping")
-    var attributeMapping: JsonObject? = null,
+    var attributeMapping: JsonObject? = null
+
+    /**
+     * Additional parameters sent with the authorization request
+     */
     @SerialName("authorization_params")
-    var authorizationParams: JsonObject? = null,
-    var enabled: Boolean? = null,
+    var authorizationParams: JsonObject? = null
+
+    /**
+     * Whether the provider is enabled
+     */
+    var enabled: Boolean? = null
+
+    /**
+     * Whether email is optional for this provider
+     */
     @SerialName("email_optional")
-    var emailOptional: Boolean? = null,
-    var issuer: String? = null,
+    var emailOptional: Boolean? = null
+
+    /**
+     * OIDC issuer URL
+     */
+    var issuer: String? = null
+
+    /**
+     * OIDC discovery URL
+     */
     @SerialName("discovery_url")
-    var discoveryUrl: String? = null,
+    var discoveryUrl: String? = null
+
+    /**
+     * Whether to skip nonce check (OIDC)
+     */
     @SerialName("skip_nonce_check")
-    var skipNonceCheck: Boolean? = null,
+    var skipNonceCheck: Boolean? = null
+
+    /**
+     * OAuth2 authorization URL
+     */
     @SerialName("authorization_url")
-    var authorizationUrl: String? = null,
+    var authorizationUrl: String? = null
+
+    /**
+     * OAuth2 token URL
+     */
     @SerialName("token_url")
-    var tokenUrl: String? = null,
+    var tokenUrl: String? = null
+
+    /**
+     * OAuth2 userinfo URL
+     */
     @SerialName("userinfo_url")
-    var userinfoUrl: String? = null,
+    var userinfoUrl: String? = null
+
+    /**
+     * JWKS URI for token verification
+     */
     @SerialName("jwks_uri")
     var jwksUri: String? = null
-)
+
+    internal fun checkRequired() {
+        requireNotNull(providerType) {
+            "Provider type must be set"
+        }
+        requireNotNull(identifier) {
+            "Identifier must be set"
+        }
+        requireNotNull(name) {
+            "Name must be set"
+        }
+        requireNotNull(clientId) {
+            "Client id must be set"
+        }
+        requireNotNull(clientSecret) {
+            "Client secret must be set"
+        }
+    }
+
+}

--- a/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/admin/custom/provider/CustomProviderBuilder.kt
+++ b/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/admin/custom/provider/CustomProviderBuilder.kt
@@ -1,0 +1,45 @@
+package io.github.jan.supabase.auth.admin.custom.provider
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonObject
+
+/**
+ * Parameters for creating a new custom provider.
+ */
+@Serializable
+data class CustomProviderBuilder(
+    @SerialName("provider_type")
+    var providerType: CustomProviderType,
+    var identifier: String,
+    var name: String,
+    @SerialName("client_id")
+    var clientId: String,
+    @SerialName("client_secret")
+    var clientSecret: String,
+    @SerialName("acceptable_client_ids")
+    var acceptableClientIds: List<String>? = null,
+    var scopes: List<String>? = null,
+    @SerialName("pkce_enabled")
+    var pkceEnabled: Boolean? = null,
+    @SerialName("attribute_mapping")
+    var attributeMapping: JsonObject? = null,
+    @SerialName("authorization_params")
+    var authorizationParams: JsonObject? = null,
+    var enabled: Boolean? = null,
+    @SerialName("email_optional")
+    var emailOptional: Boolean? = null,
+    var issuer: String? = null,
+    @SerialName("discovery_url")
+    var discoveryUrl: String? = null,
+    @SerialName("skip_nonce_check")
+    var skipNonceCheck: Boolean? = null,
+    @SerialName("authorization_url")
+    var authorizationUrl: String? = null,
+    @SerialName("token_url")
+    var tokenUrl: String? = null,
+    @SerialName("userinfo_url")
+    var userinfoUrl: String? = null,
+    @SerialName("jwks_uri")
+    var jwksUri: String? = null
+)

--- a/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/admin/custom/provider/CustomProviderType.kt
+++ b/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/admin/custom/provider/CustomProviderType.kt
@@ -8,6 +8,13 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 enum class CustomProviderType {
+    /**
+     * OAuth2 custom provider type
+     */
     @SerialName("oauth2") OAUTH2,
+
+    /**
+     * OIDC custom provider type
+     */
     @SerialName("oidc") OIDC
 }

--- a/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/admin/custom/provider/CustomProviderType.kt
+++ b/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/admin/custom/provider/CustomProviderType.kt
@@ -1,0 +1,13 @@
+package io.github.jan.supabase.auth.admin.custom.provider
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Type of custom identity provider.
+ */
+@Serializable
+enum class CustomProviderType {
+    @SerialName("oauth2") OAUTH2,
+    @SerialName("oidc") OIDC
+}

--- a/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/admin/custom/provider/CustomProviderUpdateBuilder.kt
+++ b/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/admin/custom/provider/CustomProviderUpdateBuilder.kt
@@ -1,0 +1,43 @@
+package io.github.jan.supabase.auth.admin.custom.provider
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonObject
+
+/**
+ * Parameters for updating an existing custom provider.
+ * All fields are optional. Only provided fields will be updated.
+ */
+@Serializable
+data class CustomProviderUpdateBuilder(
+    var name: String? = null,
+    @SerialName("client_id")
+    var clientId: String? = null,
+    @SerialName("client_secret")
+    var clientSecret: String? = null,
+    @SerialName("acceptable_client_ids")
+    var acceptableClientIds: List<String>? = null,
+    var scopes: List<String>? = null,
+    @SerialName("pkce_enabled")
+    var pkceEnabled: Boolean? = null,
+    @SerialName("attribute_mapping")
+    var attributeMapping: JsonObject? = null,
+    @SerialName("authorization_params")
+    var authorizationParams: JsonObject? = null,
+    var enabled: Boolean? = null,
+    @SerialName("email_optional")
+    var emailOptional: Boolean? = null,
+    var issuer: String? = null,
+    @SerialName("discovery_url")
+    var discoveryUrl: String? = null,
+    @SerialName("skip_nonce_check")
+    var skipNonceCheck: Boolean? = null,
+    @SerialName("authorization_url")
+    var authorizationUrl: String? = null,
+    @SerialName("token_url")
+    var tokenUrl: String? = null,
+    @SerialName("userinfo_url")
+    var userinfoUrl: String? = null,
+    @SerialName("jwks_uri")
+    var jwksUri: String? = null
+)

--- a/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/admin/custom/provider/CustomProviderUpdateBuilder.kt
+++ b/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/admin/custom/provider/CustomProviderUpdateBuilder.kt
@@ -7,6 +7,23 @@ import kotlinx.serialization.json.JsonObject
 /**
  * Parameters for updating an existing custom provider.
  * All fields are optional. Only provided fields will be updated.
+ * @param name Human-readable name
+ * @param clientId OAuth client ID
+ * @param clientSecret OAuth client secret (write-only, not returned in responses)
+ * @param acceptableClientIds Additional client IDs accepted during token validation
+ * @param scopes OAuth scopes requested during authorization
+ * @param pkceEnabled Whether PKCE is enabled
+ * @param attributeMapping Mapping of provider attributes to Supabase user attributes
+ * @param authorizationParams Additional parameters sent with the authorization request
+ * @param enabled Whether the provider is enabled
+ * @param emailOptional Whether email is optional for this provider
+ * @param issuer OIDC issuer URL
+ * @param discoveryUrl OIDC discovery URL
+ * @param skipNonceCheck Whether to skip nonce check (OIDC)
+ * @param authorizationUrl OAuth2 authorization URL
+ * @param tokenUrl OAuth2 token URL
+ * @param userinfoUrl OAuth2 userinfo URL
+ * @param jwksUri JWKS URI for token verification
  */
 @Serializable
 data class CustomProviderUpdateBuilder(

--- a/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/admin/custom/provider/CustomProvidersApi.kt
+++ b/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/admin/custom/provider/CustomProvidersApi.kt
@@ -1,0 +1,54 @@
+package io.github.jan.supabase.auth.admin.custom.provider
+
+/**
+ * Contains all custom OIDC/OAuth provider administration methods.
+ */
+interface CustomProvidersApi {
+
+    /**
+     * Lists all custom providers with optional type filter.
+     *
+     * This function should only be called on a server. Never expose your `service_role` key in the browser.
+     */
+    suspend fun listProviders()
+
+    /**
+     * Creates a new custom OIDC/OAuth provider.
+     *
+     * For OIDC providers, the server fetches and validates the OpenID Connect discovery document
+     * from the issuer's well-known endpoint (or the provided `discovery_url`) at creation time.
+     * This may return a validation error (`error_code: "validation_failed"`) if the discovery
+     * document is unreachable, not valid JSON, missing required fields, or if the issuer
+     * in the document does not match the expected issuer.
+     *
+     * This function should only be called on a server. Never expose your `service_role` key in the browser.
+     */
+    suspend fun createProvider()
+
+    /**
+     * Gets details of a specific custom provider by identifier.
+     *
+     * This function should only be called on a server. Never expose your `service_role` key in the browser.
+     */
+    suspend fun getProvider()
+
+    /**
+     * Updates an existing custom provider.
+     *
+     * When `issuer` or `discovery_url` is changed on an OIDC provider, the server re-fetches and
+     * validates the discovery document before persisting. This may return a validation error
+     * (`error_code: "validation_failed"`) if the discovery document is unreachable, invalid, or
+     * the issuer does not match.
+     *
+     * This function should only be called on a server. Never expose your `service_role` key in the browser.
+     */
+    suspend fun updateProvider()
+
+    /**
+     * Deletes a custom provider.
+     *
+     * This function should only be called on a server. Never expose your `service_role` key in the browser.
+     */
+    suspend fun deleteProvider(identifier: String)
+
+}

--- a/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/admin/custom/provider/CustomProvidersApi.kt
+++ b/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/admin/custom/provider/CustomProvidersApi.kt
@@ -1,5 +1,12 @@
 package io.github.jan.supabase.auth.admin.custom.provider
 
+import io.github.jan.supabase.auth.api.AuthenticatedSupabaseApi
+import io.github.jan.supabase.safeBody
+import io.github.jan.supabase.supabaseJson
+import io.ktor.client.request.parameter
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.decodeFromJsonElement
+
 /**
  * Contains all custom OIDC/OAuth provider administration methods.
  */
@@ -9,8 +16,9 @@ interface CustomProvidersApi {
      * Lists all custom providers with optional type filter.
      *
      * This function should only be called on a server. Never expose your `service_role` key in the browser.
+     * @param type The custom provider type
      */
-    suspend fun listProviders()
+    suspend fun listProviders(type: CustomProviderType? = null): List<CustomOAuthProvider>
 
     /**
      * Creates a new custom OIDC/OAuth provider.
@@ -22,15 +30,17 @@ interface CustomProvidersApi {
      * in the document does not match the expected issuer.
      *
      * This function should only be called on a server. Never expose your `service_role` key in the browser.
+     * @param builder Builder for the new provider
      */
-    suspend fun createProvider()
+    suspend fun createProvider(builder: CustomProviderBuilder.() -> Unit): CustomOAuthProvider
 
     /**
      * Gets details of a specific custom provider by identifier.
      *
      * This function should only be called on a server. Never expose your `service_role` key in the browser.
+     * @param identifier The identifier of the OAuth provider
      */
-    suspend fun getProvider()
+    suspend fun getProvider(identifier: String): CustomOAuthProvider
 
     /**
      * Updates an existing custom provider.
@@ -41,14 +51,53 @@ interface CustomProvidersApi {
      * the issuer does not match.
      *
      * This function should only be called on a server. Never expose your `service_role` key in the browser.
+     * @param identifier The identifier of the OAuth provider
+     * @param builder The update builder
      */
-    suspend fun updateProvider()
+    suspend fun updateProvider(identifier: String, builder: CustomProviderUpdateBuilder.() -> Unit): CustomOAuthProvider
 
     /**
      * Deletes a custom provider.
      *
      * This function should only be called on a server. Never expose your `service_role` key in the browser.
+     * @param identifier The identifier of the OAuth provider
      */
     suspend fun deleteProvider(identifier: String)
 
+}
+
+internal class CustomProvidersApiImpl(
+    private val api: AuthenticatedSupabaseApi
+): CustomProvidersApi {
+
+    override suspend fun listProviders(type: CustomProviderType?): List<CustomOAuthProvider> {
+        val response = api.get("") {
+            type?.let {
+                parameter("type", it.name.lowercase())
+            }
+        }.safeBody<JsonObject>()
+        return response["providers"]?.let { supabaseJson.decodeFromJsonElement(it) } ?: emptyList()
+    }
+
+    override suspend fun createProvider(builder: CustomProviderBuilder.() -> Unit): CustomOAuthProvider {
+        val builder = CustomProviderBuilder().apply(builder)
+        builder.checkRequired()
+        return api.post("", builder).safeBody()
+    }
+
+    override suspend fun getProvider(identifier: String): CustomOAuthProvider {
+        return api.get(identifier).safeBody()
+    }
+
+    override suspend fun updateProvider(
+        identifier: String,
+        builder: CustomProviderUpdateBuilder.() -> Unit
+    ): CustomOAuthProvider {
+        val builder = CustomProviderUpdateBuilder().apply(builder)
+        return api.put(identifier, builder).safeBody()
+    }
+
+    override suspend fun deleteProvider(identifier: String) {
+        api.delete(identifier)
+    }
 }

--- a/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/admin/custom/provider/CustomProvidersApi.kt
+++ b/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/admin/custom/provider/CustomProvidersApi.kt
@@ -82,7 +82,7 @@ internal class CustomProvidersApiImpl(
     override suspend fun createProvider(builder: CustomProviderBuilder.() -> Unit): CustomOAuthProvider {
         val builder = CustomProviderBuilder().apply(builder)
         builder.checkRequired()
-        return api.post("", builder).safeBody()
+        return api.postJson("", builder).safeBody()
     }
 
     override suspend fun getProvider(identifier: String): CustomOAuthProvider {
@@ -94,7 +94,7 @@ internal class CustomProvidersApiImpl(
         builder: CustomProviderUpdateBuilder.() -> Unit
     ): CustomOAuthProvider {
         val builder = CustomProviderUpdateBuilder().apply(builder)
-        return api.put(identifier, builder).safeBody()
+        return api.putJson(identifier, builder).safeBody()
     }
 
     override suspend fun deleteProvider(identifier: String) {

--- a/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/admin/custom/provider/OIDCDiscoveryDocument.kt
+++ b/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/admin/custom/provider/OIDCDiscoveryDocument.kt
@@ -1,0 +1,43 @@
+package io.github.jan.supabase.auth.admin.custom.provider
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * OIDC discovery document fields.
+ * Populated when the server successfully fetches and validates the
+ * provider's OpenID Connect discovery document.
+ *
+ * @param issuer The issuer identifier
+ * @param authorizationEndpoint URL of the authorization endpoint
+ * @param tokenEndpoint URL of the token endpoint
+ * @param jwksUri URL of the JSON Web Key Set
+ * @param userinfoEndpoint URL of the userinfo endpoint
+ * @param revocationEndpoint URL of the revocation endpoint
+ * @param supportedScopes List of supported scopes
+ * @param supportedResponseTypes List of supported response types
+ * @param supportedSubjectTypes List of supported subject types
+ * @param supportedIdTokenSigningAlgs List of supported ID token signing algorithms
+ */
+@Serializable
+data class OIDCDiscoveryDocument(
+    val issuer: String,
+    @SerialName("authorization_endpoint")
+    val authorizationEndpoint: String,
+    @SerialName("token_endpoint")
+    val tokenEndpoint: String,
+    @SerialName("jwks_uri")
+    val jwksUri: String,
+    @SerialName("userinfo_endpoint")
+    val userinfoEndpoint: String? = null,
+    @SerialName("revocation_endpoint")
+    val revocationEndpoint: String? = null,
+    @SerialName("supported_scopes")
+    val supportedScopes: List<String>? = null,
+    @SerialName("supported_response_types")
+    val supportedResponseTypes: List<String>? = null,
+    @SerialName("supported_subject_types")
+    val supportedSubjectTypes: List<String>? = null,
+    @SerialName("supported_id_token_signing_algs")
+    val supportedIdTokenSigningAlgs: List<String>? = null
+)

--- a/Auth/src/commonTest/kotlin/CustomProviderTest.kt
+++ b/Auth/src/commonTest/kotlin/CustomProviderTest.kt
@@ -1,0 +1,2 @@
+class CustomProviderTest {
+}

--- a/Auth/src/commonTest/kotlin/CustomProviderTest.kt
+++ b/Auth/src/commonTest/kotlin/CustomProviderTest.kt
@@ -1,2 +1,296 @@
+import io.github.jan.supabase.SupabaseClient
+import io.github.jan.supabase.SupabaseClientBuilder
+import io.github.jan.supabase.auth.Auth
+import io.github.jan.supabase.auth.admin.custom.provider.CustomOAuthProvider
+import io.github.jan.supabase.auth.admin.custom.provider.CustomProviderType
+import io.github.jan.supabase.auth.auth
+import io.github.jan.supabase.auth.minimalConfig
+import io.github.jan.supabase.testing.assertMethodIs
+import io.github.jan.supabase.testing.assertPathIs
+import io.github.jan.supabase.testing.createMockedSupabaseClient
+import io.github.jan.supabase.testing.pathAfterVersion
+import io.github.jan.supabase.testing.respondJson
+import io.github.jan.supabase.testing.toJsonElement
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpMethod
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.decodeFromJsonElement
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.time.Instant
+
 class CustomProviderTest {
+
+    private val configuration: SupabaseClientBuilder.() -> Unit = {
+        install(Auth) {
+            minimalConfig()
+        }
+    }
+
+    private val sampleOIDCProvider = CustomOAuthProvider(
+        id = "provider-id-1",
+        providerType = CustomProviderType.OIDC,
+        identifier = "custom:my-provider",
+        name = "My Custom Provider",
+        clientId = "client-id-123",
+        issuer = "https://accounts.example.com",
+        scopes = listOf("openid", "profile", "email"),
+        createdAt = Instant.parse("2024-01-01T00:00:00Z"),
+        updatedAt = Instant.parse("2024-01-01T00:00:00Z")
+    )
+
+    private val sampleOAuth2Provider = CustomOAuthProvider(
+        id = "provider-id-2",
+        providerType = CustomProviderType.OAUTH2,
+        identifier = "custom:oauth2-provider",
+        name = "OAuth2 Provider",
+        clientId = "oauth2-client-id",
+        authorizationUrl = "https://provider.example.com/authorize",
+        tokenUrl = "https://provider.example.com/token",
+        userinfoUrl = "https://provider.example.com/userinfo",
+        scopes = listOf("profile", "email"),
+        createdAt = Instant.parse("2024-01-02T00:00:00Z"),
+        updatedAt = Instant.parse("2024-01-02T00:00:00Z")
+    )
+
+    private lateinit var client: SupabaseClient
+
+    @Test
+    fun testListProvidersNoFilter() {
+        runTest {
+            client = createMockedSupabaseClient(configuration = configuration) {
+                assertPathIs("/admin/custom-providers/", it.url.pathAfterVersion())
+                assertMethodIs(HttpMethod.Get, it.method)
+                val params = it.url.parameters
+                assertNull(params["type"])
+                respondJson(
+                    """{"providers": ${Json.encodeToJsonElement(listOf(sampleOIDCProvider, sampleOAuth2Provider))}}"""
+                )
+            }
+            client.auth.awaitInitialization()
+            val providers = client.auth.admin.customProviders.listProviders()
+            assertEquals(2, providers.size)
+            assertEquals("custom:my-provider", providers[0].identifier)
+            assertEquals("custom:oauth2-provider", providers[1].identifier)
+        }
+    }
+
+    @Test
+    fun testListProvidersFilterByOIDC() {
+        runTest {
+            client = createMockedSupabaseClient(configuration = configuration) {
+                assertPathIs("/admin/custom-providers/", it.url.pathAfterVersion())
+                assertMethodIs(HttpMethod.Get, it.method)
+                val params = it.url.parameters
+                assertEquals("oidc", params["type"])
+                respondJson(
+                    """{"providers": ${Json.encodeToJsonElement(listOf(sampleOIDCProvider))}}"""
+                )
+            }
+            client.auth.awaitInitialization()
+            val providers = client.auth.admin.customProviders.listProviders(CustomProviderType.OIDC)
+            assertEquals(1, providers.size)
+            assertEquals("custom:my-provider", providers[0].identifier)
+            assertEquals(CustomProviderType.OIDC, providers[0].providerType)
+        }
+    }
+
+    @Test
+    fun testListProvidersFilterByOAuth2() {
+        runTest {
+            client = createMockedSupabaseClient(configuration = configuration) {
+                assertPathIs("/admin/custom-providers/", it.url.pathAfterVersion())
+                assertMethodIs(HttpMethod.Get, it.method)
+                val params = it.url.parameters
+                assertEquals("oauth2", params["type"])
+                respondJson(
+                    """{"providers": ${Json.encodeToJsonElement(listOf(sampleOAuth2Provider))}}"""
+                )
+            }
+            client.auth.awaitInitialization()
+            val providers = client.auth.admin.customProviders.listProviders(CustomProviderType.OAUTH2)
+            assertEquals(1, providers.size)
+            assertEquals("custom:oauth2-provider", providers[0].identifier)
+            assertEquals(CustomProviderType.OAUTH2, providers[0].providerType)
+        }
+    }
+
+    @Test
+    fun testCreateProviderOIDC() {
+        runTest {
+            client = createMockedSupabaseClient(configuration = configuration) {
+                assertPathIs("/admin/custom-providers/", it.url.pathAfterVersion())
+                assertMethodIs(HttpMethod.Post, it.method)
+                val body = it.body.toJsonElement().jsonObject
+                assertEquals("oidc", body["provider_type"]?.jsonPrimitive?.content)
+                assertEquals("custom:my-provider", body["identifier"]?.jsonPrimitive?.content)
+                assertEquals("My Custom Provider", body["name"]?.jsonPrimitive?.content)
+                assertEquals("client-id-123", body["client_id"]?.jsonPrimitive?.content)
+                assertEquals("client-secret", body["client_secret"]?.jsonPrimitive?.content)
+                assertEquals("https://accounts.example.com", body["issuer"]?.jsonPrimitive?.content)
+                assertEquals(setOf("openid", "profile", "email"), Json.decodeFromJsonElement(body["scopes"]!!))
+                respondJson(Json.encodeToJsonElement(sampleOIDCProvider).toString())
+            }
+            client.auth.awaitInitialization()
+            val provider = client.auth.admin.customProviders.createProvider {
+                providerType = CustomProviderType.OIDC
+                identifier = "custom:my-provider"
+                name = "My Custom Provider"
+                clientId = "client-id-123"
+                clientSecret = "client-secret"
+                issuer = "https://accounts.example.com"
+                scopes = listOf("openid", "profile", "email")
+            }
+            assertEquals("custom:my-provider", provider.identifier)
+            assertEquals(CustomProviderType.OIDC, provider.providerType)
+        }
+    }
+
+    @Test
+    fun testCreateProviderOAuth2() {
+        runTest {
+            client = createMockedSupabaseClient(configuration = configuration) {
+                assertPathIs("/admin/custom-providers/", it.url.pathAfterVersion())
+                assertMethodIs(HttpMethod.Post, it.method)
+                val body = it.body.toJsonElement().jsonObject
+                assertEquals("oauth2", body["provider_type"]?.jsonPrimitive?.content)
+                assertEquals("custom:oauth2-provider", body["identifier"]?.jsonPrimitive?.content)
+                assertEquals("https://provider.example.com/authorize", body["authorization_url"]?.jsonPrimitive?.content)
+                assertEquals("https://provider.example.com/token", body["token_url"]?.jsonPrimitive?.content)
+                assertEquals("https://provider.example.com/userinfo", body["userinfo_url"]?.jsonPrimitive?.content)
+                assertEquals(setOf("profile", "email"), Json.decodeFromJsonElement(body["scopes"]!!))
+                respondJson(Json.encodeToJsonElement(sampleOAuth2Provider).toString())
+            }
+            client.auth.awaitInitialization()
+            val provider = client.auth.admin.customProviders.createProvider {
+                providerType = CustomProviderType.OAUTH2
+                identifier = "custom:oauth2-provider"
+                name = "OAuth2 Provider"
+                clientId = "oauth2-client-id"
+                clientSecret = "oauth2-secret"
+                authorizationUrl = "https://provider.example.com/authorize"
+                tokenUrl = "https://provider.example.com/token"
+                userinfoUrl = "https://provider.example.com/userinfo"
+                scopes = listOf("profile", "email")
+            }
+            assertEquals("custom:oauth2-provider", provider.identifier)
+            assertEquals(CustomProviderType.OAUTH2, provider.providerType)
+        }
+    }
+
+    @Test
+    fun testGetProvider() {
+        runTest {
+            val providerId = "custom:my-provider"
+            client = createMockedSupabaseClient(configuration = configuration) {
+                assertPathIs("/admin/custom-providers/$providerId", it.url.pathAfterVersion())
+                assertMethodIs(HttpMethod.Get, it.method)
+                respondJson(Json.encodeToJsonElement(sampleOIDCProvider).toString())
+            }
+            client.auth.awaitInitialization()
+            val provider = client.auth.admin.customProviders.getProvider(providerId)
+            assertEquals("custom:my-provider", provider.identifier)
+            assertEquals("My Custom Provider", provider.name)
+            assertEquals(CustomProviderType.OIDC, provider.providerType)
+        }
+    }
+
+    @Test
+    fun testUpdateProvider() {
+        runTest {
+            val providerId = "custom:my-provider"
+            val updatedName = "Updated Provider Name"
+            client = createMockedSupabaseClient(configuration = configuration) {
+                assertPathIs("/admin/custom-providers/$providerId", it.url.pathAfterVersion())
+                assertMethodIs(HttpMethod.Put, it.method)
+                val body = it.body.toJsonElement().jsonObject
+                assertEquals(updatedName, body["name"]?.jsonPrimitive?.content)
+                assertEquals("https://new-issuer.example.com", body["issuer"]?.jsonPrimitive?.content)
+                assertNull(body["client_secret"])
+                respondJson(
+                    Json.encodeToJsonElement(sampleOIDCProvider.copy(name = updatedName, issuer = "https://new-issuer.example.com")).toString()
+                )
+            }
+            client.auth.awaitInitialization()
+            val provider = client.auth.admin.customProviders.updateProvider(providerId) {
+                name = updatedName
+                issuer = "https://new-issuer.example.com"
+            }
+            assertEquals(updatedName, provider.name)
+            assertEquals("https://new-issuer.example.com", provider.issuer)
+        }
+    }
+
+    @Test
+    fun testDeleteProvider() {
+        runTest {
+            val providerId = "custom:my-provider"
+            client = createMockedSupabaseClient(configuration = configuration) {
+                assertPathIs("/admin/custom-providers/$providerId", it.url.pathAfterVersion())
+                assertMethodIs(HttpMethod.Delete, it.method)
+                respond("")
+            }
+            client.auth.awaitInitialization()
+            client.auth.admin.customProviders.deleteProvider(providerId)
+        }
+    }
+
+    @Test
+    fun testListProvidersEmptyResponse() {
+        runTest {
+            client = createMockedSupabaseClient(configuration = configuration) {
+                assertPathIs("/admin/custom-providers/", it.url.pathAfterVersion())
+                respondJson("""{"providers": []}""")
+            }
+            client.auth.awaitInitialization()
+            val providers = client.auth.admin.customProviders.listProviders()
+            assertEquals(0, providers.size)
+        }
+    }
+
+    @Test
+    fun testCreateProviderWithOptionalFields() {
+        runTest {
+            client = createMockedSupabaseClient(configuration = configuration) {
+                assertPathIs("/admin/custom-providers/", it.url.pathAfterVersion())
+                assertMethodIs(HttpMethod.Post, it.method)
+                val body = it.body.toJsonElement().jsonObject
+                assertEquals("oidc", body["provider_type"]?.jsonPrimitive?.content)
+
+                assertNotNull(body["pkce_enabled"])
+                assertNotNull(body["email_optional"])
+                respondJson(Json.encodeToString(sampleOIDCProvider.copy(pkceEnabled = true, emailOptional = false)))
+            }
+            client.auth.awaitInitialization()
+            val provider = client.auth.admin.customProviders.createProvider {
+                providerType = CustomProviderType.OIDC
+                identifier = "custom:my-provider"
+                name = "My Provider"
+                clientId = "client-id"
+                clientSecret = "client-secret"
+                issuer = "https://example.com"
+                pkceEnabled = true
+                emailOptional = false
+            }
+            assertEquals(true, provider.pkceEnabled)
+            assertEquals(false, provider.emailOptional)
+        }
+    }
+
+    @AfterTest
+    fun cleanup() {
+        runTest {
+            if (::client.isInitialized) {
+                client.close()
+            }
+        }
+    }
+
 }

--- a/integration-test/src/test/kotlin/io/github/jan/supabase/integration/auth/AuthIntegrationTest.kt
+++ b/integration-test/src/test/kotlin/io/github/jan/supabase/integration/auth/AuthIntegrationTest.kt
@@ -1,15 +1,17 @@
-package io.github.jan.supabase.integration
+package io.github.jan.supabase.integration.auth
 
 import io.github.jan.supabase.auth.auth
 import io.github.jan.supabase.auth.providers.builtin.Email
 import io.github.jan.supabase.auth.status.SessionStatus
 import io.github.jan.supabase.exceptions.RestException
+import io.github.jan.supabase.integration.IntegrationTestBase
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.JsonPrimitive
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
 import kotlin.test.assertNotNull
-import kotlin.test.assertFailsWith
 
 class AuthIntegrationTest : IntegrationTestBase() {
 
@@ -81,7 +83,7 @@ class AuthIntegrationTest : IntegrationTestBase() {
 
         val updatedUser = client.auth.updateUser {
             data {
-                put("display_name", kotlinx.serialization.json.JsonPrimitive("Test User"))
+                put("display_name", JsonPrimitive("Test User"))
             }
         }
 
@@ -89,7 +91,7 @@ class AuthIntegrationTest : IntegrationTestBase() {
         assertEquals(
             "Test User",
             updatedUser.userMetadata?.get("display_name")?.let {
-                (it as? kotlinx.serialization.json.JsonPrimitive)?.content
+                (it as? JsonPrimitive)?.content
             }
         )
     }

--- a/integration-test/src/test/kotlin/io/github/jan/supabase/integration/auth/CustomProviderIntegrationTest.kt
+++ b/integration-test/src/test/kotlin/io/github/jan/supabase/integration/auth/CustomProviderIntegrationTest.kt
@@ -1,0 +1,158 @@
+package io.github.jan.supabase.integration.auth
+
+import io.github.jan.supabase.SupabaseClient
+import io.github.jan.supabase.auth.Auth
+import io.github.jan.supabase.auth.admin.custom.provider.CustomOAuthProvider
+import io.github.jan.supabase.auth.admin.custom.provider.CustomProviderType
+import io.github.jan.supabase.auth.auth
+import io.github.jan.supabase.auth.minimalConfig
+import io.github.jan.supabase.createSupabaseClient
+import io.github.jan.supabase.integration.IntegrationTestBase
+import io.github.jan.supabase.postgrest.Postgrest
+import io.github.jan.supabase.storage.Storage
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class CustomProviderIntegrationTest: IntegrationTestBase() {
+
+    private fun createServiceRoleClient() = createSupabaseClient(supabaseUrl, supabaseServiceRoleKey) {
+        install(Auth) {
+            minimalConfig()
+        }
+        install(Postgrest)
+        install(Storage)
+    }
+
+    @Test
+    fun testCreateAndTestClientOAuth2() = runTest {
+        val client = createServiceRoleClient()
+        val provider = client.auth.admin.customProviders.createProvider {
+            providerType = CustomProviderType.OAUTH2
+            identifier = "custom:local-dev-mock"
+            name = "Local Development Provider"
+            clientId = "dev-client-id-12345"
+            clientSecret = "dev-secret-super-safe-67890"
+            authorizationUrl = "https://accounts.google.com/o/oauth2/v2/auth"
+            tokenUrl = "https://oauth2.googleapis.com/token"
+            userinfoUrl = "https://www.googleapis.com/oauth2/v3/userinfo"
+            scopes = listOf("profile", "email")
+        }
+        try {
+            assertEquals("custom:local-dev-mock", provider.identifier)
+            assertEquals(CustomProviderType.OAUTH2, provider.providerType)
+            assertEquals("Local Development Provider", provider.name)
+            assertEquals("dev-client-id-12345", provider.clientId)
+            assertEquals("https://accounts.google.com/o/oauth2/v2/auth", provider.authorizationUrl)
+            assertEquals("https://oauth2.googleapis.com/token", provider.tokenUrl)
+            assertEquals("https://www.googleapis.com/oauth2/v3/userinfo", provider.userinfoUrl)
+            assertEquals(setOf("profile", "email"), provider.scopes?.toSet())
+        } finally {
+            client.auth.admin.customProviders.deleteProvider(provider.identifier)
+        }
+    }
+
+    @Test
+    fun testCreateAndTestClientOIDC() = runTest {
+        val client = createServiceRoleClient()
+        val provider = client.auth.admin.customProviders.createProvider {
+            providerType = CustomProviderType.OIDC
+            identifier = "custom:local-dev-mock"
+            name = "Local Development Provider"
+            clientId = "dev-client-id-12345"
+            clientSecret = "dev-secret-super-safe-67890"
+            issuer = "https://accounts.google.com"
+            scopes = listOf("profile", "email")
+        }
+        try {
+            assertEquals("custom:local-dev-mock", provider.identifier)
+            assertEquals(CustomProviderType.OIDC, provider.providerType)
+            assertEquals("Local Development Provider", provider.name)
+            assertEquals("dev-client-id-12345", provider.clientId)
+            assertEquals("https://accounts.google.com", provider.issuer)
+            assertEquals(setOf("profile", "email", "openid"), provider.scopes?.toSet())
+        } finally {
+            client.auth.admin.customProviders.deleteProvider(provider.identifier)
+        }
+    }
+
+    @Test
+    fun testCreateAndGetClient() = runTest {
+        val client = createServiceRoleClient()
+        val provider = client.createProvider()
+        val fetchedProvider = client.auth.admin.customProviders.getProvider(provider.identifier)
+        try {
+            assertEquals(provider, fetchedProvider)
+        } finally {
+            client.auth.admin.customProviders.deleteProvider(provider.identifier)
+        }
+    }
+
+    @Test
+    fun testListProviderNoType() = runTest {
+        val client = createServiceRoleClient()
+        val provider = client.createProvider()
+        val fetchedProvider = client.auth.admin.customProviders.listProviders()
+        try {
+        assertEquals(listOf(provider), fetchedProvider)
+        } finally {
+            client.auth.admin.customProviders.deleteProvider(provider.identifier)
+        }
+        assertEquals(0, client.auth.admin.customProviders.listProviders().size)
+    }
+
+    @Test
+    fun testListProviderOIDC() = runTest {
+        val client = createServiceRoleClient()
+        val provider = client.createProvider()
+        val fetchedProvider = client.auth.admin.customProviders.listProviders(CustomProviderType.OIDC)
+        try {
+        assertEquals(listOf(provider), fetchedProvider)
+        } finally {
+            client.auth.admin.customProviders.deleteProvider(provider.identifier)
+        }
+        assertEquals(0, client.auth.admin.customProviders.listProviders().size)
+    }
+
+    @Test
+    fun testListProviderOAuth2() = runTest {
+        val client = createServiceRoleClient()
+        val provider = client.createProvider()
+        val fetchedProvider = client.auth.admin.customProviders.listProviders(CustomProviderType.OAUTH2)
+        try {
+        assertEquals(0, fetchedProvider.size)
+        } finally {
+            client.auth.admin.customProviders.deleteProvider(provider.identifier)
+        }
+        assertEquals(0, client.auth.admin.customProviders.listProviders().size)
+    }
+
+    @Test
+    fun testUpdateProvider() = runTest {
+        val client = createServiceRoleClient()
+        val provider = client.createProvider()
+        try {
+            val updated = client.auth.admin.customProviders.updateProvider(provider.identifier) {
+                name = "Test"
+            }
+            assertEquals("Test", updated.name)
+        } finally {
+            client.auth.admin.customProviders.deleteProvider(provider.identifier)
+        }
+        assertEquals(0, client.auth.admin.customProviders.listProviders().size)
+    }
+
+
+    private suspend fun SupabaseClient.createProvider(): CustomOAuthProvider {
+        return auth.admin.customProviders.createProvider {
+            providerType = CustomProviderType.OIDC
+            identifier = "custom:local-dev-mock"
+            name = "Local Development Provider"
+            clientId = "dev-client-id-12345"
+            clientSecret = "dev-secret-super-safe-67890"
+            issuer = "https://accounts.google.com"
+            scopes = listOf("profile", "email")
+        }
+    }
+
+}

--- a/integration-test/src/test/kotlin/io/github/jan/supabase/integration/auth/OAuthClientIntegrationTest.kt
+++ b/integration-test/src/test/kotlin/io/github/jan/supabase/integration/auth/OAuthClientIntegrationTest.kt
@@ -1,4 +1,4 @@
-package io.github.jan.supabase.integration
+package io.github.jan.supabase.integration.auth
 
 import io.github.jan.supabase.auth.Auth
 import io.github.jan.supabase.auth.admin.oauth.OAuthClientTokenEndpointAuthMethod
@@ -7,6 +7,7 @@ import io.github.jan.supabase.auth.auth
 import io.github.jan.supabase.auth.minimalConfig
 import io.github.jan.supabase.createSupabaseClient
 import io.github.jan.supabase.exceptions.RestException
+import io.github.jan.supabase.integration.IntegrationTestBase
 import io.github.jan.supabase.postgrest.Postgrest
 import io.github.jan.supabase.storage.Storage
 import kotlinx.coroutines.test.runTest


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature (closes #1207 

## What is the new behavior?

**Custom Providers API Integration:**

* Added a new `CustomProvidersApi` interface and its implementation, providing methods to list, create, retrieve, update, and delete custom OAuth2/OIDC providers. This API is now exposed as a property on `AdminApi` via the `customProviders` member. 

* Introduced the `CustomOAuthProvider` data class, representing the details of a custom OAuth2/OIDC provider, including configuration fields and metadata.
* Added the `CustomProviderBuilder` class for specifying parameters when creating a new provider, with validation for required fields.
* Added the `CustomProviderUpdateBuilder` data class for updating existing providers, where all fields are optional.
* Defined the `CustomProviderType` enum to distinguish between OAuth2 and OIDC provider types.
* Added the `OIDCDiscoveryDocument` data class to represent the OpenID Connect discovery document fields.