### PR TITLE
Deprecate data property on IDToken.Config

### DIFF
--- a/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/providers/builtin/DefaultAuthProvider.kt
+++ b/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/providers/builtin/DefaultAuthProvider.kt
@@ -39,14 +39,12 @@ sealed interface DefaultAuthProvider<C, R> : AuthProvider<C, R> {
     /**
      * The default configuration for the provider.
      * @param captchaToken The captcha token when having captcha enabled
-     * @param data Extra data for the user
      */
     @Serializable
     sealed class Config(
         @Serializable(with = CaptchaTokenSerializer::class)
         @SerialName("gotrue_meta_security")
         var captchaToken: String? = null,
-        var data: JsonObject? = null,
     )
 
     override suspend fun login(

--- a/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/providers/builtin/Email.kt
+++ b/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/providers/builtin/Email.kt
@@ -22,9 +22,10 @@ data object Email : DefaultAuthProvider<Email.Config, UserInfo> {
      * The configuration for the email authentication method
      * @param email The email of the user
      * @param password The password of the user
+     * @param data Extra user metadata to include on signup
      */
     @Serializable
-    data class Config(var email: String = "", var password: String = ""): DefaultAuthProvider.Config()
+    data class Config(var email: String = "", var password: String = "", var data: JsonObject? = null): DefaultAuthProvider.Config()
 
     @OptIn(ExperimentalSerializationApi::class)
     override fun decodeResult(json: JsonObject): UserInfo = try {

--- a/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/providers/builtin/IDToken.kt
+++ b/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/providers/builtin/IDToken.kt
@@ -42,7 +42,16 @@ data object IDToken : DefaultAuthProvider<IDToken.Config, UserInfo> {
         @SerialName("access_token") var accessToken: String? = null,
         var nonce: String? = null,
         @property:SupabaseInternal @SerialName("link_identity") var linkIdentity: Boolean = false
-    ) : DefaultAuthProvider.Config()
+    ) : DefaultAuthProvider.Config() {
+
+        /**
+         * This property is ignored by the ID token endpoint and has no effect.
+         * It exists only for backward compatibility and will be removed in a future release.
+         * Use [Email.Config.data] or [Phone.Config.data] for signup metadata instead.
+         */
+        @Deprecated("data is ignored by the ID token endpoint. It exists only for backward compatibility.", level = DeprecationLevel.WARNING)
+        var data: JsonObject? = null
+    }
 
     @OptIn(ExperimentalSerializationApi::class)
     override fun decodeResult(json: JsonObject): UserInfo = try {

--- a/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/providers/builtin/Phone.kt
+++ b/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/providers/builtin/Phone.kt
@@ -29,9 +29,10 @@ data object Phone : DefaultAuthProvider<Phone.Config, UserInfo> {
      * @param phone The phone number of the user
      * @param password The password of the user
      * @param channel The channel to send the confirmation to
+     * @param data Extra user metadata to include on signup
      */
     @Serializable
-    data class Config(@SerialName("phone") var phone: String = "", var password: String = "", var channel: Channel = Channel.SMS): DefaultAuthProvider.Config()
+    data class Config(@SerialName("phone") var phone: String = "", var password: String = "", var channel: Channel = Channel.SMS, var data: JsonObject? = null): DefaultAuthProvider.Config()
 
     /**
      * Represents the phone number confirmation channel

--- a/Auth/src/commonTest/kotlin/AuthApiTest.kt
+++ b/Auth/src/commonTest/kotlin/AuthApiTest.kt
@@ -373,9 +373,6 @@ class AuthRequestTest {
     fun testSignInWithIDToken() {
         runTest {
             val captchaToken = "captchaToken"
-            val userData = buildJsonObject {
-                put("key", "value")
-            }
             val expectedIdToken = "idToken"
             val expectedProvider = Google
             val expectedAccessToken = "accessToken"
@@ -388,7 +385,6 @@ class AuthRequestTest {
                 assertPathIs("/token", it.url.pathAfterVersion())
                 assertEquals("id_token", params["grant_type"])
                 assertEquals(captchaToken, metaSecurity["captcha_token"]?.jsonPrimitive?.content)
-                assertEquals(userData, body["data"]!!.jsonObject)
                 assertEquals(expectedIdToken, body["id_token"]?.jsonPrimitive?.content)
                 assertEquals(expectedProvider.name, body["provider"]?.jsonPrimitive?.content)
                 assertEquals(expectedAccessToken, body["access_token"]?.jsonPrimitive?.content)
@@ -399,7 +395,6 @@ class AuthRequestTest {
             }.awaitInit()
             client.auth.signInWith(IDToken) {
                 this.captchaToken = captchaToken
-                data = userData
                 this.idToken = expectedIdToken
                 provider = expectedProvider
                 this.nonce = expectedNonce


### PR DESCRIPTION
## What kind of change does this PR introduce?

  Bug fix

  Closes #1104

  ## What is the current behavior?

  `IDToken.Config` exposes a `data` property inherited from `DefaultAuthProvider.Config`. Setting this
  property has no effect because the GoTrue ID token endpoint (`/token?grant_type=id_token`) does not accept
  a `data` field — it is silently ignored. This is confusing for users who expect it to work like it does for
   Email/Phone signup.

  ## What is the new behavior?

  - Removed `data` from `DefaultAuthProvider.Config` base class
  - Added `data` directly to `Email.Config` and `Phone.Config` where the signup endpoint actually uses it
  - Added a deprecated `data` on `IDToken.Config` for backward compatibility with a warning message
  explaining it has no effect

  Users setting `data` on IDToken will now see a deprecation warning:

  data is ignored by the ID token endpoint. It exists only for backward compatibility.

  ## Additional context

 The deprecated `data` property on `IDToken.Config` currently remains for backward compatibility. An
  alternative would be to remove it entirely, but that would be a breaking change for any code that sets
  `data` on IDToken sign-in (even though it has no effect). Happy to remove it if a breaking change is
  acceptable.