### PR TITLE
Implement deferred disconnect after removing last channel 

### DIFF
--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/Realtime.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/Realtime.kt
@@ -19,6 +19,7 @@ import io.ktor.serialization.kotlinx.KotlinxWebsocketSerializationConverter
 import kotlinx.coroutines.flow.StateFlow
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
+import kotlin.time.times
 
 /**
  * Plugin for interacting with the supabase realtime api
@@ -128,20 +129,22 @@ interface Realtime : MainPlugin<Realtime.Config>, CustomSerializationPlugin {
      * @property websocketFactory A custom websocket factory. If this is set, the [websocketConfig] will be ignored
      * @property rejoinDelay The interval between channel rejoin attempts
      * @property maxAttempts The maximum amount of connection attempts before giving up. Defaults to 5
+     * @property disconnectOnEmptyChannelsAfter Delay before disconnecting from the realtime socket after the last channel was removed. If null, it defaults to `2*heartbeatInterval`
      */
-    data class Config(
-        var websocketConfig: WebSockets.Config.() -> Unit = {},
-        var secure: Boolean? = null,
-        var heartbeatInterval: Duration = 15.seconds,
-        var reconnectDelay: Duration = 7.seconds,
-        var rejoinDelay: Duration = 2.seconds,
-        var maxAttempts: Int = 5,
-        var disconnectOnSessionLoss: Boolean = true,
-        var connectOnSubscribe: Boolean = true,
-        @property:SupabaseInternal var websocketFactory: RealtimeWebsocketFactory? = null,
-        var disconnectOnNoSubscriptions: Boolean = true,
-        override var requireValidSession: Boolean = false,
-    ): MainConfig(), CustomSerializationConfig, AuthDependentPluginConfig {
+    class Config: MainConfig(), CustomSerializationConfig, AuthDependentPluginConfig {
+
+        var websocketConfig: WebSockets.Config.() -> Unit = {}
+        var secure: Boolean? = null
+        var heartbeatInterval: Duration = 15.seconds
+        var reconnectDelay: Duration = 7.seconds
+        var rejoinDelay: Duration = 2.seconds
+        var disconnectOnEmptyChannelsAfter: Duration? = null
+        var maxAttempts: Int = 5
+        var disconnectOnSessionLoss: Boolean = true
+        var connectOnSubscribe: Boolean = true
+        @SupabaseInternal var websocketFactory: RealtimeWebsocketFactory? = null
+        var disconnectOnNoSubscriptions: Boolean = true
+        override var requireValidSession: Boolean = false
 
         internal var customAccessTokenProvider = false
 
@@ -154,6 +157,8 @@ interface Realtime : MainPlugin<Realtime.Config>, CustomSerializationPlugin {
                 customAccessTokenProvider = true
             }
         override var serializer: SupabaseSerializer? = null
+
+        internal fun disconnectDelay() = disconnectOnEmptyChannelsAfter ?: (2 * heartbeatInterval)
 
     }
 
@@ -220,13 +225,14 @@ interface Realtime : MainPlugin<Realtime.Config>, CustomSerializationPlugin {
  */
 inline fun Realtime.channel(channelId: String, builder: RealtimeChannelBuilder.() -> Unit = {}): RealtimeChannel = channel(channelId, RealtimeChannelBuilder(RealtimeTopic.withChannelId(channelId)).apply(builder))
 
-/**
- * Supabase Realtime is a way to listen to changes in the PostgreSQL database via websockets
- */
-val SupabaseClient.realtime: Realtime
-    get() = pluginManager.getPlugin(Realtime)
 
 /**
  * Creates a new [RealtimeChannel]
  */
 inline fun SupabaseClient.channel(channelId: String, builder: RealtimeChannelBuilder.() -> Unit = {}): RealtimeChannel = realtime.channel(channelId, builder)
+
+/**
+ * Supabase Realtime is a way to listen to changes in the PostgreSQL database via websockets
+ */
+val SupabaseClient.realtime: Realtime
+    get() = pluginManager.getPlugin(Realtime)

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/Realtime.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/Realtime.kt
@@ -16,6 +16,7 @@ import io.github.jan.supabase.serializer.KotlinXSerializer
 import io.github.jan.supabase.supabaseJson
 import io.ktor.client.plugins.websocket.WebSockets
 import io.ktor.serialization.kotlinx.KotlinxWebsocketSerializationConverter
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.StateFlow
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
@@ -147,6 +148,11 @@ interface Realtime : MainPlugin<Realtime.Config>, CustomSerializationPlugin {
         override var requireValidSession: Boolean = false
 
         internal var customAccessTokenProvider = false
+        internal var coroutineScope: CoroutineScope? = null
+
+        internal val disconnectDelay by lazy {
+            disconnectOnEmptyChannelsAfter ?: (2 * heartbeatInterval)
+        }
 
         /**
          * A custom access token provider. If this is set, the [SupabaseClient] will not be used to resolve the access token.
@@ -157,8 +163,6 @@ interface Realtime : MainPlugin<Realtime.Config>, CustomSerializationPlugin {
                 customAccessTokenProvider = true
             }
         override var serializer: SupabaseSerializer? = null
-
-        internal fun disconnectDelay() = disconnectOnEmptyChannelsAfter ?: (2 * heartbeatInterval)
 
     }
 

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeImpl.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeImpl.kt
@@ -41,6 +41,7 @@ import kotlin.concurrent.atomics.fetchAndIncrement
 import kotlin.concurrent.atomics.incrementAndFetch
 import kotlin.io.encoding.ExperimentalEncodingApi
 import kotlin.time.Clock
+import kotlin.time.Duration
 
 @PublishedApi internal class RealtimeImpl(override val supabaseClient: SupabaseClient, override val config: Realtime.Config) : Realtime {
 
@@ -52,7 +53,7 @@ import kotlin.time.Clock
     override val status: StateFlow<Realtime.Status> = _status.asStateFlow()
     private val _subscriptions = AtomicMutableMap<String, RealtimeChannel>()
     override val subscriptions: Map<String, RealtimeChannel> = _subscriptions
-    private val scope = CoroutineScope(supabaseClient.coroutineDispatcher + SupervisorJob())
+    private val scope = config.coroutineScope ?: CoroutineScope(supabaseClient.coroutineDispatcher + SupervisorJob())
     private val mutex = Mutex()
     private val isReconnecting = AtomicBoolean(false)
     private val _accessToken = AtomicReference<String?>(null)
@@ -245,15 +246,21 @@ import kotlin.time.Clock
     }
 
     private fun schedulePendingDisconnect() {
-        disconnectJob = scope.launch {
-            delay(config.disconnectDelay())
-            logger.d { "Scheduled disconnect fired. Disconnecting from realtime websocket..." }
+        if(config.disconnectDelay != Duration.ZERO) {
+            disconnectJob = scope.launch {
+                delay(config.disconnectDelay)
+                logger.d { "Scheduled disconnect fired. Disconnecting from realtime websocket..." }
+                disconnect()
+            }
+            logger.d { "Scheduling to disconnect from realtime websocket in ${config.disconnectDelay}..." }
+        } else {
+            logger.d { "Disconnecting immediately from realtime websocket as delay set to zero..." }
             disconnect()
         }
-        logger.d { "Scheduling to disconnect from realtime websocket in ${config.disconnectDelay()}..." }
     }
 
     private fun cancelPendingDisconnect() {
+        if(disconnectJob == null) return
         logger.d { "Pending disconnect cancelled - channel activity detected" }
         disconnectJob?.cancel()
         disconnectJob = null

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeImpl.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeImpl.kt
@@ -59,6 +59,7 @@ import kotlin.time.Clock
     val accessToken get() = _accessToken.load()
     private var heartbeatJob: Job? = null
     private var messageJob: Job? = null
+    private var disconnectJob: Job? = null
     internal val ref = AtomicInt(0)
     private val heartbeatRef = AtomicInt(0)
     override val apiVersion: Int
@@ -110,6 +111,7 @@ import kotlin.time.Clock
     }
 
     override fun addChannel(channel: RealtimeChannel) {
+        cancelPendingDisconnect()
         _subscriptions[channel.topic] = channel
     }
 
@@ -184,7 +186,7 @@ import kotlin.time.Clock
         val topic = RealtimeTopic.withChannelId(channelId)
         if(subscriptions.containsKey(topic)) return subscriptions[topic]!!
         val channel = builder.build(this)
-        _subscriptions[topic] = channel
+        addChannel(channel)
         return channel
     }
 
@@ -238,9 +240,23 @@ import kotlin.time.Clock
         }
         _subscriptions.remove(channel.topic)
         if(subscriptions.isEmpty() && config.disconnectOnNoSubscriptions) {
-            logger.d { "No more subscriptions, disconnecting from realtime websocket" }
+            schedulePendingDisconnect()
+        }
+    }
+
+    private fun schedulePendingDisconnect() {
+        disconnectJob = scope.launch {
+            delay(config.disconnectDelay())
+            logger.d { "Scheduled disconnect fired. Disconnecting from realtime websocket..." }
             disconnect()
         }
+        logger.d { "Scheduling to disconnect from realtime websocket in ${config.disconnectDelay()}..." }
+    }
+
+    private fun cancelPendingDisconnect() {
+        logger.d { "Pending disconnect cancelled - channel activity detected" }
+        disconnectJob?.cancel()
+        disconnectJob = null
     }
 
     override suspend fun removeAllChannels() {
@@ -251,7 +267,7 @@ import kotlin.time.Clock
         }
         _subscriptions.clear()
         if(config.disconnectOnNoSubscriptions) {
-            logger.d { "No more subscriptions, disconnecting from realtime websocket" }
+            logger.d { "No more subscriptions, disconnecting from realtime websocket." }
             disconnect()
         }
     }

--- a/Realtime/src/commonTest/kotlin/RealtimeTest.kt
+++ b/Realtime/src/commonTest/kotlin/RealtimeTest.kt
@@ -5,6 +5,7 @@ import io.github.jan.supabase.realtime.RealtimeImpl
 import io.github.jan.supabase.realtime.RealtimeMessage
 import io.github.jan.supabase.realtime.channel
 import io.github.jan.supabase.realtime.realtime
+import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
@@ -12,6 +13,8 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlin.time.Clock
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 
 class RealtimeTest {
 
@@ -32,6 +35,174 @@ class RealtimeTest {
             )
         }
     }
+
+    @Test
+    fun testRealtimeDisconnectDelayZero() {
+        runTest {
+            createTestClient(
+                wsHandler = { _, _ ->
+                    //Does not matter for this test
+                },
+                realtimeConfig = {
+                    disconnectOnEmptyChannelsAfter = Duration.ZERO
+                },
+                supabaseHandler = {
+                    assertEquals(Realtime.Status.DISCONNECTED, it.realtime.status.value)
+                    val channel = it.realtime.channel("test")
+                    it.realtime.connect()
+                    assertEquals(Realtime.Status.CONNECTED, it.realtime.status.value)
+                    it.realtime.removeChannel(channel)
+                    assertEquals(Realtime.Status.DISCONNECTED, it.realtime.status.value)
+                }
+            )
+        }
+    }
+
+    @Test
+    fun testRealtimeDisconnectNonEmpty() {
+        runTest {
+            createTestClient(
+                wsHandler = { _, _ ->
+                    //Does not matter for this test
+                },
+                realtimeConfig = {
+                    disconnectOnEmptyChannelsAfter = Duration.ZERO
+                },
+                supabaseHandler = {
+                    assertEquals(Realtime.Status.DISCONNECTED, it.realtime.status.value)
+                    val channel = it.realtime.channel("test")
+                    val channel2 = it.realtime.channel("test2")
+                    it.realtime.connect()
+                    assertEquals(Realtime.Status.CONNECTED, it.realtime.status.value)
+                    it.realtime.removeChannel(channel)
+                    assertEquals(Realtime.Status.CONNECTED, it.realtime.status.value)
+                }
+            )
+        }
+    }
+
+    @Test
+    fun testRealtimeDisconnectNonZero() {
+        runTest {
+            createTestClient(
+                wsHandler = { _, _ ->
+                    //Does not matter for this test
+                },
+                realtimeConfig = {
+                    coroutineScope = backgroundScope
+                    disconnectOnEmptyChannelsAfter = 15.seconds
+                },
+                supabaseHandler = {
+                    assertEquals(Realtime.Status.DISCONNECTED, it.realtime.status.value)
+                    val channel = it.realtime.channel("test")
+                    it.realtime.connect()
+                    assertEquals(Realtime.Status.CONNECTED, it.realtime.status.value)
+                    it.realtime.removeChannel(channel)
+                    assertEquals(Realtime.Status.CONNECTED, it.realtime.status.value)
+                    advanceTimeBy(10.seconds)
+                    assertEquals(Realtime.Status.CONNECTED, it.realtime.status.value)
+                    advanceTimeBy(6.seconds) // 1 seconds more because its not 100% accurate
+                    assertEquals(Realtime.Status.DISCONNECTED, it.realtime.status.value)
+                }
+            )
+        }
+    }
+
+    @Test
+    fun testRealtimeDisconnectNonZeroNonEmpty() {
+        runTest {
+            createTestClient(
+                wsHandler = { _, _ ->
+                    //Does not matter for this test
+                },
+                realtimeConfig = {
+                    coroutineScope = backgroundScope
+                    disconnectOnEmptyChannelsAfter = 2.seconds
+                },
+                supabaseHandler = {
+                    assertEquals(Realtime.Status.DISCONNECTED, it.realtime.status.value)
+                    val channel = it.realtime.channel("test")
+                    val channel2 = it.realtime.channel("test2")
+                    it.realtime.connect()
+                    assertEquals(Realtime.Status.CONNECTED, it.realtime.status.value)
+                    it.realtime.removeChannel(channel)
+                    assertEquals(Realtime.Status.CONNECTED, it.realtime.status.value)
+                    advanceTimeBy(3.seconds)
+                    assertEquals(Realtime.Status.CONNECTED, it.realtime.status.value)
+                }
+            )
+        }
+    }
+
+    @Test
+    fun testRealtimeDisconnectNonZeroDefault() {
+        runTest {
+            createTestClient(
+                wsHandler = { _, _ ->
+                    //Does not matter for this test
+                },
+                realtimeConfig = {
+                    coroutineScope = backgroundScope
+                    heartbeatInterval = 15.seconds
+                    // heartbeatInterval is 15 seconds so the disconnect delay should be 30s
+                },
+                supabaseHandler = {
+                    assertEquals(30.seconds, it.realtime.config.disconnectDelay)
+                }
+            )
+        }
+    }
+
+    @Test
+    fun testRealtimeDisconnectNonZeroCancel() {
+        runTest {
+            createTestClient(
+                wsHandler = { _, _ ->
+                    //Does not matter for this test
+                },
+                realtimeConfig = {
+                    coroutineScope = backgroundScope
+                    disconnectOnEmptyChannelsAfter = 15.seconds
+                },
+                supabaseHandler = {
+                    assertEquals(Realtime.Status.DISCONNECTED, it.realtime.status.value)
+                    val channel = it.realtime.channel("test")
+                    it.realtime.connect()
+                    assertEquals(Realtime.Status.CONNECTED, it.realtime.status.value)
+                    it.realtime.removeChannel(channel)
+                    assertEquals(Realtime.Status.CONNECTED, it.realtime.status.value)
+                    advanceTimeBy(10.seconds)
+                    assertEquals(Realtime.Status.CONNECTED, it.realtime.status.value)
+                    it.realtime.channel("test2")
+                    advanceTimeBy(6.seconds) // 1 seconds more because its not 100% accurate
+                    assertEquals(Realtime.Status.CONNECTED, it.realtime.status.value)
+                }
+            )
+        }
+    }
+
+    @Test
+    fun testRealtimeDisconnectRemoveAll() {
+        runTest {
+            createTestClient(
+                wsHandler = { _, _ ->
+                    //Does not matter for this test
+                },
+                realtimeConfig = {
+                    disconnectOnEmptyChannelsAfter = 200.seconds
+                },
+                supabaseHandler = {
+                    assertEquals(Realtime.Status.DISCONNECTED, it.realtime.status.value)
+                    val channel = it.realtime.channel("test")
+                    it.realtime.connect()
+                    assertEquals(Realtime.Status.CONNECTED, it.realtime.status.value)
+                    it.realtime.removeAllChannels()
+                    assertEquals(Realtime.Status.DISCONNECTED, it.realtime.status.value)
+                }
+            )
+        }
+    }
+
 
     @Test
     fun testTeardown() {


### PR DESCRIPTION
## What kind of change does this PR introduce?

closes #1257

* Added a new `disconnectOnEmptyChannelsAfter` configuration option to `Realtime.Config`, allowing users to specify a delay before disconnecting after the last channel is removed. If not set, it defaults to `2 * heartbeatInterval`.