### PR TITLE
Add url options to `download`, `publicUrl`, `createSignedUrl`...

### DIFF
--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/BucketApi.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/BucketApi.kt
@@ -178,37 +178,40 @@ interface BucketApi {
 
     /**
      * Creates a signed url to download without authentication. The url will expire after [expiresIn]
-     * @param path The path to create an url for
+     * @param path The path to create a url for
      * @param expiresIn The duration the url is valid
-     * @param transform The transformation to apply to the image
+     * @param builder Optional modifier to add a [transformation][SignedUrlBuilder.transformation],
+     * [force-download][SignedUrlBuilder.download] or [cacheNonce][BucketUrlBuilder.cacheNonce] to the created url
      * @return The url to download the file
      * @throws RestException or one of its subclasses if receiving an error response
      * @throws HttpRequestTimeoutException if the request timed out
      * @throws HttpRequestException on network related issues
      */
-    suspend fun createSignedUrl(path: String, expiresIn: Duration, transform: ImageTransformation.() -> Unit = {}): String
+    suspend fun createSignedUrl(path: String, expiresIn: Duration, builder: SignedUrlBuilder.() -> Unit = {}): String
 
     /**
      * Creates signed urls for all specified paths. The urls will expire after [expiresIn]
      * @param expiresIn The duration the urls are valid
      * @param paths The paths to create urls for
+     * @param builder Optional modifier to add a [force-download][SignedUrlsBuilder.download] or [cacheNonce][BucketUrlBuilder.cacheNonce] to the created urls
      * @return A list of [SignedUrl]s
      * @throws RestException or one of its subclasses if receiving an error response
      * @throws HttpRequestTimeoutException if the request timed out
      * @throws HttpRequestException on network related issues
      */
-    suspend fun createSignedUrls(expiresIn: Duration, paths: Collection<String>): List<SignedUrl>
+    suspend fun createSignedUrls(expiresIn: Duration, paths: Collection<String>, builder: SignedUrlsBuilder.() -> Unit = {}): List<SignedUrl>
 
     /**
      * Creates signed urls for all specified paths. The urls will expire after [expiresIn]
      * @param expiresIn The duration the urls are valid
      * @param paths The paths to create urls for
+     * @param builder Optional modifier to add a [force-download][SignedUrlsBuilder.download] or [cacheNonce][BucketUrlBuilder.cacheNonce] to the created urls
      * @return A list of [SignedUrl]s
      * @throws RestException or one of its subclasses if receiving an error response
      * @throws HttpRequestTimeoutException if the request timed out
      * @throws HttpRequestException on network related issues
      */
-    suspend fun createSignedUrls(expiresIn: Duration, vararg paths: String) = createSignedUrls(expiresIn, paths.toList())
+    suspend fun createSignedUrls(expiresIn: Duration, vararg paths: String, builder: SignedUrlsBuilder.() -> Unit = {}) = createSignedUrls(expiresIn, paths.toList(), builder)
 
     /**
      * Downloads a file from [bucketId] under [path]
@@ -299,7 +302,7 @@ interface BucketApi {
      * @throws HttpRequestTimeoutException if the request timed out
      * @throws HttpRequestException on network related issues
      */
-    fun publicUrl(path: String): String
+    fun publicUrl(path: String, builder: PublicUrlBuilder.() -> Unit = {}): String
 
     /**
      * Returns the authenticated url of [path]. Requires bearer token authentication using the user's access token
@@ -323,7 +326,10 @@ interface BucketApi {
      * @throws HttpRequestTimeoutException if the request timed out
      * @throws HttpRequestException on network related issues
      */
-    fun publicRenderUrl(path: String, transform: ImageTransformation.() -> Unit = {}): String
+    @Deprecated("Use publicUrl instead", ReplaceWith("publicUrl"))
+    fun publicRenderUrl(path: String, transform: ImageTransformation.() -> Unit = {}): String = publicUrl(path) {
+        transform(transform)
+    }
 
     companion object {
 

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/BucketApiImpl.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/BucketApiImpl.kt
@@ -1,6 +1,7 @@
 package io.github.jan.supabase.storage
 
 import io.github.jan.supabase.auth.api.AuthenticatedSupabaseApi
+import io.github.jan.supabase.buildUrl
 import io.github.jan.supabase.exceptions.RestException
 import io.github.jan.supabase.putJsonObject
 import io.github.jan.supabase.safeBody
@@ -21,6 +22,7 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.Url
 import io.ktor.http.content.OutgoingContent
 import io.ktor.http.defaultForFilePath
+import io.ktor.http.formUrlEncode
 import io.ktor.http.headers
 import io.ktor.utils.io.ByteReadChannel
 import io.ktor.utils.io.ByteWriteChannel
@@ -104,7 +106,7 @@ internal class BucketApiImpl(
         )
 
     override suspend fun delete(paths: Collection<String>) {
-        api.deleteJson("$bucketId", buildJsonObject {
+        api.deleteJson(bucketId, buildJsonObject {
             putJsonArray("prefixes") {
                 paths.forEach(this::add)
             }
@@ -132,32 +134,51 @@ internal class BucketApiImpl(
     override suspend fun createSignedUrl(
         path: String,
         expiresIn: Duration,
-        transform: ImageTransformation.() -> Unit
+        builder: SignedUrlBuilder.() -> Unit
     ): String {
-        val transformation = ImageTransformation().apply(transform)
+        val modifier = SignedUrlBuilder().apply(builder)
+        val transformation = modifier.transformation
         val body = api.postJson("sign/$bucketId/$path", buildJsonObject {
             put("expiresIn", expiresIn.inWholeSeconds)
-            val transform = buildJsonObject {
-                putImageTransformation(transformation)
+            transformation?.let {
+                val transform = buildJsonObject {
+                    putImageTransformation(transformation)
+                }
+                if(transform.isNotEmpty()) {
+                    put("transform", transform)
+                }
             }
-            if(transform.isNotEmpty()) {
-                put("transform", transform)
+        }) {
+            modifier.cacheNonce?.let {
+                url.parameters.append("cacheNonce", it)
             }
-        }).safeBody<JsonObject>()
+            modifier.download?.let {
+                url.parameters.append("download", it.fileName ?: "")
+            }
+        }.safeBody<JsonObject>()
         return storage.resolveUrl(body["signedURL"]?.jsonPrimitive?.content?.substring(1)
             ?: error("Expected signed url in response"))
     }
 
     override suspend fun createSignedUrls(
         expiresIn: Duration,
-        paths: Collection<String>
+        paths: Collection<String>,
+        builder: SignedUrlsBuilder.() -> Unit
     ): List<SignedUrl> {
+        val modifier = SignedUrlsBuilder().apply(builder)
         val body = api.postJson("sign/$bucketId", buildJsonObject {
             putJsonArray("paths") {
                 paths.forEach(this::add)
             }
             put("expiresIn", expiresIn.inWholeSeconds)
-        }).safeBody<List<SignedUrl>>().map {
+        }) {
+            modifier.cacheNonce?.let {
+                url.parameters.append("cacheNonce", it)
+            }
+            modifier.download?.let {
+                url.parameters.append("download", it.fileName ?: "")
+            }
+        }.safeBody<List<SignedUrl>>().map {
             it.copy(signedURL = storage.resolveUrl(it.signedURL.substring(1)))
         }
         return body
@@ -224,13 +245,15 @@ internal class BucketApiImpl(
         public: Boolean,
         options: DownloadOptionBuilder
     ) {
-        val transformation = ImageTransformation().apply(options.transform).queryString()
+        val transformation = ImageTransformation().apply(options.transform).query()
         val url = when (public) {
-            true -> if (transformation.isBlank()) publicUrl(path) else publicRenderUrl(
-                path,
-                options.transform
-            )
-            false -> if (transformation.isBlank()) authenticatedUrl(path) else authenticatedRenderUrl(
+            true -> publicUrl(
+                path
+            ) {
+               if(!transformation.isEmpty()) transform(options.transform)
+               cacheNonce = options.cacheNonce
+            }
+            false -> if (transformation.isEmpty()) authenticatedUrl(path) else authenticatedRenderUrl(
                 path,
                 options.transform
             )
@@ -315,20 +338,23 @@ internal class BucketApiImpl(
     override fun authenticatedUrl(path: String): String =
         storage.resolveUrl("object/authenticated/$bucketId/$path")
 
-    override fun publicUrl(path: String): String =
-        storage.resolveUrl("object/public/$bucketId/$path")
+    override fun publicUrl(path: String, builder: PublicUrlBuilder.() -> Unit): String {
+        val modifier = PublicUrlBuilder().apply(builder)
+        return buildUrl(storage.resolveUrl(
+            if(modifier.transformation != null) "render/image/public/$bucketId/$path" else "object/public/$bucketId/$path"
+        )) {
+            modifier.transformation?.let { parameters.appendAll(it.query()) }
+            modifier.cacheNonce?.let { parameters.append("cacheNonce", it) }
+            modifier.download?.let { parameters.append("download", it.fileName ?: "") }
+        }
+    }
 
     override fun authenticatedRenderUrl(
         path: String,
         transform: ImageTransformation.() -> Unit
     ): String {
-        val transformation = ImageTransformation().apply(transform).queryString()
+        val transformation = ImageTransformation().apply(transform).query().formUrlEncode()
         return storage.resolveUrl("render/image/authenticated/$bucketId/$path${if (transformation.isNotBlank()) "?$transformation" else ""}")
-    }
-
-    override fun publicRenderUrl(path: String, transform: ImageTransformation.() -> Unit): String {
-        val transformation = ImageTransformation().apply(transform).queryString()
-        return storage.resolveUrl("render/image/public/$bucketId/$path${if (transformation.isNotBlank()) "?$transformation" else ""}")
     }
 
 }

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/BucketUrlBuilder.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/BucketUrlBuilder.kt
@@ -12,6 +12,9 @@ interface BucketUrlBuilder {
      */
     var cacheNonce: String?
 
+    /**
+     * Builders where you can apply a force download
+     */
     interface WithForceDownload : BucketUrlBuilder {
 
         @SupabaseInternal
@@ -26,6 +29,9 @@ interface BucketUrlBuilder {
         }
     }
 
+    /**
+     * Builders where you can apply a transformation
+     */
     interface WithTransformation : BucketUrlBuilder {
 
         @SupabaseInternal

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/BucketUrlBuilder.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/BucketUrlBuilder.kt
@@ -1,0 +1,73 @@
+package io.github.jan.supabase.storage
+
+import io.github.jan.supabase.annotations.SupabaseInternal
+
+/**
+ * Interface for bucket file url modifiers
+ */
+interface BucketUrlBuilder {
+
+    /**
+     * Append a cache nonce parameter to the URL to invalidate the cache.
+     */
+    var cacheNonce: String?
+
+    interface WithForceDownload : BucketUrlBuilder {
+
+        @SupabaseInternal
+        var download: ForceDownload?
+
+        /**
+         * Forces a download when opening the created url.
+         * @param fileName Optional file name. Set this parameter as the name of the file if you want to trigger the download with a different filename.
+         */
+        fun forceDownload(fileName: String? = null) {
+            download = ForceDownload(fileName)
+        }
+    }
+
+    interface WithTransformation : BucketUrlBuilder {
+
+        @SupabaseInternal
+        var transformation: ImageTransformation?
+
+        /**
+         * Transforms the image before downloading
+         * @param transform The transformation to apply
+         */
+        fun transform(transform: ImageTransformation.() -> Unit) {
+            this.transformation = ImageTransformation().apply(transform)
+        }
+    }
+}
+
+/**
+ * Builder for [BucketApi.createSignedUrl]
+ */
+class SignedUrlBuilder : BucketUrlBuilder.WithTransformation, BucketUrlBuilder.WithForceDownload {
+    @SupabaseInternal
+    override var transformation: ImageTransformation? = null
+    override var download: ForceDownload? = null
+    override var cacheNonce: String? = null
+}
+
+/**
+ * Builder for [BucketApi.createSignedUrls]
+ */
+class SignedUrlsBuilder : BucketUrlBuilder.WithForceDownload {
+    @SupabaseInternal
+    override var download: ForceDownload? = null
+    override var cacheNonce: String? = null
+}
+
+/**
+ * Builder for [BucketApi.publicUrl]
+ */
+class PublicUrlBuilder: BucketUrlBuilder.WithTransformation, BucketUrlBuilder.WithForceDownload {
+    @SupabaseInternal
+    override var transformation: ImageTransformation? = null
+    override var cacheNonce: String? = null
+
+    @SupabaseInternal
+    override var download: ForceDownload? = null
+}

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/DownloadOptionBuilder.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/DownloadOptionBuilder.kt
@@ -8,7 +8,9 @@ import io.github.jan.supabase.network.HttpRequestOverride
 class DownloadOptionBuilder(
     internal var transform: ImageTransformation.() -> Unit = {},
     internal val httpRequestOverrides: MutableList<HttpRequestOverride> = mutableListOf()
-) {
+): BucketUrlBuilder {
+
+    override var cacheNonce: String? = null
 
     /**
      * Transforms the image before downloading
@@ -25,5 +27,4 @@ class DownloadOptionBuilder(
     fun httpOverride(override: HttpRequestOverride) {
         httpRequestOverrides.add(override)
     }
-
 }

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/ForceDownload.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/ForceDownload.kt
@@ -1,0 +1,7 @@
+package io.github.jan.supabase.storage
+
+/**
+ * Forces a download for a storage url with an optional [fileName]
+ * @param fileName Set this parameter as the name of the file if you want to trigger the download with a different filename.
+ */
+data class ForceDownload(val fileName: String? = null)

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/ImageTransformation.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/ImageTransformation.kt
@@ -1,9 +1,8 @@
 package io.github.jan.supabase.storage
 
 import io.github.jan.supabase.annotations.SupabaseInternal
-import io.github.jan.supabase.storage.ImageTransformation.Resize
+import io.ktor.http.Parameters
 import io.ktor.http.ParametersBuilder
-import io.ktor.http.formUrlEncode
 
 /**
  * Represents a transformation for an image. Used for [Storage] objects
@@ -73,14 +72,14 @@ class ImageTransformation {
         resize = Resize.FILL
     }
 
-    internal fun queryString(): String {
+    internal fun query(): Parameters {
         val builder = ParametersBuilder()
         width?.let { builder.append("width", it.toString()) }
         height?.let { builder.append("height", it.toString()) }
         resize?.let { builder.append("resize", it.name.lowercase()) }
         quality?.let { builder.append("quality", it.toString()) }
         format?.let { builder.append("format", it) }
-        return builder.build().formUrlEncode()
+        return builder.build()
     }
 
     /**

--- a/Storage/src/commonTest/kotlin/BucketApiTest.kt
+++ b/Storage/src/commonTest/kotlin/BucketApiTest.kt
@@ -303,6 +303,8 @@ class BucketApiTest {
                 assertEquals(expectedQuality, transform?.get("quality")?.jsonPrimitive?.int, "Quality should be $expectedQuality")
                 assertEquals(expectedResize.name.lowercase(), transform?.get("resize")?.jsonPrimitive?.content, "Resize should be ${expectedResize.name.lowercase()}")
                 assertEquals(expectedFormat, transform?.get("format")?.jsonPrimitive?.content, "Format should be $expectedFormat")
+                assertEquals("myFile.png", it.url.parameters["download"])
+                assertEquals("1234", it.url.parameters["cacheNonce"])
                 respond(
                     content = """
                     { 
@@ -316,10 +318,14 @@ class BucketApiTest {
                 )
             }
             val url = client.storage[bucketId].createSignedUrl(expectedPath, expectedExpiresIn) {
-                size(expectedWidth, expectedHeight)
-                format = expectedFormat
-                quality = expectedQuality
-                resize = expectedResize
+                transform {
+                    size(expectedWidth, expectedHeight)
+                    format = expectedFormat
+                    quality = expectedQuality
+                    resize = expectedResize
+                }
+                forceDownload("myFile.png")
+                cacheNonce = "1234"
             }
             assertEquals(client.storage.resolveUrl(expectedUrl.substring(1)), url, "URL should be $expectedUrl")
         }
@@ -380,6 +386,8 @@ class BucketApiTest {
                     content["expiresIn"]?.jsonPrimitive?.long?.seconds,
                     "Expires in should be $expectedExpiresIn"
                 )
+                assertEquals("1234", it.url.parameters["cacheNonce"])
+                assertEquals("myFile.png", it.url.parameters["download"])
                 respond(
                     content = """
                     [
@@ -394,7 +402,10 @@ class BucketApiTest {
                     )
                 )
             }
-            val urls = client.storage[bucketId].createSignedUrls(expectedExpiresIn, expectedPaths)
+            val urls = client.storage[bucketId].createSignedUrls(expectedExpiresIn, expectedPaths) {
+                forceDownload("myFile.png")
+                cacheNonce = "1234"
+            }
             assertEquals(expectedUrls.map { client.storage.resolveUrl(it.substring(1)) }, urls.map { it.signedURL }, "URLs should be $expectedUrls")
         }
     }
@@ -603,6 +614,9 @@ class BucketApiTest {
                 assertEquals(expectedQuality.toString(), content["quality"], "Quality should be $expectedQuality")
                 assertEquals(expectedResize.name.lowercase(), content["resize"], "Resize should be ${expectedResize.name.lowercase()}")
                 assertEquals(expectedFormat, content["format"], "Format should be $expectedFormat")
+                if(!authenticated) {
+                    assertEquals("1234", it.url.parameters["cacheNonce"])
+                }
                 respond(expectedData)
             }
             val transform: ImageTransformation.() -> Unit = {
@@ -611,7 +625,11 @@ class BucketApiTest {
                 quality = expectedQuality
                 resize = expectedResize
             }
-            val data = if(authenticated) client.storage[bucketId].downloadAuthenticated(expectedPath) { transform(transform) } else client.storage[bucketId].downloadPublic(expectedPath) { transform(transform) }
+            val data = if(authenticated) {
+                client.storage[bucketId].downloadAuthenticated(expectedPath) { transform(transform) }
+            } else {
+                client.storage[bucketId].downloadPublic(expectedPath) { transform(transform); cacheNonce = "1234" }
+            }
             assertContentEquals(expectedData, data, "Data should be [1, 2, 3]")
         }
     }


### PR DESCRIPTION
closes #1259 

# Changes

This pull request introduces a new, extensible builder-based approach for generating storage URLs, allowing for more flexible URL customization such as cache invalidation and forced downloads. The changes affect both the public API (in `BucketApi`) and its implementation, and add comprehensive test coverage for these new features.
