### PR TITLE
feat: Add automatic retries for transient Postgrest errors

### DIFF
--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/Postgrest.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/Postgrest.kt
@@ -108,7 +108,12 @@ interface Postgrest : MainPlugin<Postgrest.Config>, CustomSerializationPlugin {
         var propertyConversionMethod: PropertyConversionMethod = PropertyConversionMethod.CAMEL_CASE_TO_SNAKE_CASE,
         override var requireValidSession: Boolean = false,
         var urlLengthLimit: Int = 8000,
-        var timeout: Duration = 30.seconds
+        var timeout: Duration = 30.seconds,
+        /**
+         * Maximum number of retries for idempotent requests (GET, HEAD) that fail with
+         * transient errors (network errors, HTTP 503/520). Set to 0 to disable retries.
+         */
+        var maxRetries: Int = 3,
     ): MainConfig(), CustomSerializationConfig, AuthDependentPluginConfig {
 
         override var serializer: SupabaseSerializer? = null

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/Postgrest.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/Postgrest.kt
@@ -102,6 +102,7 @@ interface Postgrest : MainPlugin<Postgrest.Config>, CustomSerializationPlugin {
      * @param urlLengthLimit Maximum URL length in characters before warnings/errors are triggered. Defaults to 8000.
      * @param defaultSchema The default schema to use for the requests. Defaults to "public"
      * @param propertyConversionMethod The method to use to convert the property names to the column names in [PostgrestRequestBuilder] and [PostgrestUpdate]. Defaults to [PropertyConversionMethod.CAMEL_CASE_TO_SNAKE_CASE]
+     * @param maxRetries Maximum number of retries for idempotent requests (GET, HEAD) that fail with transient errors (network errors, HTTP 503/520). Set to 0 to disable retries. Defaults to 3.
      */
     data class Config(
         var defaultSchema: String = "public",
@@ -109,10 +110,6 @@ interface Postgrest : MainPlugin<Postgrest.Config>, CustomSerializationPlugin {
         override var requireValidSession: Boolean = false,
         var urlLengthLimit: Int = 8000,
         var timeout: Duration = 30.seconds,
-        /**
-         * Maximum number of retries for idempotent requests (GET, HEAD) that fail with
-         * transient errors (network errors, HTTP 503/520). Set to 0 to disable retries.
-         */
         var maxRetries: Int = 3,
     ): MainConfig(), CustomSerializationConfig, AuthDependentPluginConfig {
 

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/PostgrestImpl.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/PostgrestImpl.kt
@@ -74,7 +74,8 @@ internal class PostgrestImpl(override val supabaseClient: SupabaseClient, overri
             urlParams = urlParams,
             body = body,
             schema = requestBuilder.schema,
-            headers = requestBuilder.headers.build()
+            headers = requestBuilder.headers.build(),
+            retry = requestBuilder.retry,
         )
         return RestRequestExecutor.execute(postgrest = this, path = "rpc/$function", request = rpcRequest)
     }

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/executor/RestRequestExecutor.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/executor/RestRequestExecutor.kt
@@ -20,6 +20,7 @@ internal data object RestRequestExecutor : RequestExecutor {
     private const val MAX_RETRY_DELAY_MS = 30_000L
     private const val BASE_DELAY_MS = 1000L
     private const val BACKOFF_MULTIPLIER = 2.0
+    private const val RETRY_COUNT_HEADER = "x-retry-count"
 
     override suspend fun execute(
         postgrest: Postgrest,
@@ -38,7 +39,7 @@ internal data object RestRequestExecutor : RequestExecutor {
                 val response = authenticatedSupabaseApi.request(path) {
                     configurePostgrestRequest(request)
                     if (attempt > 0) {
-                        headers.append("x-retry-count", attempt.toString())
+                        headers.append(RETRY_COUNT_HEADER, attempt.toString())
                     }
                 }
                 return response.asPostgrestResult(postgrest)

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/executor/RestRequestExecutor.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/executor/RestRequestExecutor.kt
@@ -14,8 +14,12 @@ import kotlinx.coroutines.delay
 internal data object RestRequestExecutor : RequestExecutor {
 
     private val RETRYABLE_METHODS = setOf(HttpMethod.Get, HttpMethod.Head)
-    private val RETRYABLE_STATUS_CODES = setOf(503, 520)
+    private const val HTTP_SERVICE_UNAVAILABLE = 503
+    private const val HTTP_UNKNOWN_ERROR = 520
+    private val RETRYABLE_STATUS_CODES = setOf(HTTP_SERVICE_UNAVAILABLE, HTTP_UNKNOWN_ERROR)
     private const val MAX_RETRY_DELAY_MS = 30_000L
+    private const val BASE_DELAY_MS = 1000L
+    private const val BACKOFF_MULTIPLIER = 2.0
 
     override suspend fun execute(
         postgrest: Postgrest,
@@ -57,10 +61,8 @@ internal data object RestRequestExecutor : RequestExecutor {
         throw lastException!!
     }
 
-    private val BASE_DELAY_MS = 1000L
-
     private fun getRetryDelay(attempt: Int): Long {
-        val exponentialDelay = BASE_DELAY_MS * 2.0.pow(attempt).toLong()
+        val exponentialDelay = BASE_DELAY_MS * BACKOFF_MULTIPLIER.pow(attempt).toLong()
         return minOf(exponentialDelay, MAX_RETRY_DELAY_MS)
     }
 

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/executor/RestRequestExecutor.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/executor/RestRequestExecutor.kt
@@ -1,22 +1,67 @@
 package io.github.jan.supabase.postgrest.executor
 
+import io.github.jan.supabase.exceptions.HttpRequestException
+import io.github.jan.supabase.exceptions.RestException
 import io.github.jan.supabase.postgrest.Postgrest
 import io.github.jan.supabase.postgrest.PostgrestImpl
 import io.github.jan.supabase.postgrest.request.PostgrestRequest
 import io.github.jan.supabase.postgrest.result.PostgrestResult
+import io.ktor.http.HttpMethod
+import kotlin.math.pow
+import kotlinx.coroutines.delay
 
 @PublishedApi
 internal data object RestRequestExecutor : RequestExecutor {
+
+    private val RETRYABLE_METHODS = setOf(HttpMethod.Get, HttpMethod.Head)
+    private val RETRYABLE_STATUS_CODES = setOf(503, 520)
+    private const val MAX_RETRY_DELAY_MS = 30_000L
 
     override suspend fun execute(
         postgrest: Postgrest,
         path: String,
         request: PostgrestRequest
     ): PostgrestResult {
+        val maxRetries = postgrest.config.maxRetries
+        val shouldRetry = request.retry && request.method in RETRYABLE_METHODS
+        val retryCount = if (shouldRetry) maxRetries else 0
+
         val authenticatedSupabaseApi = (postgrest as PostgrestImpl).api
-        return authenticatedSupabaseApi.request(path) {
-            configurePostgrestRequest(request)
-        }.asPostgrestResult(postgrest)
+
+        var lastException: Exception? = null
+        for (attempt in 0..retryCount) {
+            try {
+                val response = authenticatedSupabaseApi.request(path) {
+                    configurePostgrestRequest(request)
+                    if (attempt > 0) {
+                        headers.append("x-retry-count", attempt.toString())
+                    }
+                }
+                return response.asPostgrestResult(postgrest)
+            } catch (e: RestException) {
+                lastException = e
+                if (attempt < retryCount && e.statusCode in RETRYABLE_STATUS_CODES) {
+                    delay(getRetryDelay(attempt))
+                } else {
+                    throw e
+                }
+            } catch (e: HttpRequestException) {
+                lastException = e
+                if (attempt < retryCount) {
+                    delay(getRetryDelay(attempt))
+                } else {
+                    throw e
+                }
+            }
+        }
+        throw lastException!!
+    }
+
+    private val BASE_DELAY_MS = 1000L
+
+    private fun getRetryDelay(attempt: Int): Long {
+        val exponentialDelay = BASE_DELAY_MS * 2.0.pow(attempt).toLong()
+        return minOf(exponentialDelay, MAX_RETRY_DELAY_MS)
     }
 
 }

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/PostgrestQueryBuilder.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/PostgrestQueryBuilder.kt
@@ -53,7 +53,8 @@ class PostgrestQueryBuilder(
             count = requestBuilder.count,
             urlParams = requestBuilder.params.mapToFirstValue(),
             schema = schema,
-            headers = requestBuilder.headers.build()
+            headers = requestBuilder.headers.build(),
+            retry = requestBuilder.retry,
         )
         return RestRequestExecutor.execute(postgrest = postgrest,path = table, request = selectRequest)
     }

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/PostgrestRequestBuilder.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/PostgrestRequestBuilder.kt
@@ -31,6 +31,21 @@ open class PostgrestRequestBuilder(@PublishedApi internal val propertyConversion
     @SupabaseExperimental val headers: HeadersBuilder = HeadersBuilder()
 
     /**
+     * Whether to retry this request on transient errors (network errors, HTTP 503/520).
+     * Only applies to idempotent requests (GET, HEAD) — non-idempotent requests are never retried.
+     * Set to `false` to disable retries for this specific request.
+     */
+    var retry: Boolean = true
+        private set
+
+    /**
+     * Disables automatic retries for this request.
+     */
+    fun noRetry() {
+        this.retry = false
+    }
+
+    /**
      * Setting [count] allows to use [PostgrestResult.countOrNull] to get the total amount of items in the database.
      * @param count algorithm to use to count rows in the table or view.
      */

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/request/PostgrestRequest.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/request/PostgrestRequest.kt
@@ -22,5 +22,7 @@ sealed interface PostgrestRequest {
     val returning: Returning get() = Returning.Minimal
     val prefer: List<String>
     val schema: String
+    /** Whether to retry on transient errors. Only applies to idempotent methods (GET, HEAD). */
+    val retry: Boolean get() = true
 
 }

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/request/RpcRequest.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/request/RpcRequest.kt
@@ -5,6 +5,7 @@ import io.ktor.http.Headers
 import io.ktor.http.HttpMethod
 import kotlinx.serialization.json.JsonElement
 
+@Suppress("LongParameterList")
 @PublishedApi
 internal class RpcRequest(
     override val method: HttpMethod,

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/request/RpcRequest.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/request/RpcRequest.kt
@@ -12,7 +12,8 @@ internal class RpcRequest(
     override val urlParams: Map<String, String>,
     override val body: JsonElement? = null,
     override val schema: String = "public",
-    override val headers: Headers = Headers.Empty
+    override val headers: Headers = Headers.Empty,
+    override val retry: Boolean = true,
 ) : PostgrestRequest {
 
     override val prefer = if (count != null) listOf("count=${count.identifier}") else listOf()

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/request/SelectRequest.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/request/SelectRequest.kt
@@ -11,6 +11,7 @@ import io.ktor.http.HttpMethod
     override val urlParams: Map<String, String>,
     override val schema: String,
     override val headers: Headers = Headers.Empty,
+    override val retry: Boolean = true,
 ): PostgrestRequest {
 
     override val method = if (head) HttpMethod.Head else HttpMethod.Get

--- a/Postgrest/src/commonTest/kotlin/RetryTest.kt
+++ b/Postgrest/src/commonTest/kotlin/RetryTest.kt
@@ -10,6 +10,7 @@ import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFails
 
 class RetryTest {
 
@@ -65,11 +66,11 @@ class RetryTest {
             respond("Service Unavailable", HttpStatusCode.ServiceUnavailable)
         }
         // POST (insert) should not retry - it will get a RestException from the error response
-        try {
+        assertFails {
             supabase.from("test").insert(buildJsonArray {
                 add(buildJsonObject { put("id", 1) })
             })
-        } catch (_: Exception) { }
+        }
         assertEquals(1, requestCount, "POST should not retry")
     }
 
@@ -82,11 +83,11 @@ class RetryTest {
             requestCount++
             respond("Service Unavailable", HttpStatusCode.ServiceUnavailable)
         }
-        try {
+        assertFails {
             supabase.from("test").select {
                 noRetry()
             }
-        } catch (_: Exception) { }
+        }
         assertEquals(1, requestCount, "Should not retry when noRetry() is set")
     }
 
@@ -101,9 +102,9 @@ class RetryTest {
         }
         // All retries fail with 503 - the last response should be returned as a result
         // (the error parsing happens in asPostgrestResult, not in the retry logic)
-        try {
+        assertFails {
             supabase.from("test").select()
-        } catch (_: Exception) { }
+        }
         assertEquals(3, requestCount, "Should attempt 1 + 2 retries = 3 total requests")
     }
 
@@ -152,9 +153,9 @@ class RetryTest {
             requestCount++
             respond("Service Unavailable", HttpStatusCode.ServiceUnavailable)
         }
-        try {
+        assertFails {
             supabase.from("test").select()
-        } catch (_: Exception) { }
+        }
         assertEquals(1, requestCount, "Should not retry when maxRetries is 0")
     }
 

--- a/Postgrest/src/commonTest/kotlin/RetryTest.kt
+++ b/Postgrest/src/commonTest/kotlin/RetryTest.kt
@@ -1,0 +1,176 @@
+import io.github.jan.supabase.SupabaseClientBuilder
+import io.github.jan.supabase.postgrest.Postgrest
+import io.github.jan.supabase.postgrest.from
+import io.github.jan.supabase.testing.createMockedSupabaseClient
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class RetryTest {
+
+    private var requestCount = 0
+
+    private fun configureClient(maxRetries: Int = 3): SupabaseClientBuilder.() -> Unit = {
+        install(Postgrest) {
+            this.maxRetries = maxRetries
+        }
+    }
+
+    @Test
+    fun testRetryOnHttp503() = runTest {
+        requestCount = 0
+        val supabase = createMockedSupabaseClient(
+            configuration = configureClient()
+        ) {
+            requestCount++
+            if (requestCount < 3) {
+                respond("Service Unavailable", HttpStatusCode.ServiceUnavailable)
+            } else {
+                respond("[]")
+            }
+        }
+        val result = supabase.from("test").select()
+        assertEquals(3, requestCount, "Should have retried until success")
+    }
+
+    @Test
+    fun testRetryOnHttp520() = runTest {
+        requestCount = 0
+        val supabase = createMockedSupabaseClient(
+            configuration = configureClient()
+        ) {
+            requestCount++
+            if (requestCount < 2) {
+                respond("Unknown Error", HttpStatusCode(520, "Unknown Error"))
+            } else {
+                respond("[]")
+            }
+        }
+        val result = supabase.from("test").select()
+        assertEquals(2, requestCount, "Should have retried once then succeeded")
+    }
+
+    @Test
+    fun testNoRetryForPost() = runTest {
+        requestCount = 0
+        val supabase = createMockedSupabaseClient(
+            configuration = configureClient()
+        ) {
+            requestCount++
+            respond("Service Unavailable", HttpStatusCode.ServiceUnavailable)
+        }
+        // POST (insert) should not retry - it will get a RestException from the error response
+        try {
+            supabase.from("test").insert(buildJsonArray {
+                add(buildJsonObject { put("id", 1) })
+            })
+        } catch (_: Exception) { }
+        assertEquals(1, requestCount, "POST should not retry")
+    }
+
+    @Test
+    fun testNoRetryWhenDisabled() = runTest {
+        requestCount = 0
+        val supabase = createMockedSupabaseClient(
+            configuration = configureClient()
+        ) {
+            requestCount++
+            respond("Service Unavailable", HttpStatusCode.ServiceUnavailable)
+        }
+        try {
+            supabase.from("test").select {
+                noRetry()
+            }
+        } catch (_: Exception) { }
+        assertEquals(1, requestCount, "Should not retry when noRetry() is set")
+    }
+
+    @Test
+    fun testMaxRetriesExhausted() = runTest {
+        requestCount = 0
+        val supabase = createMockedSupabaseClient(
+            configuration = configureClient(maxRetries = 2)
+        ) {
+            requestCount++
+            respond("Service Unavailable", HttpStatusCode.ServiceUnavailable)
+        }
+        // All retries fail with 503 - the last response should be returned as a result
+        // (the error parsing happens in asPostgrestResult, not in the retry logic)
+        try {
+            supabase.from("test").select()
+        } catch (_: Exception) { }
+        assertEquals(3, requestCount, "Should attempt 1 + 2 retries = 3 total requests")
+    }
+
+    @Test
+    fun testRetryCountHeader() = runTest {
+        requestCount = 0
+        var lastRetryHeader: String? = null
+        val supabase = createMockedSupabaseClient(
+            configuration = configureClient()
+        ) {
+            requestCount++
+            lastRetryHeader = it.headers["x-retry-count"]
+            if (requestCount < 3) {
+                respond("Service Unavailable", HttpStatusCode.ServiceUnavailable)
+            } else {
+                respond("[]")
+            }
+        }
+        supabase.from("test").select()
+        assertEquals("2", lastRetryHeader, "x-retry-count should be the attempt number")
+    }
+
+    @Test
+    fun testNoRetryHeaderOnFirstRequest() = runTest {
+        requestCount = 0
+        var firstRetryHeader: String? = "not-checked"
+        val supabase = createMockedSupabaseClient(
+            configuration = configureClient()
+        ) {
+            requestCount++
+            if (requestCount == 1) {
+                firstRetryHeader = it.headers["x-retry-count"]
+            }
+            respond("[]")
+        }
+        supabase.from("test").select()
+        assertEquals(null, firstRetryHeader, "First request should not have x-retry-count header")
+    }
+
+    @Test
+    fun testZeroMaxRetriesDisablesRetry() = runTest {
+        requestCount = 0
+        val supabase = createMockedSupabaseClient(
+            configuration = configureClient(maxRetries = 0)
+        ) {
+            requestCount++
+            respond("Service Unavailable", HttpStatusCode.ServiceUnavailable)
+        }
+        try {
+            supabase.from("test").select()
+        } catch (_: Exception) { }
+        assertEquals(1, requestCount, "Should not retry when maxRetries is 0")
+    }
+
+    @Test
+    fun testRetryOnNetworkError() = runTest {
+        requestCount = 0
+        val supabase = createMockedSupabaseClient(
+            configuration = configureClient()
+        ) {
+            requestCount++
+            if (requestCount < 2) {
+                throw RuntimeException("Connection reset")
+            }
+            respond("[]")
+        }
+        val result = supabase.from("test").select()
+        assertEquals(2, requestCount, "Should retry on network error")
+    }
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

  Feature

  Closes #1243

  ## What is the current behavior?

  All Postgrest requests fail immediately on transient errors (HTTP 503/520, network failures) with no retry
  mechanism. This is problematic for intermittent infrastructure issues where a retry would succeed.

  ## What is the new behavior?

  Idempotent requests (GET, HEAD) are automatically retried with exponential backoff on transient errors:

  - Retries on HTTP 503 (Service Unavailable) and 520 (Unknown Error)
  - Retries on network errors (connection failures, timeouts)
  - Exponential backoff: 1s, 2s, 4s delays (max 30s)
  - Default max 3 retries, configurable via `Postgrest.Config.maxRetries`
  - Per-query opt-out via `noRetry()` in the request builder
  - `x-retry-count` header sent on retried requests
  - Non-idempotent methods (POST, PATCH, DELETE) are never retried

  ```kotlin
  // Retries enabled by default for GET requests
  val result = supabase.from("messages").select()

  // Disable retries for a specific query
  val result = supabase.from("messages").select {
      noRetry()
  }

  // Configure max retries globally
  install(Postgrest) {
      maxRetries = 5  // default is 3
  }
```

  Additional context

  Matches the retry behavior in supabase-js (PR supabase/supabase-js#2072). The retry logic catches both
  RestException (for retryable HTTP status codes) and HttpRequestException (for network errors) since they
  represent different failure modes in the supabase-kt HTTP stack.
