### PR TITLE
fix(auth): don't emit spurious NotAuthenticated on Android lifecycle onStart

### DIFF
--- a/Auth/src/androidMain/kotlin/io/github/jan/supabase/auth/setupPlatform.kt
+++ b/Auth/src/androidMain/kotlin/io/github/jan/supabase/auth/setupPlatform.kt
@@ -51,15 +51,6 @@ private fun addLifecycleCallbacks(auth: Auth) {
                                 auth.logger.d {
                                     "Session found, auto refresh started"
                                 }
-                                // Do NOT call initDone() here. importSession()
-                                // launched by loadFromStorage() will set the
-                                // status to Authenticated once the (possibly
-                                // async) refresh completes — or to
-                                // NotAuthenticated via clearSession() on a 4xx
-                                // refresh failure. Calling initDone() while the
-                                // refresh job is still in flight emits a spurious
-                                // NotAuthenticated(isSignOut=false) because the
-                                // status is still Initializing at that point.
                             }
                         }
                     }

--- a/Auth/src/androidMain/kotlin/io/github/jan/supabase/auth/setupPlatform.kt
+++ b/Auth/src/androidMain/kotlin/io/github/jan/supabase/auth/setupPlatform.kt
@@ -46,12 +46,21 @@ private fun addLifecycleCallbacks(auth: Auth) {
                                 auth.logger.d {
                                     "No session found, not starting auto refresh"
                                 }
+                                auth.initDone()
                             } else {
                                 auth.logger.d {
                                     "Session found, auto refresh started"
                                 }
+                                // Do NOT call initDone() here. importSession()
+                                // launched by loadFromStorage() will set the
+                                // status to Authenticated once the (possibly
+                                // async) refresh completes — or to
+                                // NotAuthenticated via clearSession() on a 4xx
+                                // refresh failure. Calling initDone() while the
+                                // refresh job is still in flight emits a spurious
+                                // NotAuthenticated(isSignOut=false) because the
+                                // status is still Initializing at that point.
                             }
-                            auth.initDone()
                         }
                     }
                 }


### PR DESCRIPTION
## Summary

Fixes #1266 — on background→foreground with an expired session in storage, the Android lifecycle observer emits a transient `NotAuthenticated(isSignOut=false)` while the async refresh is still in flight. Consumers see a spurious sign-out flash before `Authenticated` arrives.

## Root cause (full analysis in #1266)

`addLifecycleCallbacks.onStart` calls `loadFromStorage()` then `initDone()` in the same coroutine. For an expired session, `loadFromStorage()` queues `recreateSessionJob` in `authScope.launch{}` and **does not join** because `initializing=false`. Control returns to the lifecycle coroutine which immediately calls `initDone()` while `_sessionStatus` is still `Initializing`. `initDone()` then emits `NotAuthenticated(isSignOut=false)` even though a valid session was loaded and a refresh is in progress.

`Auth.init()`'s cold-start path doesn't have this bug because it uses `loadFromStorage(initializing=true)` which joins the refresh job.

## Change

Only call `initDone()` when no session was found. When a session is loaded, `importSession()` sets the terminal status itself — `Authenticated` on refresh success, `NotAuthenticated(isSignOut=true)` via `clearSession()` on 4xx, or `RefreshFailure` on transient errors.

## Test

The existing `PlatformSetupTest` runs with `enableLifecycleCallbacks = false`, so the buggy path isn't exercised. I haven't added a lifecycle-driven test in this PR — happy to add one (Robolectric or similar to drive `ProcessLifecycleOwner`) if you'd prefer that before merging.