### PR TITLE
Fix JS test

### DIFF
--- a/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/AuthConfig.kt
+++ b/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/AuthConfig.kt
@@ -11,6 +11,7 @@ import io.github.jan.supabase.auth.user.UserSession
 import io.github.jan.supabase.plugins.CustomSerializationConfig
 import io.github.jan.supabase.plugins.MainConfig
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
@@ -59,6 +60,9 @@ open class AuthConfigDefaults : MainConfig(), AuthDependentPluginConfig, CustomS
      */
     @Deprecated("SupabaseClientBuilder.coroutineDispatcher should be used instead")
     var coroutineDispatcher: CoroutineDispatcher? = null
+
+    @SupabaseInternal
+    var authScope: CoroutineScope? = null
 
     /**
      * The type of login flow to use. Defaults to [FlowType.IMPLICIT]

--- a/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/AuthImpl.kt
+++ b/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/AuthImpl.kt
@@ -106,7 +106,7 @@ internal class AuthImpl(
     private val _events = MutableSharedFlow<AuthEvent>(replay = 1)
     override val events: SharedFlow<AuthEvent> = _events.asSharedFlow()
     @Suppress("DEPRECATION")
-    override val authScope = CoroutineScope((config.coroutineDispatcher ?: supabaseClient.coroutineDispatcher) + SupervisorJob())
+    override val authScope = config.authScope ?: CoroutineScope((config.coroutineDispatcher ?: supabaseClient.coroutineDispatcher) + SupervisorJob())
     override val sessionManager = config.sessionManager ?: createDefaultSessionManager()
     override val codeVerifierCache = config.codeVerifierCache ?: createDefaultCodeVerifierCache()
 

--- a/Auth/src/commonTest/kotlin/AuthTest.kt
+++ b/Auth/src/commonTest/kotlin/AuthTest.kt
@@ -23,6 +23,7 @@ import io.ktor.http.Url
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.buildJsonObject
 import kotlin.test.AfterTest
@@ -57,7 +58,10 @@ class AuthTest {
                 }
             }
         )
-        client.auth.awaitInitialization()
+        launch {
+            client.auth.awaitInitialization()
+        }
+        advanceUntilIdle()
         assertIs<SessionStatus.Authenticated>(client.auth.sessionStatus.value)
     }
 


### PR DESCRIPTION
# Changes

- Adds a new internal-marked config property to `AuthConfig` to provide an auth scope
- This is used in the faulty `testLoadingFromStorage` test