### PR TITLE
Fix consecutive connects

### DIFF
--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeChannelImpl.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeChannelImpl.kt
@@ -68,6 +68,8 @@ internal class RealtimeChannelImpl(
         if(realtimeImpl.status.value != Realtime.Status.CONNECTED) {
             if(!realtimeImpl.config.connectOnSubscribe) error("You can't subscribe to a channel while the realtime client is not connected. Did you forget to call `realtime.connect()`?")
             realtimeImpl.connect()
+            // If connect fails, it will schedule a retry, wait for the connection
+            realtimeImpl.status.first { it == Realtime.Status.CONNECTED }
         }
         if(!realtimeImpl.subscriptions.containsKey(topic)) {
             realtime.addChannel(this)

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeImpl.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeImpl.kt
@@ -30,6 +30,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.buildJsonObject
+import kotlin.concurrent.atomics.AtomicBoolean
 import kotlin.concurrent.atomics.AtomicInt
 import kotlin.concurrent.atomics.AtomicReference
 import kotlin.concurrent.atomics.fetchAndIncrement
@@ -47,6 +48,7 @@ import kotlin.time.Clock
     private val _subscriptions = AtomicMutableMap<String, RealtimeChannel>()
     override val subscriptions: Map<String, RealtimeChannel> = _subscriptions
     private val scope = CoroutineScope(supabaseClient.coroutineDispatcher + SupervisorJob())
+    private val isReconnecting = AtomicBoolean(false)
     private val _accessToken = AtomicReference<String?>(null)
     val accessToken get() = _accessToken.load()
     private var heartbeatJob: Job? = null
@@ -66,12 +68,12 @@ import kotlin.time.Clock
     override suspend fun connect() = connect(false)
 
     private suspend fun connect(reconnect: Boolean) {
-        // Prevent multiple sources from starting the connection concurrently
-        if (!_status.compareAndSet(Realtime.Status.DISCONNECTED, Realtime.Status.CONNECTING)) return
         if (reconnect) {
             delay(config.reconnectDelay)
             Realtime.logger.d { "Reconnecting..." }
         }
+        // Prevent multiple sources from starting the connection concurrently
+        if (!_status.compareAndSet(Realtime.Status.DISCONNECTED, Realtime.Status.CONNECTING)) return
         try {
             ws = websocketFactory.create(websocketUrl)
             _status.value = Realtime.Status.CONNECTED
@@ -80,6 +82,7 @@ import kotlin.time.Clock
             startHeartbeating()
             if(reconnect) {
                 rejoinChannels()
+                isReconnecting.store(false)
             }
         } catch(e: Exception) {
             currentCoroutineContext().ensureActive()
@@ -87,6 +90,9 @@ import kotlin.time.Clock
                 Error while trying to connect to realtime websocket. Trying again in ${config.reconnectDelay}
                 URL: $websocketUrl
                 """.trimIndent() }
+            if(reconnect) {
+                isReconnecting.store(false)
+            }
             reconnect()
         }
     }
@@ -295,9 +301,11 @@ import kotlin.time.Clock
     }
 
     private fun reconnect() {
-        scope.launch {
-            disconnect()
-            connect(true)
+        if(isReconnecting.compareAndSet(expectedValue = false, newValue = true)) {
+            scope.launch {
+                disconnect()
+                connect(true)
+            }
         }
     }
 

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeImpl.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeImpl.kt
@@ -70,14 +70,13 @@ import kotlin.time.Clock
 
     override suspend fun connect() = connect(false)
 
-    private suspend fun connect(reconnect: Boolean) = mutex.withLock {
+    private suspend fun connect(reconnect: Boolean): Unit = mutex.withLock {
         if (reconnect) {
             delay(config.reconnectDelay)
             Realtime.logger.d { "Reconnecting..." }
         }
-        // Prevent multiple sources from starting the connection concurrently
-        if (!_status.compareAndSet(Realtime.Status.DISCONNECTED, Realtime.Status.CONNECTING))
-            return@withLock
+        if (status.value == Realtime.Status.CONNECTED) return
+        _status.value = Realtime.Status.CONNECTING
         try {
             ws = websocketFactory.create(websocketUrl)
             _status.value = Realtime.Status.CONNECTED

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeImpl.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeImpl.kt
@@ -29,8 +29,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.json.buildJsonObject
 import kotlin.concurrent.atomics.AtomicInt
 import kotlin.concurrent.atomics.AtomicReference
@@ -49,7 +47,6 @@ import kotlin.time.Clock
     private val _subscriptions = AtomicMutableMap<String, RealtimeChannel>()
     override val subscriptions: Map<String, RealtimeChannel> = _subscriptions
     private val scope = CoroutineScope(supabaseClient.coroutineDispatcher + SupervisorJob())
-    private val mutex = Mutex()
     private val _accessToken = AtomicReference<String?>(null)
     val accessToken get() = _accessToken.load()
     private var heartbeatJob: Job? = null
@@ -160,7 +157,7 @@ import kotlin.time.Clock
         ws = null
         heartbeatJob?.cancel()
         for ((_, channel) in subscriptions) {
-            channel.teardown()
+            channel.updateStatus(RealtimeChannel.Status.UNSUBSCRIBED)
         }
         _status.value = Realtime.Status.DISCONNECTED
     }
@@ -244,6 +241,9 @@ import kotlin.time.Clock
     override suspend fun close() {
         disconnect()
         scope.cancel()
+        for ((_, channel) in subscriptions) {
+            channel.teardown()
+        }
     }
 
     override suspend fun block() {
@@ -296,12 +296,7 @@ import kotlin.time.Clock
 
     private fun reconnect() {
         scope.launch {
-            Realtime.logger.d { "Closing websocket connection" }
-            messageJob?.cancel()
-            ws?.disconnect()
-            ws = null
-            heartbeatJob?.cancel()
-            _status.value = Realtime.Status.DISCONNECTED
+            disconnect()
             connect(true)
         }
     }

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeImpl.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeImpl.kt
@@ -65,13 +65,13 @@ import kotlin.time.Clock
 
     override suspend fun connect() = connect(false)
 
-    suspend fun connect(reconnect: Boolean): Unit = mutex.withLock {
+    private suspend fun connect(reconnect: Boolean) {
+        // Prevent multiple sources from starting the connection concurrently
+        if (!_status.compareAndSet(Realtime.Status.DISCONNECTED, Realtime.Status.CONNECTING)) return
         if (reconnect) {
             delay(config.reconnectDelay)
             Realtime.logger.d { "Reconnecting..." }
         }
-        if (status.value == Realtime.Status.CONNECTED) return
-        _status.value = Realtime.Status.CONNECTING
         try {
             ws = websocketFactory.create(websocketUrl)
             _status.value = Realtime.Status.CONNECTED

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeImpl.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeImpl.kt
@@ -29,6 +29,8 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.json.buildJsonObject
 import kotlin.concurrent.atomics.AtomicBoolean
 import kotlin.concurrent.atomics.AtomicInt
@@ -48,6 +50,7 @@ import kotlin.time.Clock
     private val _subscriptions = AtomicMutableMap<String, RealtimeChannel>()
     override val subscriptions: Map<String, RealtimeChannel> = _subscriptions
     private val scope = CoroutineScope(supabaseClient.coroutineDispatcher + SupervisorJob())
+    private val mutex = Mutex()
     private val isReconnecting = AtomicBoolean(false)
     private val _accessToken = AtomicReference<String?>(null)
     val accessToken get() = _accessToken.load()
@@ -67,13 +70,14 @@ import kotlin.time.Clock
 
     override suspend fun connect() = connect(false)
 
-    private suspend fun connect(reconnect: Boolean) {
+    private suspend fun connect(reconnect: Boolean) = mutex.withLock {
         if (reconnect) {
             delay(config.reconnectDelay)
             Realtime.logger.d { "Reconnecting..." }
         }
         // Prevent multiple sources from starting the connection concurrently
-        if (!_status.compareAndSet(Realtime.Status.DISCONNECTED, Realtime.Status.CONNECTING)) return
+        if (!_status.compareAndSet(Realtime.Status.DISCONNECTED, Realtime.Status.CONNECTING))
+            return@withLock
         try {
             ws = websocketFactory.create(websocketUrl)
             _status.value = Realtime.Status.CONNECTED


### PR DESCRIPTION
I'm still getting occasional silent reconnect failures. Part of the issue is that channels aren't marked as unsubscribed when the reconnection starts, which makes the failure silent. I don't know why the reconnect doesn't retry. I suspect that a heartbeat an websocket disconnect happen simultaneously and both start the reconnect process at the same time. It could be something completely different, but I still think this set of changes is correct.