### PR TITLE
Use inject-based logging approach for configurabilty and mocking

### DIFF
--- a/Auth/src/androidMain/kotlin/io/github/jan/supabase/auth/setupPlatform.kt
+++ b/Auth/src/androidMain/kotlin/io/github/jan/supabase/auth/setupPlatform.kt
@@ -37,17 +37,17 @@ private fun addLifecycleCallbacks(auth: Auth) {
 
                 override fun onStart(owner: LifecycleOwner) {
                     if(!auth.isAutoRefreshRunning && auth.config.alwaysAutoRefresh) {
-                        Auth.logger.d {
+                        auth.logger.d {
                             "Trying to re-load session from storage..."
                         }
                         scope.launch {
                             val sessionFound = auth.loadFromStorage()
                             if(!sessionFound) {
-                                Auth.logger.d {
+                                auth.logger.d {
                                     "No session found, not starting auto refresh"
                                 }
                             } else {
-                                Auth.logger.d {
+                                auth.logger.d {
                                     "Session found, auto refresh started"
                                 }
                             }
@@ -57,7 +57,7 @@ private fun addLifecycleCallbacks(auth: Auth) {
                 }
                 override fun onStop(owner: LifecycleOwner) {
                     if(auth.isAutoRefreshRunning) {
-                        Auth.logger.d { "Cancelling auto refresh because app is switching to the background" }
+                        auth.logger.d { "Cancelling auto refresh because app is switching to the background" }
                         scope.launch {
                             auth.stopAutoRefreshForCurrentSession()
                             auth.setSessionStatus(SessionStatus.Initializing)

--- a/Auth/src/appleMain/kotlin/io/github/jan/supabase/auth/Apple.kt
+++ b/Auth/src/appleMain/kotlin/io/github/jan/supabase/auth/Apple.kt
@@ -22,14 +22,14 @@ fun SupabaseClient.handleDeeplinks(
     onError: (Throwable) -> Unit = {}
 ) {
     if (url.scheme != auth.config.scheme || url.host != auth.config.host) {
-        Auth.logger.d { "Received deeplink with wrong scheme or host" }
+        auth.logger.d { "Received deeplink with wrong scheme or host" }
         return
     }
     when (auth.config.flowType) {
         FlowType.IMPLICIT -> {
             val fragment = url.fragment
             if (fragment == null) {
-                Auth.logger.d { "No fragment for deeplink" }
+                auth.logger.d { "No fragment for deeplink" }
                 return
             }
             auth.parseFragmentAndImportSession(fragment) {

--- a/Auth/src/appleMain/kotlin/io/github/jan/supabase/auth/Utils.apple.kt
+++ b/Auth/src/appleMain/kotlin/io/github/jan/supabase/auth/Utils.apple.kt
@@ -5,5 +5,5 @@ import io.github.jan.supabase.auth.providers.openUrl
 import platform.Foundation.NSURL
 
 internal actual suspend fun SupabaseClient.openExternalUrl(url: String) {
-    openUrl(NSURL(string = url))
+    auth.openUrl(NSURL(string = url))
 }

--- a/Auth/src/appleMain/kotlin/io/github/jan/supabase/auth/providers/OAuthProvider.kt
+++ b/Auth/src/appleMain/kotlin/io/github/jan/supabase/auth/providers/OAuthProvider.kt
@@ -1,5 +1,6 @@
 package io.github.jan.supabase.auth.providers
 
+import io.github.jan.supabase.auth.Auth
 import platform.Foundation.NSURL
 
-internal expect fun openUrl(url: NSURL)
+internal expect fun Auth.openUrl(url: NSURL)

--- a/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/AccessToken.kt
+++ b/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/AccessToken.kt
@@ -50,7 +50,7 @@ private suspend fun SupabaseClient.checkAccessToken(token: String) {
     val autoRefreshEnabled = auth.config.alwaysAutoRefresh
     if (sessionExistsAndExpired && autoRefreshEnabled) {
         val autoRefreshRunning = auth.isAutoRefreshRunning
-        Auth.logger.e {
+        auth.logger.e {
             """
                 Authenticated request attempted with expired access token. This should not happen. Please report this issue. Trying to refresh session before...
                 Auto refresh running: $autoRefreshRunning
@@ -63,7 +63,7 @@ private suspend fun SupabaseClient.checkAccessToken(token: String) {
         try {
             auth.refreshCurrentSession()
         } catch (e: Exception) {
-            Auth.logger.d(e) { "Failed to force-refresh session before making a request with an expired access token" }
+            auth.logger.d(e) { "Failed to force-refresh session before making a request with an expired access token" }
             throw TokenExpiredException()
         }
     }

--- a/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/Auth.kt
+++ b/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/Auth.kt
@@ -29,7 +29,6 @@ import io.github.jan.supabase.auth.user.UserSession
 import io.github.jan.supabase.auth.user.UserUpdateBuilder
 import io.github.jan.supabase.exceptions.HttpRequestException
 import io.github.jan.supabase.exceptions.RestException
-import io.github.jan.supabase.logging.SupabaseLogger
 import io.github.jan.supabase.plugins.CustomSerializationPlugin
 import io.github.jan.supabase.plugins.MainPlugin
 import io.github.jan.supabase.plugins.SupabasePluginProvider
@@ -538,7 +537,10 @@ interface Auth : MainPlugin<AuthConfig>, CustomSerializationPlugin {
 
         override val key = "auth"
 
-        override val logger: SupabaseLogger = SupabaseClient.createLogger("Supabase-Auth")
+        /**
+         * The tag for the Auth logger.
+         */
+        const val LOGGING_TAG = "Supabase-Auth"
 
         /**
          * The auth api version to use

--- a/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/AuthExtensions.kt
+++ b/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/AuthExtensions.kt
@@ -24,7 +24,7 @@ internal fun noDeeplinkError(arg: String): Nothing = error("""
 fun Auth.parseSessionFromFragment(fragment: String): UserSession {
     val sessionParts = getFragmentParts(fragment)
 
-    Auth.logger.d { "Fragment parts: $sessionParts" }
+    logger.d { "Fragment parts: $sessionParts" }
 
     val accessToken = sessionParts["access_token"] ?: invalidArg("No access token found")
     val refreshToken = sessionParts["refresh_token"] ?: invalidArg("No refresh token found")

--- a/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/AuthImpl.kt
+++ b/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/AuthImpl.kt
@@ -47,6 +47,8 @@ import io.github.jan.supabase.exceptions.BadRequestRestException
 import io.github.jan.supabase.exceptions.RestException
 import io.github.jan.supabase.exceptions.UnauthorizedRestException
 import io.github.jan.supabase.exceptions.UnknownRestException
+import io.github.jan.supabase.logging.SupabaseLogger
+import io.github.jan.supabase.logging.createLogger
 import io.github.jan.supabase.logging.d
 import io.github.jan.supabase.logging.e
 import io.github.jan.supabase.logging.i
@@ -103,6 +105,7 @@ internal class AuthImpl(
     override val config: AuthConfig
 ) : Auth {
 
+    override val logger: SupabaseLogger = supabaseClient.createLogger(Auth.LOGGING_TAG, config)
     private val _sessionStatus = MutableStateFlow<SessionStatus>(SessionStatus.Initializing)
     override val sessionStatus: StateFlow<SessionStatus> = _sessionStatus.asStateFlow()
     private val _events = MutableSharedFlow<AuthEvent>(replay = 1)
@@ -137,19 +140,19 @@ internal class AuthImpl(
     }
 
     override fun init() {
-        Auth.logger.d { "Initializing Auth plugin..." }
+        logger.d { "Initializing Auth plugin..." }
         if (config.autoLoadFromStorage) {
             authScope.launch {
-                Auth.logger.i {
+                logger.i {
                     "Loading session from storage..."
                 }
                 val successful = loadFromStorage(initializing = true)
                 if (successful) {
-                    Auth.logger.i {
+                    logger.i {
                         "Successfully loaded session from storage!"
                     }
                 } else {
-                    Auth.logger.i {
+                    logger.i {
                         "No session found in storage."
                     }
                 }
@@ -158,7 +161,7 @@ internal class AuthImpl(
                 }
             }
         } else {
-            Auth.logger.d { "Skipping loading from storage (autoLoadFromStorage is set to false)" }
+            logger.d { "Skipping loading from storage (autoLoadFromStorage is set to false)" }
             if(config.autoSetupPlatform) {
                 authScope.launch {
                     setupPlatform()
@@ -166,7 +169,7 @@ internal class AuthImpl(
             }
         }
 
-        Auth.logger.d { "Initialized Auth plugin" }
+        logger.d { "Initialized Auth plugin" }
     }
 
     override suspend fun <C, R, Provider : AuthProvider<C, R>> signInWith(
@@ -353,17 +356,17 @@ internal class AuthImpl(
                 }
             } catch(e: RestException) {
                 if(e.statusCode in SIGN_OUT_IGNORE_CODES) {
-                    Auth.logger.d { "Received error code ${e.statusCode} while signing out user. This can happen if the user doesn't exist anymore or the JWT is invalid/expired. Proceeding to clean up local data..." }
+                    logger.d { "Received error code ${e.statusCode} while signing out user. This can happen if the user doesn't exist anymore or the JWT is invalid/expired. Proceeding to clean up local data..." }
                 } else throw e
             }
-            Auth.logger.d { "Logged out session in Supabase" }
+            logger.d { "Logged out session in Supabase" }
         } else {
-            Auth.logger.i { "Skipping session logout as there is no session available. Proceeding to clean up local data..." }
+            logger.i { "Skipping session logout as there is no session available. Proceeding to clean up local data..." }
         }
         if (scope != SignOutScope.OTHERS) {
             clearSession()
         }
-        Auth.logger.d { "Successfully logged out" }
+        logger.d { "Successfully logged out" }
     }
 
     private suspend fun verify(
@@ -379,9 +382,9 @@ internal class AuthImpl(
             additionalData()
         }
         val response = publicApi.postJson("verify", body)
-        val session = response.bodyOrNull<UserSession>()
+        val session = supabaseClient.bodyOrNull<UserSession>(response)
         if(session == null) {
-            Auth.logger.d { "Received `verifyOtp` response without session: ${response.bodyAsText()}. This may occur if changing the email with 'Secure email change' enabled" }
+            logger.d { "Received `verifyOtp` response without session: ${response.bodyAsText()}. This may occur if changing the email with 'Secure email change' enabled" }
             return OtpVerifyResult.VerifiedNoSession
         }
         importSession(session, source = SessionSource.SignIn(OTP))
@@ -514,7 +517,7 @@ internal class AuthImpl(
     }
 
     override suspend fun refreshSession(refreshToken: String): UserSession {
-        Auth.logger.d {
+        logger.d {
             "Refreshing session"
         }
         val body = buildJsonObject {
@@ -545,29 +548,29 @@ internal class AuthImpl(
         source: SessionSource,
         initializing: Boolean
     ) {
-        Auth.logger.d { "Importing session $session from $source, auto refresh is set to $autoRefresh." }
+        logger.d { "Importing session $session from $source, auto refresh is set to $autoRefresh." }
         if (!autoRefresh) {
             if (session.refreshToken.isNotBlank() && session.expiresIn != 0L && config.autoSaveToStorage) {
                 sessionManager.saveSession(session)
-                Auth.logger.d { "Session saved to storage (no auto refresh)" }
+                logger.d { "Session saved to storage (no auto refresh)" }
             }
             setSessionStatus(SessionStatus.Authenticated(session, source))
-            Auth.logger.d { "Session imported successfully." }
+            logger.d { "Session imported successfully." }
             return
         }
         val thresholdDate = session.expiresAt - session.expiresIn.seconds * (1 - SESSION_REFRESH_THRESHOLD)
         if (thresholdDate <= Clock.System.now()) {
-            Auth.logger.d { "Session is under the threshold date. Refreshing session..." }
+            logger.d { "Session is under the threshold date. Refreshing session..." }
             recreateSessionJob(session, source, false, initializing)
         } else {
             if (config.autoSaveToStorage) {
                 sessionManager.saveSession(session)
-                Auth.logger.d { "Session saved to storage (auto refresh enabled)" }
+                logger.d { "Session saved to storage (auto refresh enabled)" }
             }
             setSessionStatus(SessionStatus.Authenticated(session, source))
-            Auth.logger.d { "Session imported successfully. Starting auto refresh..." }
+            logger.d { "Session imported successfully. Starting auto refresh..." }
             recreateSessionJob(session, source, true, initializing)
-            Auth.logger.d { "Auto refresh started." }
+            logger.d { "Auto refresh started." }
         }
     }
 
@@ -599,17 +602,17 @@ internal class AuthImpl(
             importRefreshedSession()
         } catch (e: RestException) {
             if (e.statusCode in NETWORK_ERROR_CODES) {
-                Auth.logger.e(e) { "Couldn't refresh session due to an internal server error. Retrying in ${config.retryDelay} (Status code ${e.statusCode})..." }
+                logger.e(e) { "Couldn't refresh session due to an internal server error. Retrying in ${config.retryDelay} (Status code ${e.statusCode})..." }
                 updateStatus(RefreshFailureCause.InternalServerError(e))
                 delay(config.retryDelay)
                 retry()
             } else {
-                Auth.logger.e(e) { "Couldn't refresh session. The refresh token may have been revoked. Clearing session (Status code ${e.statusCode})... " }
+                logger.e(e) { "Couldn't refresh session. The refresh token may have been revoked. Clearing session (Status code ${e.statusCode})... " }
                 clearSession()
             }
         } catch (e: Exception) {
             currentCoroutineContext().ensureActive()
-            Auth.logger.d(e) { "Couldn't reach Supabase. Either the address doesn't exist or the network might not be on. Retrying in ${config.retryDelay}..." }
+            logger.d(e) { "Couldn't reach Supabase. Either the address doesn't exist or the network might not be on. Retrying in ${config.retryDelay}..." }
             updateStatus(RefreshFailureCause.NetworkError(e))
             delay(config.retryDelay)
             retry()
@@ -618,7 +621,7 @@ internal class AuthImpl(
 
     private fun updateStatusIfExpired(session: UserSession, reason: RefreshFailureCause) {
         if (session.expiresAt <= Clock.System.now()) {
-            Auth.logger.d { "Session expired while trying to refresh the session. Updating status..." }
+            logger.d { "Session expired while trying to refresh the session. Updating status..." }
             setSessionStatus(SessionStatus.RefreshFailure(reason))
         }
         emitEvent(AuthEvent.RefreshFailure(reason))
@@ -633,7 +636,7 @@ internal class AuthImpl(
 
         val delayDuration = targetRefreshTime - now
         updateRefreshInformation(targetRefreshTime, null)
-        Auth.logger.d {
+        logger.d {
             "Refreshing session in $delayDuration."
         }
         // if the delayDuration is negative, delay() will not delay
@@ -653,7 +656,7 @@ internal class AuthImpl(
     }
 
     private suspend fun handleExpiredSession(session: UserSession, autoRefresh: Boolean = true) {
-        Auth.logger.d {
+        logger.d {
             "Session expired. Refreshing session..."
         }
         val newSession = refreshSession(session.refreshToken)
@@ -668,7 +671,7 @@ internal class AuthImpl(
         )
 
     override fun stopAutoRefreshForCurrentSession() {
-        Auth.logger.d { "Stopping auto refresh for current session" }
+        logger.d { "Stopping auto refresh for current session" }
         sessionJob?.cancel()
         sessionJob = null
     }
@@ -679,7 +682,11 @@ internal class AuthImpl(
     override suspend fun loadFromStorage(autoRefresh: Boolean): Boolean = loadFromStorage(autoRefresh, false)
 
     suspend fun loadFromStorage(autoRefresh: Boolean = config.alwaysAutoRefresh, initializing: Boolean): Boolean {
-        val session = sessionManager.loadSession()
+        val session = try { sessionManager.loadSession() } catch (e: Exception) {
+            currentCoroutineContext().ensureActive()
+            logger.e(e) { "Failed to load session" }
+            null
+        }
         session?.let {
             importSession(it, autoRefresh, SessionSource.Storage, initializing)
         }
@@ -692,7 +699,7 @@ internal class AuthImpl(
 
     override suspend fun parseErrorResponse(response: HttpResponse): RestException {
         val errorBody =
-            response.bodyOrNull<GoTrueErrorResponse>() ?: GoTrueErrorResponse("Unknown error", "")
+            supabaseClient.bodyOrNull<GoTrueErrorResponse>(response) ?: GoTrueErrorResponse("Unknown error", "")
         checkErrorCodes(errorBody, response)?.let { return it }
         return when (response.status) {
             HttpStatusCode.Unauthorized -> UnauthorizedRestException(
@@ -719,7 +726,7 @@ internal class AuthImpl(
             AuthWeakPasswordException.CODE -> AuthWeakPasswordException(error.description, response, error.weakPassword?.reasons ?: emptyList())
             AuthSessionMissingException.CODE -> {
                 authScope.launch {
-                    Auth.logger.e { "Received session not found api error. Clearing session..." }
+                    logger.e { "Received session not found api error. Clearing session..." }
                     clearSession()
                 }
                 AuthSessionMissingException(response)
@@ -766,12 +773,12 @@ internal class AuthImpl(
     }
 
     override fun setSessionStatus(status: SessionStatus) {
-        Auth.logger.d { "Setting session status to $status" }
+        logger.d { "Setting session status to $status" }
         _sessionStatus.value = status
     }
 
     override fun emitEvent(event: AuthEvent) {
-        Auth.logger.d { "Emitting event $event" }
+        logger.d { "Emitting event $event" }
         _events.tryEmit(event)
     }
 

--- a/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/SessionManager.kt
+++ b/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/SessionManager.kt
@@ -16,7 +16,7 @@ interface SessionManager {
     /**
      * Loads the saved session from storage.
      */
-    suspend fun loadSession(): UserSession?
+    suspend fun loadSession(): UserSession
 
     /**
      * Deletes the saved session from storage.
@@ -36,8 +36,8 @@ class MemorySessionManager(session: UserSession? = null): SessionManager {
         this.session.store(session)
     }
 
-    override suspend fun loadSession(): UserSession? {
-        return session.load()
+    override suspend fun loadSession(): UserSession {
+        return session.load() ?: error("No session stored")
     }
 
     override suspend fun deleteSession() {

--- a/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/SessionManager.kt
+++ b/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/SessionManager.kt
@@ -19,6 +19,15 @@ interface SessionManager {
     suspend fun loadSession(): UserSession
 
     /**
+     * Loads the saved session from storage.
+     */
+    suspend fun loadSessionOrNull(): UserSession? = try {
+        loadSession()
+    } catch(e: Exception) {
+        null
+    }
+
+    /**
      * Deletes the saved session from storage.
      */
     suspend fun deleteSession()

--- a/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/Utils.kt
+++ b/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/Utils.kt
@@ -27,6 +27,6 @@ internal suspend fun Auth.tryToGetUser(accessToken: String) = try {
     retrieveUser(accessToken)
 } catch (e: Exception) {
     currentCoroutineContext().ensureActive()
-    Auth.logger.e(e) { "Couldn't retrieve user using access token $accessToken.\nIf you use the project secret, ignore this message." }
+    logger.e(e) { "Couldn't retrieve user using access token $accessToken.\nIf you use the project secret, ignore this message." }
     null
 }

--- a/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/providers/builtin/DefaultAuthProvider.kt
+++ b/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/providers/builtin/DefaultAuthProvider.kt
@@ -2,7 +2,6 @@ package io.github.jan.supabase.auth.providers.builtin
 
 import io.github.jan.supabase.SupabaseClient
 import io.github.jan.supabase.annotations.SupabaseInternal
-import io.github.jan.supabase.auth.Auth
 import io.github.jan.supabase.auth.AuthImpl
 import io.github.jan.supabase.auth.FlowType
 import io.github.jan.supabase.auth.auth
@@ -101,7 +100,7 @@ sealed interface DefaultAuthProvider<C, R> : AuthProvider<C, R> {
                 val userJson = json["user"]?.jsonObject ?: buildJsonObject { }
                 return decodeResult(userJson)
             }.onFailure { exception ->
-                Auth.logger.w(exception) { "Failed to decode user info" }
+                supabaseClient.auth.logger.w(exception) { "Failed to decode user info" }
                 return null
             }
         }

--- a/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/url/ErrorHandling.kt
+++ b/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/url/ErrorHandling.kt
@@ -21,7 +21,7 @@ internal fun Auth.handledUrlParameterError(parameters: (String) -> String?): Boo
     val error = checkForUrlParameterError(parameters)
     return if(error != null) {
         if(sessionStatus.value !is SessionStatus.Authenticated) {
-            Auth.logger.d { "Found error code in the URL Parameters: $error. Emitting event..." }
+            logger.d { "Found error code in the URL Parameters: $error. Emitting event..." }
             emitEvent(error)
         }
         true

--- a/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/url/HashParsing.kt
+++ b/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/url/HashParsing.kt
@@ -6,7 +6,7 @@ import io.github.jan.supabase.buildUrl
 import io.github.jan.supabase.logging.d
 
 internal fun Auth.validateHash(hash: String): UrlValidationResult {
-    Auth.logger.d { "Parsing fragment/hash $hash" }
+    logger.d { "Parsing fragment/hash $hash" }
     val parameters = getFragmentParts(hash)
     if(handledUrlParameterError { parameters[it] }) {
         return UrlValidationResult.ErrorFound
@@ -14,7 +14,7 @@ internal fun Auth.validateHash(hash: String): UrlValidationResult {
     val session = try {
         parseSessionFromFragment(hash)
     } catch(e: IllegalArgumentException) {
-        Auth.logger.d(e) { "Received invalid session fragment. Ignoring." }
+        logger.d(e) { "Received invalid session fragment. Ignoring." }
         return UrlValidationResult.Skipped
     }
     return UrlValidationResult.SessionFound(session)

--- a/Auth/src/commonTest/kotlin/AuthTest.kt
+++ b/Auth/src/commonTest/kotlin/AuthTest.kt
@@ -94,11 +94,11 @@ class AuthTest {
             )
             client.auth.awaitInitialization()
             assertIs<SessionStatus.NotAuthenticated>(client.auth.sessionStatus.value)
-            assertNull(sessionManager.loadSession())
+            assertNull(sessionManager.loadSessionOrNull())
             val session = userSession()
             client.auth.importSession(session)
             assertIs<SessionStatus.Authenticated>(client.auth.sessionStatus.value)
-            assertEquals(session, sessionManager.loadSession())
+            assertEquals(session, sessionManager.loadSessionOrNull())
         }
     }
 

--- a/Auth/src/commonTest/kotlin/MemorySessionManagerTest.kt
+++ b/Auth/src/commonTest/kotlin/MemorySessionManagerTest.kt
@@ -12,13 +12,13 @@ class MemorySessionManagerTest {
         runTest {
             val session = userSession()
             val sessionManager = MemorySessionManager(session)
-            assertEquals(session, sessionManager.loadSession()) //Check if the session is loaded correctly
+            assertEquals(session, sessionManager.loadSessionOrNull()) //Check if the session is loaded correctly
             val newSession = userSession(expiresIn = 200)
             sessionManager.saveSession(newSession)
-            assertEquals(newSession, sessionManager.loadSession()) //Check if the new session is saved correctly
-            assertNotEquals(session, sessionManager.loadSession()) //Check if the new session is different from the old session
+            assertEquals(newSession, sessionManager.loadSessionOrNull()) //Check if the new session is saved correctly
+            assertNotEquals(session, sessionManager.loadSessionOrNull()) //Check if the new session is different from the old session
             sessionManager.deleteSession()
-            assertNull(sessionManager.loadSession()) //Check if the session is deleted correctly
+            assertNull(sessionManager.loadSessionOrNull()) //Check if the session is deleted correctly
         }
     }
 

--- a/Auth/src/desktopMain/kotlin/io/github/jan/supabase/auth/server/HttpCallbackRoutes.kt
+++ b/Auth/src/desktopMain/kotlin/io/github/jan/supabase/auth/server/HttpCallbackRoutes.kt
@@ -18,11 +18,11 @@ internal fun Routing.configureRoutes(
     get("/") {
         val code = call.parameters["code"]
         if (auth.handledUrlParameterError { call.parameters[it] }) {
-            errorResponse()
+            auth.errorResponse(this)
         } else if(code != null) {
             val session = auth.exchangeCodeForSession(code, false)
             onSuccess(session)
-            Auth.logger.d {
+            auth.logger.d {
                 "Successfully authenticated user with OAuth using the PKCE flow"
             }
             shutdown(call, auth.config.httpCallbackConfig.redirectHtml)
@@ -31,11 +31,11 @@ internal fun Routing.configureRoutes(
         }
     }
     get("/callback") {
-        Auth.logger.d {
+        auth.logger.d {
             "Received request on OAuth callback route"
         }
         if (auth.handledUrlParameterError { call.parameters[it] }) {
-            errorResponse()
+            auth.errorResponse(this)
             return@get
         }
         val accessToken = call.parameters["access_token"] ?: return@get
@@ -47,18 +47,18 @@ internal fun Routing.configureRoutes(
         val type = call.parameters["type"].orEmpty()
         val user = auth.retrieveUser(accessToken)
         onSuccess(UserSession(accessToken, refreshToken, providerRefreshToken, providerToken, expiresIn, tokenType, user, type))
-        Auth.logger.d {
+        auth.logger.d {
             "Successfully authenticated user with OAuth using the implicit flow"
         }
         shutdown(call, auth.config.httpCallbackConfig.redirectHtml)
     }
 }
 
-private suspend fun RoutingContext.errorResponse() {
-    Auth.logger.d {
+private suspend fun Auth.errorResponse(ctx: RoutingContext) {
+    logger.d {
         "Error in OAuth callback"
     }
-    call.respondText(
+    ctx.call.respondText(
         text = "Error",
         contentType = ContentType.Text.Html,
         status = HttpStatusCode.BadRequest

--- a/Auth/src/desktopMain/kotlin/io/github/jan/supabase/auth/server/HttpCallbackServer.kt
+++ b/Auth/src/desktopMain/kotlin/io/github/jan/supabase/auth/server/HttpCallbackServer.kt
@@ -27,7 +27,7 @@ internal suspend fun createServer(
     onSuccess: suspend (UserSession) -> Unit
 ) {
     auth as AuthImpl
-    Auth.logger.d { "Creating OAuth callback server" }
+    auth.logger.d { "Creating OAuth callback server" }
     val server = embeddedServer(CIO, port = auth.config.httpCallbackConfig.httpPort) {
         routing {
             configureRoutes(
@@ -39,7 +39,7 @@ internal suspend fun createServer(
     coroutineScope {
         val timeoutScope = launch {
             val port = server.engine.resolvedConnectors().first().port
-            Auth.logger.d {
+            auth.logger.d {
                 "Started OAuth callback server on port $port. Opening url in browser..."
             }
             auth.config.urlLauncher.openUrl(
@@ -50,12 +50,12 @@ internal suspend fun createServer(
             )
             delay(auth.config.httpCallbackConfig.timeout)
             if(this.isActive) {
-                Auth.logger.d {
+                auth.logger.d {
                     "Timeout reached. Shutting down callback server..."
                 }
                 server.stop()
             } else {
-                Auth.logger.d {
+                auth.logger.d {
                     "Callback server was shut down manually"
                 }
             }

--- a/Auth/src/iosMain/kotlin/io/github/jan/supabase/auth/providers/openUrl.kt
+++ b/Auth/src/iosMain/kotlin/io/github/jan/supabase/auth/providers/openUrl.kt
@@ -6,8 +6,8 @@ import io.github.jan.supabase.logging.e
 import platform.Foundation.NSURL
 import platform.UIKit.UIApplication
 
-internal actual fun openUrl(url: NSURL) {
+internal actual fun Auth.openUrl(url: NSURL) {
     UIApplication.sharedApplication.openURL(url, emptyMap<Any?, Any>()) {
-        if(it) Auth.logger.d { "Successfully opened provider url in safari" } else Auth.logger.e { "Failed to open provider url in safari" }
+        if(it) logger.d { "Successfully opened provider url in safari" } else logger.e { "Failed to open provider url in safari" }
     }
 }

--- a/Auth/src/linuxMain/kotlin/io/github/jan/supabase/auth/setupPlatform.kt
+++ b/Auth/src/linuxMain/kotlin/io/github/jan/supabase/auth/setupPlatform.kt
@@ -5,6 +5,6 @@ import io.github.jan.supabase.logging.w
 
 @SupabaseInternal
 actual suspend fun Auth.setupPlatform() {
-    Auth.logger.w { "Linux support is experimental, please report any bugs you find!" }
+    logger.w { "Linux support is experimental, please report any bugs you find!" }
     initDone()
 }

--- a/Auth/src/macosMain/kotlin/io/github/jan/supabase/auth/providers/openUrl.kt
+++ b/Auth/src/macosMain/kotlin/io/github/jan/supabase/auth/providers/openUrl.kt
@@ -7,8 +7,8 @@ import platform.AppKit.NSWorkspace
 import platform.AppKit.NSWorkspaceOpenConfiguration
 import platform.Foundation.NSURL
 
-internal actual fun openUrl(url: NSURL) {
+internal actual fun Auth.openUrl(url: NSURL) {
     NSWorkspace.sharedWorkspace().openURL(url, NSWorkspaceOpenConfiguration()) { _, error ->
-        if(error != null) Auth.logger.d { "Successfully opened provider url in safari" } else Auth.logger.e { "Failed to open provider url in safari" }
+        if(error != null) logger.d { "Successfully opened provider url in safari" } else logger.e { "Failed to open provider url in safari" }
     }
 }

--- a/Auth/src/mingwMain/kotlin/io/github/jan/supabase/auth/setupPlatform.kt
+++ b/Auth/src/mingwMain/kotlin/io/github/jan/supabase/auth/setupPlatform.kt
@@ -5,6 +5,6 @@ import io.github.jan.supabase.logging.w
 
 @SupabaseInternal
 actual suspend fun Auth.setupPlatform() {
-    Auth.logger.w { "Windows support is experimental, please report any bugs you find!" }
+    logger.w { "Windows support is experimental, please report any bugs you find!" }
     initDone()
 }

--- a/Auth/src/settingsMain/kotlin/io/github/jan/supabase/auth/SettingsSessionManager.kt
+++ b/Auth/src/settingsMain/kotlin/io/github/jan/supabase/auth/SettingsSessionManager.kt
@@ -4,9 +4,6 @@ import com.russhwolf.settings.ExperimentalSettingsApi
 import com.russhwolf.settings.Settings
 import com.russhwolf.settings.coroutines.toSuspendSettings
 import io.github.jan.supabase.auth.user.UserSession
-import io.github.jan.supabase.logging.e
-import kotlinx.coroutines.currentCoroutineContext
-import kotlinx.coroutines.ensureActive
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonBuilder
 
@@ -50,15 +47,9 @@ class SettingsSessionManager(
         suspendSettings.putString(key, json.encodeToString(session))
     }
 
-    override suspend fun loadSession(): UserSession? {
-        val session = suspendSettings.getStringOrNull(key) ?: return null
-        return try {
-            json.decodeFromString(session)
-        } catch(e: Exception) {
-            currentCoroutineContext().ensureActive()
-            Auth.logger.e(e) { "Failed to load session" }
-            null
-        }
+    override suspend fun loadSession(): UserSession {
+        val session = suspendSettings.getStringOrNull(key) ?: error("No entry with the key $key")
+        return json.decodeFromString(session)
     }
 
     override suspend fun deleteSession() {

--- a/Auth/src/settingsTest/kotlin/SettingsSessionManagerTest.kt
+++ b/Auth/src/settingsTest/kotlin/SettingsSessionManagerTest.kt
@@ -2,7 +2,6 @@ import com.russhwolf.settings.MapSettings
 import io.github.jan.supabase.auth.SettingsSessionManager
 import io.github.jan.supabase.auth.user.UserSession
 import kotlinx.coroutines.test.runTest
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -21,17 +20,17 @@ class SettingsSessionManagerTest {
             val session = userSession()
             val settings = MapSettings(SettingsSessionManager.SETTINGS_KEY to json.encodeToString(session))
             val sessionManager = SettingsSessionManager(settings)
-            assertEquals(session, sessionManager.loadSession()) //Check if the session is loaded correctly
+            assertEquals(session, sessionManager.loadSessionOrNull()) //Check if the session is loaded correctly
             assertEquals(session, json.decodeFromString(settings.getString(SettingsSessionManager.SETTINGS_KEY, ""))) //Check if the session is saved correctly
             val newSession = userSession(expiresIn = 200)
             sessionManager.saveSession(newSession)
-            assertEquals(newSession, sessionManager.loadSession()) //Check if the new session is saved correctly
+            assertEquals(newSession, sessionManager.loadSessionOrNull()) //Check if the new session is saved correctly
             assertEquals(newSession,
                 json.decodeFromString<UserSession>(settings.getString(SettingsSessionManager.SETTINGS_KEY, ""))
             ) //Check if the new session is saved correctly
-            assertNotEquals(session, sessionManager.loadSession()) //Check if the new session is different from the old session
+            assertNotEquals(session, sessionManager.loadSessionOrNull()) //Check if the new session is different from the old session
             sessionManager.deleteSession()
-            assertNull(sessionManager.loadSession()) //Check if the session is deleted correctly
+            assertNull(sessionManager.loadSessionOrNull()) //Check if the session is deleted correctly
             assertFalse(settings.hasKey(SettingsSessionManager.SETTINGS_KEY)) //Check if the session is deleted correctly
         }
     }

--- a/Auth/src/tvosMain/kotlin/io/github/jan/supabase/auth/providers/openUrl.kt
+++ b/Auth/src/tvosMain/kotlin/io/github/jan/supabase/auth/providers/openUrl.kt
@@ -1,7 +1,8 @@
 package io.github.jan.supabase.auth.providers
 
+import io.github.jan.supabase.auth.Auth
 import platform.Foundation.NSURL
 
-internal actual fun openUrl(url: NSURL) {
+internal actual fun Auth.openUrl(url: NSURL) {
     error("Can't open url on tvOS")
 }

--- a/Auth/src/watchosMain/kotlin/io/github/jan/supabase/auth/providers/openUrl.kt
+++ b/Auth/src/watchosMain/kotlin/io/github/jan/supabase/auth/providers/openUrl.kt
@@ -1,7 +1,8 @@
 package io.github.jan.supabase.auth.providers
 
+import io.github.jan.supabase.auth.Auth
 import platform.Foundation.NSURL
 
-internal actual fun openUrl(url: NSURL) {
+internal actual fun Auth.openUrl(url: NSURL) {
     error("Can't open url on watchOS")
 }

--- a/Auth/src/webMain/kotlin/io/github/jan/supabase/auth/setupPlatform.kt
+++ b/Auth/src/webMain/kotlin/io/github/jan/supabase/auth/setupPlatform.kt
@@ -27,7 +27,7 @@ private fun Auth.checkForHash(bridge: BrowserBridge): UserSession? {
     if(bridge.hash.isBlank()) return null
     val afterHash = bridge.hash.substring(1)
     if(!afterHash.contains('=')) return null
-    Auth.logger.d { "Found hash: $afterHash" }
+    logger.d { "Found hash: $afterHash" }
     return when(val result = validateHash(afterHash)) {
         is UrlValidationResult.SessionFound, UrlValidationResult.ErrorFound -> {
             cleanHash(bridge)
@@ -49,12 +49,12 @@ private fun Auth.checkForPKCECode(bridge: BrowserBridge): String? {
 }
 
 private suspend fun Auth.handlePKCECode(code: String) {
-    Auth.logger.d { "Found PCKE code: $code" }
+    logger.d { "Found PCKE code: $code" }
     try {
         val session = exchangeCodeForSession(code)
         importSession(session, source = SessionSource.External)
     } catch(e: Exception) {
-        Auth.logger.w(e) { "Failed to exchange PCKE code for session" }
+        logger.w(e) { "Failed to exchange PCKE code for session" }
     }
     initDone()
 }
@@ -70,12 +70,12 @@ actual suspend fun Auth.setupPlatform() {
     if(IS_BROWSER && !config.disableUrlChecking && config.browserBridge != null) {
         when(config.flowType) {
             FlowType.PKCE -> {
-                Auth.logger.d { "Using PCKE flow type, checking for PCKE code..." }
+                logger.d { "Using PCKE flow type, checking for PCKE code..." }
                 val code = checkForPKCECode(config.browserBridge!!) ?: return initDone()
                 handlePKCECode(code)
             }
             FlowType.IMPLICIT -> {
-                Auth.logger.d { "Using IMPLICIT flow type, checking for hash..." }
+                logger.d { "Using IMPLICIT flow type, checking for hash..." }
                 val sessionInHash = checkForHash(config.browserBridge!!) ?: return initDone()
                 handleHashSession(sessionInHash)
             }

--- a/Functions/src/commonMain/kotlin/io/github/jan/supabase/functions/Functions.kt
+++ b/Functions/src/commonMain/kotlin/io/github/jan/supabase/functions/Functions.kt
@@ -14,6 +14,8 @@ import io.github.jan.supabase.exceptions.NotFoundRestException
 import io.github.jan.supabase.exceptions.RestException
 import io.github.jan.supabase.exceptions.UnauthorizedRestException
 import io.github.jan.supabase.exceptions.UnknownRestException
+import io.github.jan.supabase.logging.SupabaseLogger
+import io.github.jan.supabase.logging.createLogger
 import io.github.jan.supabase.plugins.CustomSerializationConfig
 import io.github.jan.supabase.plugins.CustomSerializationPlugin
 import io.github.jan.supabase.plugins.MainConfig
@@ -56,6 +58,7 @@ import kotlinx.coroutines.flow.flow
  */
 class Functions(override val config: Config, override val supabaseClient: SupabaseClient) : MainPlugin<Functions.Config>, CustomSerializationPlugin {
 
+    override val logger: SupabaseLogger = supabaseClient.createLogger(Functions.LOGGING_TAG, config)
     override val apiVersion: Int
         get() = API_VERSION
 
@@ -80,7 +83,7 @@ class Functions(override val config: Config, override val supabaseClient: Supaba
     suspend inline operator fun invoke(function: String, region: FunctionRegion = config.defaultRegion, crossinline builder: HttpRequestBuilder.() -> Unit): HttpResponse {
         return api.post(function) {
             builder()
-            header("x-region", region.value)
+            header(X_REGION_HEADER, region.value)
         }
     }
 
@@ -97,7 +100,7 @@ class Functions(override val config: Config, override val supabaseClient: Supaba
      */
     suspend inline operator fun <reified T : Any> invoke(function: String, body: T, region: FunctionRegion = config.defaultRegion, headers: Headers = Headers.Empty): HttpResponse = invoke(function) {
         this.headers.appendAll(headers)
-        header("x-region", region.value)
+        header(X_REGION_HEADER, region.value)
         setBody(serializer.encode(body))
     }
 
@@ -112,7 +115,7 @@ class Functions(override val config: Config, override val supabaseClient: Supaba
      */
     suspend inline operator fun invoke(function: String, region: FunctionRegion = config.defaultRegion, headers: Headers = Headers.Empty): HttpResponse = invoke(function) {
         this.headers.appendAll(headers)
-        header("x-region", region.value)
+        header(X_REGION_HEADER, region.value)
     }
 
     /**
@@ -146,7 +149,7 @@ class Functions(override val config: Config, override val supabaseClient: Supaba
             request = {
                 method = HttpMethod.Post
                 headers.appendAll(defaultHeaders)
-                header("x-region", region.value)
+                header(X_REGION_HEADER, region.value)
                 builder()
             }
         ) {
@@ -172,7 +175,7 @@ class Functions(override val config: Config, override val supabaseClient: Supaba
         return api.prepareRequest(function) {
             method = HttpMethod.Post
             builder()
-            header("x-region", region.value)
+            header(X_REGION_HEADER, region.value)
         }
     }
 
@@ -191,7 +194,7 @@ class Functions(override val config: Config, override val supabaseClient: Supaba
         functionName = function,
         headers = Headers.build {
             appendAll(headers)
-            append("x-region", region.value)
+            append(X_REGION_HEADER, region.value)
         },
         supabaseClient = supabaseClient
     )
@@ -232,7 +235,15 @@ class Functions(override val config: Config, override val supabaseClient: Supaba
 
         override val key = "functions"
 
-        override val logger = SupabaseClient.createLogger("Supabase-Functions")
+        /**
+         * The tag for the Functions logger.
+         */
+        const val LOGGING_TAG = "Supabase-Functions"
+
+        /**
+         * The header for specifying which region the function should be called in
+         */
+        const val X_REGION_HEADER = "x-region"
 
         /**
          * The current functions api version

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/Postgrest.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/Postgrest.kt
@@ -4,7 +4,6 @@ import io.github.jan.supabase.SupabaseClient
 import io.github.jan.supabase.SupabaseSerializer
 import io.github.jan.supabase.auth.AuthDependentPluginConfig
 import io.github.jan.supabase.exceptions.HttpRequestException
-import io.github.jan.supabase.logging.SupabaseLogger
 import io.github.jan.supabase.plugins.CustomSerializationConfig
 import io.github.jan.supabase.plugins.CustomSerializationPlugin
 import io.github.jan.supabase.plugins.MainConfig
@@ -121,7 +120,10 @@ interface Postgrest : MainPlugin<Postgrest.Config>, CustomSerializationPlugin {
 
         override val key = "rest"
 
-        override val logger: SupabaseLogger = SupabaseClient.createLogger("Supabase-PostgREST")
+        /**
+         * The tag for the PostgREST logger.
+         */
+        const val LOGGING_TAG = "Supabase-PostgREST"
 
         /**
          * The current postgrest API version

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/PostgrestImpl.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/PostgrestImpl.kt
@@ -5,6 +5,8 @@ import io.github.jan.supabase.annotations.SupabaseInternal
 import io.github.jan.supabase.auth.api.authenticatedSupabaseApi
 import io.github.jan.supabase.bodyOrNull
 import io.github.jan.supabase.exceptions.RestException
+import io.github.jan.supabase.logging.SupabaseLogger
+import io.github.jan.supabase.logging.createLogger
 import io.github.jan.supabase.postgrest.exception.PostgrestRestException
 import io.github.jan.supabase.postgrest.executor.RestRequestExecutor
 import io.github.jan.supabase.postgrest.query.PostgrestQueryBuilder
@@ -17,6 +19,7 @@ import kotlinx.serialization.json.JsonObject
 
 internal class PostgrestImpl(override val supabaseClient: SupabaseClient, override val config: Postgrest.Config) : Postgrest {
 
+    override val logger: SupabaseLogger = supabaseClient.createLogger(Postgrest.LOGGING_TAG, config)
     override val apiVersion: Int
         get() = Postgrest.API_VERSION
 
@@ -48,7 +51,7 @@ internal class PostgrestImpl(override val supabaseClient: SupabaseClient, overri
     }
 
     override suspend fun parseErrorResponse(response: HttpResponse): RestException {
-        val body = response.bodyOrNull<PostgrestErrorResponse>() ?: PostgrestErrorResponse("Unknown error")
+        val body = supabaseClient.bodyOrNull<PostgrestErrorResponse>(response) ?: PostgrestErrorResponse("Unknown error")
         return PostgrestRestException(body.message, body.hint, body.details, body.code, response)
     }
 

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/Realtime.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/Realtime.kt
@@ -6,8 +6,6 @@ import io.github.jan.supabase.SupabaseSerializer
 import io.github.jan.supabase.annotations.SupabaseInternal
 import io.github.jan.supabase.auth.AuthDependentPluginConfig
 import io.github.jan.supabase.auth.resolveAccessToken
-import io.github.jan.supabase.logging.SupabaseLogger
-import io.github.jan.supabase.logging.w
 import io.github.jan.supabase.plugins.CustomSerializationConfig
 import io.github.jan.supabase.plugins.CustomSerializationPlugin
 import io.github.jan.supabase.plugins.MainConfig
@@ -145,13 +143,15 @@ interface Realtime : MainPlugin<Realtime.Config>, CustomSerializationPlugin {
         override var requireValidSession: Boolean = false,
     ): MainConfig(), CustomSerializationConfig, AuthDependentPluginConfig {
 
+        internal var customAccessTokenProvider = false
+
         /**
          * A custom access token provider. If this is set, the [SupabaseClient] will not be used to resolve the access token.
          */
         var accessToken: suspend SupabaseClient.() -> String? = { resolveAccessToken(realtime, keyAsFallback = false) }
             set(value) {
-                logger.w { "You are setting a custom access token provider. This can lead to unexpected behavior." }
                 field = value
+                customAccessTokenProvider = true
             }
         override var serializer: SupabaseSerializer? = null
 
@@ -161,7 +161,10 @@ interface Realtime : MainPlugin<Realtime.Config>, CustomSerializationPlugin {
 
         override val key = "realtime"
 
-        override val logger: SupabaseLogger = SupabaseClient.createLogger("Supabase-Realtime")
+        /**
+         * The tag for the Realtime logger.
+         */
+        const val LOGGING_TAG = "Supabase-Realtime"
 
         /**
          * The current realtime api version

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeChannel.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeChannel.kt
@@ -3,6 +3,7 @@ package io.github.jan.supabase.realtime
 import io.github.jan.supabase.SupabaseClient
 import io.github.jan.supabase.annotations.SupabaseInternal
 import io.github.jan.supabase.encodeToJsonElement
+import io.github.jan.supabase.logging.SupabaseLogger
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.serialization.json.JsonObject
@@ -38,6 +39,8 @@ interface RealtimeChannel {
 
     @SupabaseInternal
     val callbackManager: CallbackManager
+
+    val logger: SupabaseLogger
 
     /**
      * Subscribes to the channel

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeChannel.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeChannel.kt
@@ -40,6 +40,7 @@ interface RealtimeChannel {
     @SupabaseInternal
     val callbackManager: CallbackManager
 
+    @SupabaseInternal
     val logger: SupabaseLogger
 
     /**

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeChannelImpl.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeChannelImpl.kt
@@ -2,6 +2,7 @@ package io.github.jan.supabase.realtime
 
 import io.github.jan.supabase.annotations.SupabaseInternal
 import io.github.jan.supabase.collections.AtomicMutableList
+import io.github.jan.supabase.logging.SupabaseLogger
 import io.github.jan.supabase.logging.d
 import io.github.jan.supabase.logging.e
 import io.github.jan.supabase.putJsonObject
@@ -38,6 +39,7 @@ internal class RealtimeChannelImpl(
     private val isPrivate: Boolean,
 ) : RealtimeChannel {
 
+    override val logger: SupabaseLogger = realtime.logger.appendTag(" [$topic$]")
     private val realtimeImpl: RealtimeImpl = realtime as RealtimeImpl
     private val clientChanges = AtomicMutableList<PostgresJoinConfig>()
     @SupabaseInternal
@@ -75,7 +77,7 @@ internal class RealtimeChannelImpl(
             realtime.addChannel(this)
         }
         _status.value = RealtimeChannel.Status.SUBSCRIBING
-        Realtime.logger.d { "Subscribing to channel $topic" }
+        logger.d { "Subscribing to channel $topic" }
         val currentJwt = accessToken()
         val postgrestChanges = clientChanges.toList()
         presenceJoinConfig.enabled = shouldEnablePresence()
@@ -86,7 +88,7 @@ internal class RealtimeChannelImpl(
                 put("access_token", currentJwt)
             }
         }
-        Realtime.logger.d { "Subscribing to channel with body $joinConfigObject" }
+        logger.d { "Subscribing to channel with body $joinConfigObject" }
         realtimeImpl.send(
             RealtimeMessage(topic, RealtimeChannel.CHANNEL_EVENT_JOIN, joinConfigObject, null)
         )
@@ -99,26 +101,26 @@ internal class RealtimeChannelImpl(
     suspend fun onMessage(message: RealtimeMessage) {
         val event = RealtimeEvent.resolveEvent(message)
         if(event == null) {
-            Realtime.logger.e { "Received message without event: $message" }
+            logger.e { "Received message without event: $message" }
             return
         }
         event.handle(this, message)
     }
 
     override suspend fun scheduleRejoin() {
-        Realtime.logger.d { "Rejoining channel $topic in" }
+        logger.d { "Rejoining channel $topic in" }
         delay(realtime.config.rejoinDelay)
         resubscribe()
     }
 
     override suspend fun unsubscribe() {
         _status.value = RealtimeChannel.Status.UNSUBSCRIBING
-        Realtime.logger.d { "Unsubscribing from channel $topic" }
+        logger.d { "Unsubscribing from channel $topic" }
         realtimeImpl.send(RealtimeMessage(topic, RealtimeChannel.CHANNEL_EVENT_LEAVE, buildJsonObject {}, null))
     }
 
     override suspend fun updateAuth(jwt: String?) {
-        Realtime.logger.d { "Updating auth token for channel $topic" }
+        logger.d { "Updating auth token for channel $topic" }
         realtimeImpl.send(RealtimeMessage(topic, RealtimeChannel.CHANNEL_EVENT_ACCESS_TOKEN, buildJsonObject {
             put("access_token", jwt)
         }, (realtimeImpl.ref.incrementAndFetch()).toString()))
@@ -227,7 +229,7 @@ internal class RealtimeChannelImpl(
                 supabaseClient.realtime.serializer.decode<T>(type, it.toString())
             } catch(e: Exception) {
                 coroutineContext.ensureActive()
-                Realtime.logger.e(e) { "Couldn't decode $it as $type. The corresponding handler wasn't called" }
+                logger.e(e) { "Couldn't decode $it as $type. The corresponding handler wasn't called" }
                 null
             }
             decodedValue?.let { value -> trySend(value) }
@@ -241,7 +243,7 @@ internal class RealtimeChannelImpl(
         }
         val id = callbackManager.addPresenceCallback(callback)
         if(status.value == RealtimeChannel.Status.SUBSCRIBED && !presenceJoinConfig.enabled) {
-            Realtime.logger.d { "Resubscribing to channel $topic to enable presence..." }
+            logger.d { "Resubscribing to channel $topic to enable presence..." }
             resubscribe()
         }
         awaitClose { callbackManager.removeCallbackById(id) }

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeImpl.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeImpl.kt
@@ -8,6 +8,8 @@ import io.github.jan.supabase.buildUrl
 import io.github.jan.supabase.collections.AtomicMutableMap
 import io.github.jan.supabase.exceptions.RestException
 import io.github.jan.supabase.exceptions.UnknownRestException
+import io.github.jan.supabase.logging.SupabaseLogger
+import io.github.jan.supabase.logging.createLogger
 import io.github.jan.supabase.logging.d
 import io.github.jan.supabase.logging.e
 import io.github.jan.supabase.logging.i
@@ -42,6 +44,7 @@ import kotlin.time.Clock
 
 @PublishedApi internal class RealtimeImpl(override val supabaseClient: SupabaseClient, override val config: Realtime.Config) : Realtime {
 
+    override val logger: SupabaseLogger = supabaseClient.createLogger(Realtime.LOGGING_TAG, config)
     private val websocketFactory = config.websocketFactory ?: KtorRealtimeWebsocketFactory(supabaseClient.httpClient.httpClient)
     private var ws: RealtimeWebsocket? = null
     @Suppress("MagicNumber")
@@ -68,19 +71,25 @@ import kotlin.time.Clock
     private val websocketUrl = realtimeWebsocketUrl()
     private val incrementId = AtomicInt(0)
 
+    init {
+        if(config.customAccessTokenProvider) {
+            logger.w { "You are setting a custom access token provider. This can lead to unexpected behavior." }
+        }
+    }
+
     override suspend fun connect() = connect(false)
 
     private suspend fun connect(reconnect: Boolean): Unit = mutex.withLock {
         if (reconnect) {
             delay(config.reconnectDelay)
-            Realtime.logger.d { "Reconnecting..." }
+            logger.d { "Reconnecting..." }
         }
         if (status.value == Realtime.Status.CONNECTED) return
         _status.value = Realtime.Status.CONNECTING
         try {
             ws = websocketFactory.create(websocketUrl)
             _status.value = Realtime.Status.CONNECTED
-            Realtime.logger.i { "Connected to realtime websocket!" }
+            logger.i { "Connected to realtime websocket!" }
             listenForMessages()
             startHeartbeating()
             if(reconnect) {
@@ -89,7 +98,7 @@ import kotlin.time.Clock
             }
         } catch(e: Exception) {
             currentCoroutineContext().ensureActive()
-            Realtime.logger.e(e) { """
+            logger.e(e) { """
                 Error while trying to connect to realtime websocket. Trying again in ${config.reconnectDelay}
                 URL: $websocketUrl
                 """.trimIndent() }
@@ -112,7 +121,7 @@ import kotlin.time.Clock
                         is SessionStatus.Authenticated -> setAuth(it.session.accessToken)
                         is SessionStatus.NotAuthenticated -> {
                             if(config.disconnectOnSessionLoss) {
-                                Realtime.logger.w { "No auth session found, disconnecting from realtime websocket"}
+                                logger.w { "No auth session found, disconnecting from realtime websocket"}
                                 disconnect()
                             }
                         }
@@ -141,7 +150,7 @@ import kotlin.time.Clock
                 }
             } catch(e: Exception) {
                 currentCoroutineContext().ensureActive()
-                Realtime.logger.e(e) { "Error while listening for messages. Trying again in ${config.reconnectDelay}" }
+                logger.e(e) { "Error while listening for messages. Trying again in ${config.reconnectDelay}" }
                 reconnect()
             }
         }
@@ -160,7 +169,7 @@ import kotlin.time.Clock
     }
 
     override fun disconnect() {
-        Realtime.logger.d { "Closing websocket connection" }
+        logger.d { "Closing websocket connection" }
         messageJob?.cancel()
         ws?.disconnect()
         ws = null
@@ -180,13 +189,13 @@ import kotlin.time.Clock
     }
 
     private suspend fun onMessage(message: RealtimeMessage) {
-        Realtime.logger.d { "Received message $message" }
+        logger.d { "Received message $message" }
         val channel = subscriptions[message.topic] as? RealtimeChannelImpl
         val ref = message.ref?.toIntOrNull()
         if(ref != null && heartbeatRef.compareAndSet(ref, 0)) {
-            Realtime.logger.d { "Heartbeat received" }
+            logger.d { "Heartbeat received" }
         } else {
-            Realtime.logger.d { "Received event ${message.event} for channel ${channel?.topic}" }
+            logger.d { "Received event ${message.event} for channel ${channel?.topic}" }
             channel?.onMessage(message)
         }
     }
@@ -200,7 +209,7 @@ import kotlin.time.Clock
             val now = Clock.System.now()
             val diff = exp - now
             if(diff.isNegative()) {
-                Realtime.logger.w { "Token is expired. Not sending it to realtime." }
+                logger.w { "Token is expired. Not sending it to realtime." }
                 return
             }
         }
@@ -214,11 +223,11 @@ import kotlin.time.Clock
         if (heartbeatRef.load() != 0) {
             heartbeatRef.store(0)
             ref.store(0)
-            Realtime.logger.e { "Heartbeat timeout. Trying to reconnect in ${config.reconnectDelay}" }
+            logger.e { "Heartbeat timeout. Trying to reconnect in ${config.reconnectDelay}" }
             reconnect()
             return
         }
-        Realtime.logger.d { "Sending heartbeat" }
+        logger.d { "Sending heartbeat" }
         heartbeatRef.store(ref.incrementAndFetch())
         send(RealtimeMessage("phoenix", "heartbeat", buildJsonObject { }, heartbeatRef.toString()))
     }
@@ -229,7 +238,7 @@ import kotlin.time.Clock
         }
         _subscriptions.remove(channel.topic)
         if(subscriptions.isEmpty() && config.disconnectOnNoSubscriptions) {
-            Realtime.logger.d { "No more subscriptions, disconnecting from realtime websocket" }
+            logger.d { "No more subscriptions, disconnecting from realtime websocket" }
             disconnect()
         }
     }
@@ -242,7 +251,7 @@ import kotlin.time.Clock
         }
         _subscriptions.clear()
         if(config.disconnectOnNoSubscriptions) {
-            Realtime.logger.d { "No more subscriptions, disconnecting from realtime websocket" }
+            logger.d { "No more subscriptions, disconnecting from realtime websocket" }
             disconnect()
         }
     }
@@ -294,7 +303,7 @@ import kotlin.time.Clock
             ws?.send(message)
         } catch(e: Exception) {
             currentCoroutineContext().ensureActive()
-            Realtime.logger.e(e) { "Error while sending message $message. Reconnecting in ${config.reconnectDelay}" }
+            logger.e(e) { "Error while sending message $message. Reconnecting in ${config.reconnectDelay}" }
             reconnect()
         }
     }

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/event/RCloseEvent.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/event/RCloseEvent.kt
@@ -1,7 +1,6 @@
 package io.github.jan.supabase.realtime.event
 
 import io.github.jan.supabase.logging.d
-import io.github.jan.supabase.realtime.Realtime
 import io.github.jan.supabase.realtime.RealtimeChannel
 import io.github.jan.supabase.realtime.RealtimeMessage
 
@@ -12,7 +11,7 @@ data object RCloseEvent : RealtimeEvent {
 
     override suspend fun handle(channel: RealtimeChannel, message: RealtimeMessage) {
         channel.realtime.removeChannel(channel)
-        Realtime.logger.d { "Unsubscribed from channel ${message.topic}" }
+        channel.logger.d { "Unsubscribed from channel ${message.topic}" }
         channel.updateStatus(RealtimeChannel.Status.UNSUBSCRIBED)
     }
 

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/event/RErrorEvent.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/event/RErrorEvent.kt
@@ -1,7 +1,6 @@
 package io.github.jan.supabase.realtime.event
 
 import io.github.jan.supabase.logging.e
-import io.github.jan.supabase.realtime.Realtime
 import io.github.jan.supabase.realtime.RealtimeChannel
 import io.github.jan.supabase.realtime.RealtimeChannelImpl
 import io.github.jan.supabase.realtime.RealtimeMessage
@@ -17,11 +16,11 @@ data object RErrorEvent : RealtimeEvent {
         channel as RealtimeChannelImpl
         val currentAttempt = channel.joinAttempt.incrementAndFetch()
         if(currentAttempt >= channel.realtime.config.maxAttempts) {
-            Realtime.logger.e { "Failed to rejoin channel ${message.topic} after $currentAttempt attempts. Giving up. ${message.payload}" }
+            channel.logger.e { "Failed to rejoin channel ${message.topic} after $currentAttempt attempts. Giving up. ${message.payload}" }
             channel.updateStatus(RealtimeChannel.Status.UNSUBSCRIBED)
             return
         }
-        Realtime.logger.e { "Received an error in channel ${message.topic}. That could be as a result of an invalid access token. Trying to rejoin the channel...\n${message.payload}" }
+        channel.logger.e { "Received an error in channel ${message.topic}. That could be as a result of an invalid access token. Trying to rejoin the channel...\n${message.payload}" }
         channel.scheduleRejoin()
     }
 

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/event/RPostgresServerChangesEvent.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/event/RPostgresServerChangesEvent.kt
@@ -2,7 +2,6 @@ package io.github.jan.supabase.realtime.event
 
 import io.github.jan.supabase.logging.d
 import io.github.jan.supabase.realtime.PostgresJoinConfig
-import io.github.jan.supabase.realtime.Realtime
 import io.github.jan.supabase.realtime.RealtimeChannel
 import io.github.jan.supabase.realtime.RealtimeMessage
 import kotlinx.serialization.json.Json
@@ -19,7 +18,7 @@ data object RPostgresServerChangesEvent : RealtimeEvent {
         val serverPostgresChanges = message.payload["response"]?.jsonObject?.get("postgres_changes")?.jsonArray?.let { Json.decodeFromJsonElement<List<PostgresJoinConfig>>(it) } ?: listOf() //server postgres changes
         channel.callbackManager.setServerChanges(serverPostgresChanges)
         if(channel.status.value != RealtimeChannel.Status.SUBSCRIBED) {
-            Realtime.logger.d { "Joined channel ${message.topic}" }
+            channel.logger.d { "Joined channel ${message.topic}" }
             channel.updateStatus(RealtimeChannel.Status.SUBSCRIBED)
         }
     }

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/event/RSystemEvent.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/event/RSystemEvent.kt
@@ -1,7 +1,6 @@
 package io.github.jan.supabase.realtime.event
 
 import io.github.jan.supabase.logging.d
-import io.github.jan.supabase.realtime.Realtime
 import io.github.jan.supabase.realtime.RealtimeChannel
 import io.github.jan.supabase.realtime.RealtimeMessage
 import kotlinx.serialization.json.jsonPrimitive
@@ -12,7 +11,7 @@ import kotlinx.serialization.json.jsonPrimitive
 data object RSystemEvent : RealtimeEvent {
 
     override suspend fun handle(channel: RealtimeChannel, message: RealtimeMessage) {
-        Realtime.logger.d { "Subscribed to channel ${message.topic}" }
+        channel.logger.d { "Subscribed to channel ${message.topic}" }
         channel.updateStatus(RealtimeChannel.Status.SUBSCRIBED)
     }
 

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/event/RSystemReplyEvent.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/event/RSystemReplyEvent.kt
@@ -1,7 +1,6 @@
 package io.github.jan.supabase.realtime.event
 
 import io.github.jan.supabase.logging.d
-import io.github.jan.supabase.realtime.Realtime
 import io.github.jan.supabase.realtime.RealtimeChannel
 import io.github.jan.supabase.realtime.RealtimeMessage
 import kotlinx.serialization.json.jsonPrimitive
@@ -12,10 +11,10 @@ import kotlinx.serialization.json.jsonPrimitive
 data object RSystemReplyEvent : RealtimeEvent {
 
     override suspend fun handle(channel: RealtimeChannel, message: RealtimeMessage) {
-        Realtime.logger.d { "Received system reply: ${message.payload}." }
+        channel.logger.d { "Received system reply: ${message.payload}." }
         if(channel.status.value == RealtimeChannel.Status.UNSUBSCRIBING) {
             channel.updateStatus(RealtimeChannel.Status.UNSUBSCRIBED)
-            Realtime.logger.d { "Unsubscribed from channel ${message.topic}" }
+            channel.logger.d { "Unsubscribed from channel ${message.topic}" }
         }
     }
 

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/event/RTokenExpiredEvent.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/event/RTokenExpiredEvent.kt
@@ -1,7 +1,6 @@
 package io.github.jan.supabase.realtime.event
 
 import io.github.jan.supabase.logging.w
-import io.github.jan.supabase.realtime.Realtime
 import io.github.jan.supabase.realtime.RealtimeChannel
 import io.github.jan.supabase.realtime.RealtimeMessage
 import kotlinx.serialization.json.jsonPrimitive
@@ -12,7 +11,7 @@ import kotlinx.serialization.json.jsonPrimitive
 data object RTokenExpiredEvent : RealtimeEvent {
 
     override suspend fun handle(channel: RealtimeChannel, message: RealtimeMessage) {
-        Realtime.logger.w { "Received token expired event. This should not happen, please report this warning." }
+        channel.logger.w { "Received token expired event. This should not happen, please report this warning." }
     }
 
     override fun appliesTo(message: RealtimeMessage): Boolean {

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/Storage.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/Storage.kt
@@ -14,6 +14,7 @@ import io.github.jan.supabase.exceptions.RestException
 import io.github.jan.supabase.exceptions.UnauthorizedRestException
 import io.github.jan.supabase.exceptions.UnknownRestException
 import io.github.jan.supabase.logging.SupabaseLogger
+import io.github.jan.supabase.logging.createLogger
 import io.github.jan.supabase.logging.w
 import io.github.jan.supabase.plugins.CustomSerializationConfig
 import io.github.jan.supabase.plugins.CustomSerializationPlugin
@@ -21,6 +22,7 @@ import io.github.jan.supabase.plugins.MainConfig
 import io.github.jan.supabase.plugins.MainPlugin
 import io.github.jan.supabase.plugins.SupabasePluginProvider
 import io.github.jan.supabase.safeBody
+import io.github.jan.supabase.storage.Storage.Companion.DEFAULT_CHUNK_SIZE
 import io.github.jan.supabase.storage.analytics.StorageAnalyticsClient
 import io.github.jan.supabase.storage.analytics.StorageAnalyticsClientImpl
 import io.github.jan.supabase.storage.resumable.ResumableCache
@@ -164,12 +166,6 @@ interface Storage : MainPlugin<Storage.Config>, CustomSerializationPlugin {
              * The default chunk size for resumable uploads. **Supabase currently only supports a chunk size of 6MB, so be careful when changing this value**
              */
             var defaultChunkSize: Long = DEFAULT_CHUNK_SIZE
-                set(value) {
-                    if(value != DEFAULT_CHUNK_SIZE) {
-                        logger.w { "Supabase currently only supports a chunk size of 6MB" }
-                    }
-                    field = value
-                }
 
         }
 
@@ -186,7 +182,10 @@ interface Storage : MainPlugin<Storage.Config>, CustomSerializationPlugin {
 
         override val key: String = "storage"
 
-        override val logger: SupabaseLogger = SupabaseClient.createLogger("Supabase-Storage")
+        /**
+         * The tag for the Storage logger.
+         */
+        const val LOGGING_TAG = "Supabase-Storage"
 
         /**
          * The api version of the storage plugin
@@ -216,6 +215,7 @@ internal class StorageImpl(override val supabaseClient: SupabaseClient, override
         get() = Storage.API_VERSION
 
     override val serializer: SupabaseSerializer = config.serializer ?: supabaseClient.defaultSerializer
+    override val logger: SupabaseLogger = supabaseClient.createLogger(Storage.LOGGING_TAG, config)
 
     @OptIn(SupabaseInternal::class)
     internal val api = supabaseClient.authenticatedSupabaseApi(this, defaultRequest = {
@@ -226,6 +226,12 @@ internal class StorageImpl(override val supabaseClient: SupabaseClient, override
 
     override val analytics: StorageAnalyticsClient = StorageAnalyticsClientImpl(api.resolve("iceberg"))
     override val vectors: StorageVectorsClient = StorageVectorsClientImpl(api.resolve("vector"))
+
+    init {
+        if(config.resumable.defaultChunkSize != DEFAULT_CHUNK_SIZE) {
+            logger.w { "Supabase currently only supports a chunk size of 6MB" }
+        }
+    }
 
     override suspend fun listBuckets(filter: StorageListFilter.Buckets.() -> Unit): List<Bucket> {
         val response = api.get("bucket") {
@@ -282,7 +288,7 @@ internal class StorageImpl(override val supabaseClient: SupabaseClient, override
 
     override suspend fun parseErrorResponse(response: HttpResponse): RestException {
         val statusCode = response.status
-        val error = response.bodyOrNull<StorageErrorResponse>() ?: StorageErrorResponse(
+        val error = supabaseClient.bodyOrNull<StorageErrorResponse>(response) ?: StorageErrorResponse(
             response.status.value,
             "Unknown error",
             ""

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/resumable/ResumableClient.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/resumable/ResumableClient.kt
@@ -6,7 +6,6 @@ import io.github.jan.supabase.annotations.SupabaseInternal
 import io.github.jan.supabase.auth.Auth
 import io.github.jan.supabase.logging.d
 import io.github.jan.supabase.storage.BucketApi
-import io.github.jan.supabase.storage.Storage
 import io.github.jan.supabase.storage.UploadOptionBuilder
 import io.github.jan.supabase.storage.resumable.ResumableClient.Companion.TUS_VERSION
 import io.github.jan.supabase.storage.storage
@@ -78,11 +77,12 @@ internal class ResumableClientImpl(private val storageApi: BucketApi, private va
     private val httpClient = storageApi.supabaseClient.httpClient.httpClient
     private val url = storageApi.supabaseClient.storage.resolveUrl("upload/resumable")
     private val chunkSize = storageApi.supabaseClient.storage.config.resumable.defaultChunkSize
+    val logger = storageApi.supabaseClient.logger
 
     override suspend fun continuePreviousUploads(channelProducer: suspend (source: String, offset: Long) -> ByteReadChannel): List<Deferred<ResumableUpload>> {
         val cachedEntries = cache.entries()
         return cachedEntries.map { (fingerprint, cacheEntry) ->
-            Storage.logger.d { "Found cached upload for ${cacheEntry.path}" }
+            logger.d { "Found cached upload for ${cacheEntry.path}" }
             coroutineScope {
                 async {
                     resumeUpload({ channelProducer(fingerprint.source, it) }, cacheEntry, fingerprint.source, cacheEntry.path, fingerprint.size)
@@ -100,7 +100,7 @@ internal class ResumableClientImpl(private val storageApi: BucketApi, private va
     ): ResumableUpload {
         val cachedEntry = cache.get(Fingerprint(source, size))
         if(cachedEntry != null) {
-            Storage.logger.d { "Found cached upload for $path" }
+            logger.d { "Found cached upload for $path" }
             return resumeUpload(channel, cachedEntry, source, path, size)
         }
         return createUpload(channel, source, path, size, options)
@@ -144,7 +144,7 @@ internal class ResumableClientImpl(private val storageApi: BucketApi, private va
     private suspend fun resumeUpload(channel: suspend (Long) -> ByteReadChannel, entry: ResumableCacheEntry, source: String, path: String, size: Long): ResumableUploadImpl {
         val fingerprint = Fingerprint(source, size)
         if(Clock.System.now() > entry.expiresAt) {
-            Storage.logger.d { "Upload url for $path expired. Creating new one" }
+            logger.d { "Upload url for $path expired. Creating new one" }
             cache.remove(fingerprint)
             return createUpload(channel, source, path, size) {
                 upsert = entry.upsert
@@ -178,7 +178,7 @@ internal class ResumableClientImpl(private val storageApi: BucketApi, private va
         }
         if(!response.status.isSuccess()) error("Failed to retrieve server offset: ${response.status} ${response.bodyAsText()}")
         val offset = response.headers["Upload-Offset"]?.toLongOrNull() ?: error("No upload offset found")
-        Storage.logger.d { "Server offset for $path is $offset" }
+        logger.d { "Server offset for $path is $offset" }
         return offset
     }
 

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/resumable/ResumableUpload.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/resumable/ResumableUpload.kt
@@ -97,6 +97,7 @@ internal class ResumableUploadImpl(
     private val scope = CoroutineScope(coroutineDispatcher)
     private val config = storageApi.supabaseClient.storage.config.resumable
     private lateinit var dataStream: ByteReadChannel
+    val logger = storageApi.supabaseClient.logger
 
     override suspend fun pause() {
         paused.store(true)
@@ -116,7 +117,7 @@ internal class ResumableUploadImpl(
             while (offset < size) {
                 if(paused.load() || !isActive) return@launch //check if paused or the scope is still active
                 if(updateOffset) { //after an upload error we retrieve the server offset and update the data stream to avoid conflicts
-                    Storage.logger.d { "Trying to update server offset for $path" }
+                    logger.d { "Trying to update server offset for $path" }
                     try {
                         serverOffset = retrieveServerOffset() //retrieve server offset
                         offset = serverOffset
@@ -124,7 +125,7 @@ internal class ResumableUploadImpl(
                         dataStream = createDataStream(offset) //create new data stream
                     } catch(e: Exception) {
                         currentCoroutineContext().ensureActive()
-                        Storage.logger.e(e) { "Error while updating server offset for $path. Retrying in ${config.retryTimeout}" }
+                        logger.e(e) { "Error while updating server offset for $path. Retrying in ${config.retryTimeout}" }
                         delay(config.retryTimeout)
                         continue
                     }
@@ -136,7 +137,7 @@ internal class ResumableUploadImpl(
                 } catch(e: Exception) {
                     currentCoroutineContext().ensureActive()
                     if(e !is IllegalStateException) {
-                        Storage.logger.e(e) {"Error while uploading chunk. Retrying in ${config.retryTimeout}" }
+                        logger.e(e) {"Error while uploading chunk. Retrying in ${config.retryTimeout}" }
                         delay(config.retryTimeout)
                         updateOffset = true //if an error occurs, we need to update the server offset to avoid conflicts
                         continue
@@ -176,11 +177,11 @@ internal class ResumableUploadImpl(
                 serverOffset = uploadResponse.headers["Upload-Offset"]?.toLong() ?: error("No upload offset found")
             }
             HttpStatusCode.Conflict -> {
-                Storage.logger.w { "Upload conflict, skipping chunk" }
+                logger.w { "Upload conflict, skipping chunk" }
                 serverOffset = offset + limit
             }
             HttpStatusCode.NoContent -> {
-                Storage.logger.d { "Uploaded chunk" }
+                logger.d { "Uploaded chunk" }
             }
             else -> error("Upload failed with status ${uploadResponse.status}. ${uploadResponse.bodyAsText()}")
         }

--- a/Supabase/src/commonMain/kotlin/io/github/jan/supabase/PlatformTarget.kt
+++ b/Supabase/src/commonMain/kotlin/io/github/jan/supabase/PlatformTarget.kt
@@ -1,8 +1,6 @@
 @file:Suppress("UndocumentedPublicProperty")
 package io.github.jan.supabase
 
-import io.github.jan.supabase.logging.e
-
 /**
  * Represents a target platform
  */
@@ -20,9 +18,6 @@ data class OSInformation(
             try {
                 getOSInformation()
             } catch (e: Exception) {
-                SupabaseClient.LOGGER.e(e) {
-                    "Failed to get OS information, please report this issue"
-                }
                 null
             }
         }

--- a/Supabase/src/commonMain/kotlin/io/github/jan/supabase/SupabaseClient.kt
+++ b/Supabase/src/commonMain/kotlin/io/github/jan/supabase/SupabaseClient.kt
@@ -1,16 +1,13 @@
 package io.github.jan.supabase
 
-import io.github.jan.supabase.SupabaseClient.Companion.DEFAULT_LOG_LEVEL
 import io.github.jan.supabase.annotations.SupabaseInternal
-import io.github.jan.supabase.logging.KermitSupabaseLogger
-import io.github.jan.supabase.logging.LogLevel
 import io.github.jan.supabase.logging.SupabaseLogger
+import io.github.jan.supabase.logging.createLogger
 import io.github.jan.supabase.logging.i
 import io.github.jan.supabase.network.KtorSupabaseHttpClient
 import io.github.jan.supabase.plugins.PluginManager
 import io.github.jan.supabase.plugins.SupabasePlugin
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlin.concurrent.Volatile
 
 /**
  * The main class to interact with Supabase.
@@ -71,6 +68,8 @@ interface SupabaseClient {
     @SupabaseInternal
     val coroutineDispatcher: CoroutineDispatcher
 
+    val logger: SupabaseLogger
+
     /**
      * Releases all resources held by the [httpClient] and all plugins the [pluginManager]
      */
@@ -79,21 +78,9 @@ interface SupabaseClient {
     companion object {
 
         /**
-         * The default minimum logging level used for plugins. Can be changed within the [SupabaseClientBuilder]
+         * The tag for the Supabase logger.
          */
-        @Volatile
-        var DEFAULT_LOG_LEVEL = LogLevel.INFO
-            internal set
-
-        val LOGGER: SupabaseLogger = createLogger("Supabase-Core")
-
-        /**
-         * Creates a new [SupabaseLogger] using the [KermitSupabaseLogger] implementation.
-         * @param tag The tag for the logger
-         * @param level The logging level. If set to null, the [DEFAULT_LOG_LEVEL] property will be used instead
-         */
-        fun createLogger(tag: String, level: LogLevel? = null): SupabaseLogger =
-            KermitSupabaseLogger(null, tag)
+        const val LOGGING_TAG = "Supabase-Core"
 
     }
 
@@ -109,10 +96,22 @@ internal class SupabaseClientImpl(
     override val supabaseKey: String = config.supabaseKey
     override val useHTTPS: Boolean = config.networkConfig.useHTTPS
     override val coroutineDispatcher: CoroutineDispatcher = config.coroutineDispatcher
+    override val logger: SupabaseLogger = createLogger(
+        SupabaseClient.LOGGING_TAG,
+        config.loggingConfig.defaultLogLevel,
+        config.loggingConfig.defaultLoggingFactory
+    )
 
     init {
-        SupabaseClient.LOGGER.i {
+        logger.i {
             "SupabaseClient created! Please report any bugs you find."
+        }
+        try {
+            getOSInformation()
+        } catch(e: Exception) {
+            logger.i(e) {
+                "Failed to get OS information. If this is not intentional, please report this issue."
+            }
         }
     }
 
@@ -129,14 +128,14 @@ internal class SupabaseClientImpl(
 
     override val pluginManager = PluginManager(config.plugins.toList().associate { (key, value) ->
         key to value(this)
-    })
+    }, logger.appendTag(" [PluginManager]"))
 
     init {
         pluginManager.installedPlugins.values.forEach(SupabasePlugin<*>::init)
     }
 
     override suspend fun close() {
-        SupabaseClient.LOGGER.i { "Closing SupabaseClient" }
+        logger.i { "Closing SupabaseClient" }
         httpClient.close()
         pluginManager.closeAllPlugins()
     }

--- a/Supabase/src/commonMain/kotlin/io/github/jan/supabase/SupabaseClientBuilder.kt
+++ b/Supabase/src/commonMain/kotlin/io/github/jan/supabase/SupabaseClientBuilder.kt
@@ -65,7 +65,10 @@ class SupabaseClientBuilder @PublishedApi internal constructor(
      */
     var defaultLogLevel: LogLevel = LogLevel.INFO
 
-    var defaultLoggingProcessor: SupabaseLoggingProcessorFactory = { level -> KermitLoggingProcessor(level) }
+    /**
+     * The default logging factory. Used for creating a [SupabaseLoggingProcessor] using a specified [LogLevel]
+     */
+    var defaultLoggingFactory: SupabaseLoggingProcessorFactory = { level -> KermitLoggingProcessor(level) }
 
     /**
      * The default serializer used to serialize and deserialize custom data types.
@@ -124,7 +127,7 @@ class SupabaseClientBuilder @PublishedApi internal constructor(
             supabaseKey = supabaseKey,
             loggingConfig = SupabaseLoggingConfig(
                 defaultLogLevel,
-                defaultLoggingProcessor
+                defaultLoggingFactory
             ),
             networkConfig = SupabaseNetworkConfig(
                 useHTTPS = useHTTPS,

--- a/Supabase/src/commonMain/kotlin/io/github/jan/supabase/SupabaseClientBuilder.kt
+++ b/Supabase/src/commonMain/kotlin/io/github/jan/supabase/SupabaseClientBuilder.kt
@@ -2,7 +2,9 @@ package io.github.jan.supabase
 
 import io.github.jan.supabase.annotations.SupabaseDsl
 import io.github.jan.supabase.annotations.SupabaseInternal
+import io.github.jan.supabase.logging.KermitLoggingProcessor
 import io.github.jan.supabase.logging.LogLevel
+import io.github.jan.supabase.logging.SupabaseLoggingProcessor
 import io.github.jan.supabase.plugins.PluginManager
 import io.github.jan.supabase.plugins.SupabasePlugin
 import io.github.jan.supabase.plugins.SupabasePluginProvider
@@ -17,6 +19,7 @@ import kotlin.time.Duration.Companion.seconds
 
 internal typealias PluginProvider = (SupabaseClient) -> SupabasePlugin<*>
 internal typealias HttpConfigOverride = HttpClientConfig<*>.() -> Unit
+typealias SupabaseLoggingProcessorFactory = (level: LogLevel) -> SupabaseLoggingProcessor
 
 /**
  * Creates a new [SupabaseClient] with the given options.
@@ -24,7 +27,10 @@ internal typealias HttpConfigOverride = HttpClientConfig<*>.() -> Unit
  * Use [createSupabaseClient] to create a new instance of [SupabaseClient].
  */
 @SupabaseDsl
-class SupabaseClientBuilder @PublishedApi internal constructor(private val supabaseUrl: String, private val supabaseKey: String) {
+class SupabaseClientBuilder @PublishedApi internal constructor(
+    private val supabaseUrl: String,
+    private val supabaseKey: String
+) {
 
     /**
      * Whether to use HTTPS for network requests with the [supabaseUrl]
@@ -57,11 +63,9 @@ class SupabaseClientBuilder @PublishedApi internal constructor(private val supab
      *
      * Can be overridden by the plugin's config
      */
-    var defaultLogLevel: LogLevel
-        set(value) {
-            SupabaseClient.DEFAULT_LOG_LEVEL = value
-        }
-        get() = SupabaseClient.DEFAULT_LOG_LEVEL
+    var defaultLogLevel: LogLevel = LogLevel.INFO
+
+    var defaultLoggingProcessor: SupabaseLoggingProcessorFactory = { level -> KermitLoggingProcessor(level) }
 
     /**
      * The default serializer used to serialize and deserialize custom data types.
@@ -118,7 +122,10 @@ class SupabaseClientBuilder @PublishedApi internal constructor(private val supab
         val config = SupabaseClientConfig(
             supabaseUrl = supabaseUrl.split("//").last(),
             supabaseKey = supabaseKey,
-            defaultLogLevel = defaultLogLevel,
+            loggingConfig = SupabaseLoggingConfig(
+                defaultLogLevel,
+                defaultLoggingProcessor
+            ),
             networkConfig = SupabaseNetworkConfig(
                 useHTTPS = useHTTPS,
                 httpEngine = httpEngine,

--- a/Supabase/src/commonMain/kotlin/io/github/jan/supabase/SupabaseClientConfig.kt
+++ b/Supabase/src/commonMain/kotlin/io/github/jan/supabase/SupabaseClientConfig.kt
@@ -8,13 +8,18 @@ import kotlin.time.Duration
 data class SupabaseClientConfig(
     val supabaseUrl: String,
     val supabaseKey: String,
-    val defaultLogLevel: LogLevel,
+    val loggingConfig: SupabaseLoggingConfig,
     val networkConfig: SupabaseNetworkConfig,
     val defaultSerializer: SupabaseSerializer,
     val coroutineDispatcher: CoroutineDispatcher,
     val accessToken: AccessTokenProvider?,
     val plugins: Map<String, PluginProvider>,
     val osInformation: OSInformation?
+)
+
+data class SupabaseLoggingConfig(
+    val defaultLogLevel: LogLevel,
+    val defaultLoggingFactory: SupabaseLoggingProcessorFactory
 )
 
 data class SupabaseNetworkConfig(

--- a/Supabase/src/commonMain/kotlin/io/github/jan/supabase/Utils.kt
+++ b/Supabase/src/commonMain/kotlin/io/github/jan/supabase/Utils.kt
@@ -51,12 +51,12 @@ inline fun <reified T> JsonObject.decodeIfNotEmptyOrDefault(default: T): T {
 }
 
 @SupabaseInternal
-suspend inline fun <reified T> HttpResponse.bodyOrNull(): T? {
-    val text = bodyAsText()
+suspend inline fun <reified T> SupabaseClient.bodyOrNull(response: HttpResponse): T? {
+    val text = response.bodyAsText()
     return try {
         supabaseJson.decodeFromString<T>(text)
     } catch(e: SerializationException) {
-        SupabaseClient.LOGGER.i(e) { "Could not decode $text as ${T::class}." }
+        logger.i(e) { "Could not decode ${text.take(200)} as ${T::class.simpleName}." }
         null
     }
 }

--- a/Supabase/src/commonMain/kotlin/io/github/jan/supabase/logging/KermitLoggingProcessor.kt
+++ b/Supabase/src/commonMain/kotlin/io/github/jan/supabase/logging/KermitLoggingProcessor.kt
@@ -1,0 +1,36 @@
+package io.github.jan.supabase.logging
+
+import co.touchlab.kermit.Logger
+import co.touchlab.kermit.Severity
+import co.touchlab.kermit.loggerConfigInit
+import co.touchlab.kermit.platformLogWriter
+
+/**
+ * A [SupabaseLoggingProcessor] implementation using Kermit.
+ * @param level The minimum log level for this logger.
+ */
+internal class KermitLoggingProcessor(
+    level: LogLevel,
+) : SupabaseLoggingProcessor {
+
+    private val logger: Logger = Logger(
+        config = loggerConfigInit(platformLogWriter(), minSeverity = level.toSeverity())
+    )
+
+    override fun isEnabled(level: LogLevel): Boolean {
+        return logger.config.minSeverity <= level.toSeverity()
+    }
+
+    override fun processLog(level: LogLevel, tag: String, throwable: Throwable?, message: String) {
+        logger.processLog(level.toSeverity(), tag, throwable, message)
+    }
+
+    private fun LogLevel.toSeverity() = when (this) {
+        LogLevel.DEBUG -> Severity.Debug
+        LogLevel.INFO -> Severity.Info
+        LogLevel.WARNING -> Severity.Warn
+        LogLevel.ERROR -> Severity.Error
+        LogLevel.NONE -> Severity.Assert
+    }
+
+}

--- a/Supabase/src/commonMain/kotlin/io/github/jan/supabase/logging/SupabaseLogger.kt
+++ b/Supabase/src/commonMain/kotlin/io/github/jan/supabase/logging/SupabaseLogger.kt
@@ -1,22 +1,21 @@
 package io.github.jan.supabase.logging
 
-import co.touchlab.kermit.Logger
-import co.touchlab.kermit.Severity
-import co.touchlab.kermit.loggerConfigInit
-import co.touchlab.kermit.platformLogWriter
 import io.github.jan.supabase.SupabaseClient
-import io.github.jan.supabase.annotations.SupabaseInternal
-import kotlin.concurrent.Volatile
+import io.github.jan.supabase.SupabaseLoggingProcessorFactory
+import io.github.jan.supabase.plugins.MainConfig
 
 /**
  * An interface for logging in Supabase plugins.
+ * @param level The minimum log level to handle for this logger. If null, [SupabaseClient.DEFAULT_LOG_LEVEL] will be used.
+ * @param processor The logging processor used for the actual logging
  */
-abstract class SupabaseLogger {
+class SupabaseLogger(
+    val level: LogLevel,
+    val tag: String,
+    processorFactory: SupabaseLoggingProcessorFactory
+) {
 
-    /**
-     * The minimum log level to handle for this logger. If null, [SupabaseClient.DEFAULT_LOG_LEVEL] will be used.
-     */
-    abstract val level: LogLevel?
+    val processor = processorFactory(level)
 
     /**
      * Log a message with the given [level] and [message]. An optional [throwable] can be provided.
@@ -24,7 +23,9 @@ abstract class SupabaseLogger {
      * @param throwable An optional throwable
      * @param message The message to log
      */
-    abstract fun log(level: LogLevel, throwable: Throwable? = null, message: String)
+    fun log(level: LogLevel, throwable: Throwable? = null, message: String) = processor.log(level, tag, throwable) {
+        message
+    }
 
     /**
      * Log a message with the given [level] and [message]. An optional [throwable] can be provided.
@@ -32,62 +33,19 @@ abstract class SupabaseLogger {
      * @param throwable An optional throwable
      * @param message The message to log
      */
-    inline fun log(level: LogLevel, throwable: Throwable? = null, message: () -> String) {
-        if (level >= (this.level ?: SupabaseClient.DEFAULT_LOG_LEVEL)) {
-            log(level, throwable, message())
-        }
-    }
+    inline fun log(level: LogLevel, throwable: Throwable? = null, message: () -> String) = processor.log(level, tag, throwable, message)
 
     /**
-     * Set the log level for this logger. If set to `null`, [SupabaseClient.DEFAULT_LOG_LEVEL] will be used.
-     * @param level The log level
+     * Creates a new logger with the new [tag], but with the same [processor]
+     * @param tag The new tag
      */
-    @SupabaseInternal
-    abstract fun setLevel(level: LogLevel?)
+    fun withTag(tag: String) = SupabaseLogger(level, tag, { _ -> processor })
 
-}
-
-/**
- * A logger implementation using the Kermit logger.
- * @param level The minimum log level for this logger.
- * @param tag The tag for this logger
- */
-internal class KermitSupabaseLogger(
-    initialLevel: LogLevel?,
-    tag: String,
-) : SupabaseLogger() {
-
-    @Volatile
-    override var level: LogLevel? = initialLevel
-        private set
-
-    private val logger: Logger = Logger(
-        config = loggerConfigInit(platformLogWriter(), minSeverity = Severity.Debug),
-        tag = tag,
-    )
-
-    override fun log(level: LogLevel, throwable: Throwable?, message: String) {
-        if (level >= getLevelOrDefault()) {
-            logger.processLog(level.toSeverity(), logger.tag, throwable, message)
-        }
-    }
-
-    private fun LogLevel.toSeverity() = when (this) {
-        LogLevel.DEBUG -> Severity.Debug
-        LogLevel.INFO -> Severity.Info
-        LogLevel.WARNING -> Severity.Warn
-        LogLevel.ERROR -> Severity.Error
-        LogLevel.NONE -> Severity.Assert
-    }
-
-    @SupabaseInternal
-    override fun setLevel(level: LogLevel?) {
-        this.level = level
-    }
-
-    private fun getLevelOrDefault(): LogLevel {
-        return this.level ?: SupabaseClient.DEFAULT_LOG_LEVEL
-    }
+    /**
+     * Creates a new logger and appends [tag] to the current tag
+     * @param tag The tag to append
+     */
+    fun appendTag(tag: String) = withTag(tag + this.tag)
 
 }
 
@@ -126,3 +84,14 @@ inline fun SupabaseLogger.w(throwable: Throwable? = null, message: () -> String)
 inline fun SupabaseLogger.e(throwable: Throwable? = null, message: () -> String) {
     log(LogLevel.ERROR, throwable, message)
 }
+
+fun SupabaseClient.createLogger(
+    tag: String,
+    logLevel: LogLevel?,
+    loggingFactory: SupabaseLoggingProcessorFactory?
+) = SupabaseLogger(logLevel ?: logger.level, tag, loggingFactory ?: config.loggingConfig.defaultLoggingFactory)
+
+fun SupabaseClient.createLogger(
+    tag: String,
+    config: MainConfig
+) = createLogger(tag, config.logLevel,config.loggingFactory)

--- a/Supabase/src/commonMain/kotlin/io/github/jan/supabase/logging/SupabaseLoggingProcessor.kt
+++ b/Supabase/src/commonMain/kotlin/io/github/jan/supabase/logging/SupabaseLoggingProcessor.kt
@@ -1,0 +1,36 @@
+package io.github.jan.supabase.logging
+
+/**
+ * An interface for processing logs
+ */
+interface SupabaseLoggingProcessor {
+
+    /**
+     * Returns whether log messages at the given [level] are enabled.
+     * @param level The log level
+     */
+    fun isEnabled(level: LogLevel): Boolean
+
+    /**
+     * Log a message with the given [level], [tag] and [message]. An optional [throwable] can be provided.
+     * @param level The log level
+     * @param tag The logging tag
+     * @param throwable An optional throwable
+     * @param message The message to log
+     */
+    fun processLog(level: LogLevel, tag: String, throwable: Throwable? = null, message: String)
+
+}
+
+/**
+ * Log a message with the given [level], [tag] and [message]. Only invokes the [message] lambda, if the level [isEnabled][SupabaseLoggingProcessor.isEnabled]. An optional [throwable] can be provided.
+ * @param level The log level
+ * @param tag The logging tag
+ * @param throwable An optional throwable
+ * @param message The message to log
+ */
+inline fun SupabaseLoggingProcessor.log(level: LogLevel, tag: String, throwable: Throwable?, message: () -> String) {
+    if(isEnabled(level)) {
+        processLog(level, tag, throwable, message())
+    }
+}

--- a/Supabase/src/commonMain/kotlin/io/github/jan/supabase/network/KtorSupabaseHttpClient.kt
+++ b/Supabase/src/commonMain/kotlin/io/github/jan/supabase/network/KtorSupabaseHttpClient.kt
@@ -40,7 +40,8 @@ typealias HttpRequestOverride = HttpRequestBuilder.() -> Unit
 class KtorSupabaseHttpClient @SupabaseInternal constructor(
     private val supabase: SupabaseClient
 ): SupabaseHttpClient() {
-
+    
+    val logger = supabase.logger.appendTag(" [Network]")
     private val supabaseKey = supabase.supabaseKey
     private val osInformation = supabase.config.osInformation
 
@@ -56,7 +57,7 @@ class KtorSupabaseHttpClient @SupabaseInternal constructor(
     }
 
     init {
-        SupabaseClient.LOGGER.d { "Creating KtorSupabaseHttpClient with request timeout $requestTimeout, HttpClientEngine: $engine" }
+        logger.d { "Creating KtorSupabaseHttpClient with request timeout $requestTimeout, HttpClientEngine: $engine" }
     }
 
     @SupabaseInternal
@@ -70,21 +71,21 @@ class KtorSupabaseHttpClient @SupabaseInternal constructor(
             builder()
         }
         val endPoint = request.url.encodedPath
-        SupabaseClient.LOGGER.d { "Starting ${request.method.value} request to endpoint $endPoint" }
+        logger.d { "Starting ${request.method.value} request to endpoint $endPoint" }
         val response = try {
             httpClient.request(url, builder)
         } catch(e: HttpRequestTimeoutException) {
-            SupabaseClient.LOGGER.d(e) { "${request.method.value} request to endpoint $endPoint timed out after $requestTimeout" }
+            logger.d(e) { "${request.method.value} request to endpoint $endPoint timed out after $requestTimeout" }
             throw e
         } catch(e: CancellationException) {
-            SupabaseClient.LOGGER.d(e) { "${request.method.value} request to endpoint $endPoint was cancelled"}
+            logger.d(e) { "${request.method.value} request to endpoint $endPoint was cancelled"}
             throw e
         } catch(e: Exception) {
-            SupabaseClient.LOGGER.d(e) { "${request.method.value} request to endpoint $endPoint failed with exception ${e.message}" }
+            logger.d(e) { "${request.method.value} request to endpoint $endPoint failed with exception ${e.message}" }
             throw HttpRequestException(e.message ?: "", request)
         }
         val responseTime = (response.responseTime.timestamp - response.requestTime.timestamp).milliseconds
-        SupabaseClient.LOGGER.d { "${request.method.value} request to endpoint $endPoint successfully finished in $responseTime" }
+        logger.d { "${request.method.value} request to endpoint $endPoint successfully finished in $responseTime" }
         return response
     }
 
@@ -99,13 +100,13 @@ class KtorSupabaseHttpClient @SupabaseInternal constructor(
         val response = try {
             httpClient.prepareRequest(url, builder)
         } catch(e: HttpRequestTimeoutException) {
-            SupabaseClient.LOGGER.d(e) { "Request timed out after $requestTimeout on url $url" }
+            logger.d(e) { "Request timed out after $requestTimeout on url $url" }
             throw e
         } catch(e: CancellationException) {
-            SupabaseClient.LOGGER.d(e) { "Request was cancelled on url $url" }
+            logger.d(e) { "Request was cancelled on url $url" }
             throw e
         } catch(e: Exception) {
-            SupabaseClient.LOGGER.d(e) { "Request failed with ${e.message} on url $url" }
+            logger.d(e) { "Request failed with ${e.message} on url $url" }
             throw HttpRequestException(e.message ?: "", request)
         }
         return response

--- a/Supabase/src/commonMain/kotlin/io/github/jan/supabase/plugins/MainPlugin.kt
+++ b/Supabase/src/commonMain/kotlin/io/github/jan/supabase/plugins/MainPlugin.kt
@@ -1,9 +1,12 @@
 package io.github.jan.supabase.plugins
 
 import io.github.jan.supabase.SupabaseClient
+import io.github.jan.supabase.SupabaseLoggingProcessorFactory
 import io.github.jan.supabase.annotations.SupabaseInternal
 import io.github.jan.supabase.buildUrl
 import io.github.jan.supabase.exceptions.RestException
+import io.github.jan.supabase.logging.LogLevel
+import io.github.jan.supabase.logging.SupabaseLogger
 import io.ktor.client.statement.HttpResponse
 import io.ktor.http.appendEncodedPathSegments
 
@@ -22,6 +25,10 @@ open class MainConfig {
      */
     var jwtToken: String? = null
 
+    var logLevel: LogLevel? = null
+
+    var loggingFactory: SupabaseLoggingProcessorFactory? = null
+
 }
 
 /**
@@ -38,6 +45,8 @@ interface MainPlugin <Config : MainConfig> : SupabasePlugin<Config> {
      * The unique key for this plugin
      */
     val pluginKey: String
+
+    val logger: SupabaseLogger
 
     /**
      * Gets the auth url from either [MainConfig.customUrl] or [SupabaseClient.supabaseHttpUrl] and adds [path] to it

--- a/Supabase/src/commonMain/kotlin/io/github/jan/supabase/plugins/PluginManager.kt
+++ b/Supabase/src/commonMain/kotlin/io/github/jan/supabase/plugins/PluginManager.kt
@@ -1,17 +1,20 @@
 package io.github.jan.supabase.plugins
 
-import io.github.jan.supabase.SupabaseClient
 import io.github.jan.supabase.SupabaseClientBuilder
+import io.github.jan.supabase.logging.SupabaseLogger
 import io.github.jan.supabase.logging.d
 
 /**
  * The plugin manager is used to manage installed plugins
  * @param installedPlugins A map of installed plugins. You can install plugins by using the [SupabaseClientBuilder.install] method
  */
-class PluginManager(val installedPlugins: Map<String, SupabasePlugin<*>>) {
+class PluginManager(
+    val installedPlugins: Map<String, SupabasePlugin<*>>,
+    val logger: SupabaseLogger
+) {
 
     init {
-        SupabaseClient.LOGGER.d { "PluginManager initialized with plugins: ${installedPlugins.keys}" }
+        logger.d { "PluginManager initialized with plugins: ${installedPlugins.keys}" }
     }
 
     /**

--- a/Supabase/src/commonMain/kotlin/io/github/jan/supabase/plugins/SupabasePluginProvider.kt
+++ b/Supabase/src/commonMain/kotlin/io/github/jan/supabase/plugins/SupabasePluginProvider.kt
@@ -2,8 +2,6 @@ package io.github.jan.supabase.plugins
 
 import io.github.jan.supabase.SupabaseClient
 import io.github.jan.supabase.SupabaseClientBuilder
-import io.github.jan.supabase.logging.LogLevel
-import io.github.jan.supabase.logging.SupabaseLogger
 
 /**
  * A plugin provider is used to create a plugin instance. Typically inherited by a companion object of the plugin
@@ -14,11 +12,6 @@ interface SupabasePluginProvider<Config, PluginInstance : SupabasePlugin<Config>
      * The key of this plugin. This key is used to identify the plugin within the [PluginManager]
      */
     val key: String
-
-    /**
-     * The logger used in this plugin.
-     */
-    val logger: SupabaseLogger
 
     /**
      * Create a config for this plugin using the [init] function

--- a/Supabase/src/commonTest/kotlin/SupabaseLoggerTest.kt
+++ b/Supabase/src/commonTest/kotlin/SupabaseLoggerTest.kt
@@ -1,0 +1,46 @@
+import io.github.jan.supabase.logging.LogLevel
+import io.github.jan.supabase.logging.SupabaseLogger
+import io.github.jan.supabase.logging.SupabaseLoggingProcessor
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.SendChannel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SupabaseLoggerTest {
+
+    class MockLoggingProcessor(
+        private val logLevel: LogLevel,
+        private val writeChannel: SendChannel<String>,
+        private val coroutineScope: CoroutineScope
+    ) : SupabaseLoggingProcessor {
+
+        override fun isEnabled(level: LogLevel): Boolean {
+            return level <= logLevel
+        }
+
+        override fun processLog(
+            level: LogLevel,
+            tag: String,
+            throwable: Throwable?,
+            message: String
+        ) {
+           coroutineScope.launch {
+               writeChannel.send(level.name + tag + message)
+           }
+        }
+    }
+
+    @Test
+    fun testLogging() = runTest {
+        val channel = Channel<String>()
+        val logger = SupabaseLogger(LogLevel.DEBUG, "MyTag", { MockLoggingProcessor(it, channel, backgroundScope)} )
+        logger.log(LogLevel.DEBUG, null, "Test")
+        advanceUntilIdle()
+        assertEquals("DEBUGMyTagTest", channel.receive())
+    }
+
+}

--- a/Supabase/src/commonTest/kotlin/SupabaseLoggerTest.kt
+++ b/Supabase/src/commonTest/kotlin/SupabaseLoggerTest.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class SupabaseLoggerTest {
 
@@ -19,7 +20,7 @@ class SupabaseLoggerTest {
     ) : SupabaseLoggingProcessor {
 
         override fun isEnabled(level: LogLevel): Boolean {
-            return level <= logLevel
+            return level >= logLevel
         }
 
         override fun processLog(
@@ -37,10 +38,46 @@ class SupabaseLoggerTest {
     @Test
     fun testLogging() = runTest {
         val channel = Channel<String>()
-        val logger = SupabaseLogger(LogLevel.DEBUG, "MyTag", { MockLoggingProcessor(it, channel, backgroundScope)} )
+        val logger = SupabaseLogger(LogLevel.DEBUG, "MyTag") { MockLoggingProcessor(it, channel, backgroundScope) }
         logger.log(LogLevel.DEBUG, null, "Test")
         advanceUntilIdle()
         assertEquals("DEBUGMyTagTest", channel.receive())
+    }
+
+    @Test
+    fun testLogLevelFiltering() = runTest {
+        val channel = Channel<String>(capacity = 10)
+        // Set processor to INFO
+        val logger = SupabaseLogger(LogLevel.INFO, "Tag") { MockLoggingProcessor(it, channel, backgroundScope) }
+
+        // 1. Log at DEBUG (should be ignored if INFO is the threshold)
+        logger.log(LogLevel.DEBUG, null, "Lower priority")
+
+        // 2. Log at ERROR (should be allowed)
+        logger.log(LogLevel.ERROR, null, "Higher priority")
+
+        advanceUntilIdle()
+
+        // Check that we only got the ERROR message, not the DEBUG one
+        assertEquals("ERRORTagHigher priority", channel.receive())
+        assertTrue(channel.isEmpty, "Channel should have no more messages")
+    }
+
+    @Test
+    fun testRapidFireLoggingOrder() = runTest {
+        val channel = Channel<String>(capacity = 100)
+        val logger = SupabaseLogger(LogLevel.DEBUG, "Tag", { MockLoggingProcessor(it, channel, backgroundScope)} )
+
+        val count = 50
+        repeat(count) { i ->
+            logger.log(LogLevel.DEBUG, null, "Msg $i")
+        }
+
+        advanceUntilIdle()
+
+        repeat(count) { i ->
+            assertEquals("DEBUGTagMsg $i", channel.receive())
+        }
     }
 
 }

--- a/test-common/src/commonTest/kotlin/SupabaseClientTest.kt
+++ b/test-common/src/commonTest/kotlin/SupabaseClientTest.kt
@@ -1,7 +1,6 @@
 import io.github.jan.supabase.BuildConfig
 import io.github.jan.supabase.OSInformation
 import io.github.jan.supabase.SupabaseClient
-import io.github.jan.supabase.logging.LogLevel
 import io.github.jan.supabase.testing.createMockedSupabaseClient
 import io.github.jan.supabase.testing.withMockedSupabaseClient
 import io.ktor.client.engine.mock.respond
@@ -77,20 +76,6 @@ class SupabaseClientTest {
             )
             assertEquals("myToken", client.accessToken?.invoke())
         }
-    }
-
-    @Test
-    fun testDefaultLogLevel() {
-        createMockedSupabaseClient(
-            configuration = {
-                defaultLogLevel = LogLevel.DEBUG
-            }
-        )
-        assertEquals(
-            LogLevel.DEBUG,
-            SupabaseClient.DEFAULT_LOG_LEVEL,
-            "Default log level should be set to ${LogLevel.DEBUG}"
-        )
     }
 
     @Test

--- a/test-common/src/commonTest/kotlin/TestPlugin.kt
+++ b/test-common/src/commonTest/kotlin/TestPlugin.kt
@@ -1,6 +1,5 @@
 import io.github.jan.supabase.SupabaseClient
 import io.github.jan.supabase.SupabaseClientBuilder
-import io.github.jan.supabase.logging.SupabaseLogger
 import io.github.jan.supabase.plugins.SupabasePlugin
 import io.github.jan.supabase.plugins.SupabasePluginProvider
 
@@ -12,8 +11,6 @@ class TestPlugin(override val config: Config, override val supabaseClient: Supab
     companion object : SupabasePluginProvider<Config, TestPlugin> {
 
         override val key = "test"
-
-        override val logger: SupabaseLogger = SupabaseClient.createLogger("Test")
 
         override fun createConfig(init: Config.() -> Unit): Config {
             return Config().apply(init)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Rework (closes #1247)

## What is the current behavior?

Loggers are static, which has the upside that they can be called from anywhere, but customization is hard and messy.

## What is the new behavior?

In the `SupabaseClientBuilder`, you specify two things:
- `defaultLogLevel` - Basically the same as before, this is the log level for all loggers, if no other is specified
- `defaultLoggingFactory` - A factory for creating a `SupabaseLoggingProcessor` e.g. the default:
```kotlin
defaultLoggingFactory = { level -> KermitLoggingProcessor(level) }
```

Then a `SupabaseLogger` gets created in the `SupabaseClient` using the two options. This class basically just calls the processor, but has some handy methods on top.

On the plugin side you can still override the log level and processor, if you want for some reason. Each plugin has a `logger` property now.

Todo:
- [ ] Tests
