### PR TITLE
add intent modifier & add NO_HISTORY flag to custom tab on Android

### DIFF
--- a/Auth/src/androidMain/kotlin/io/github/jan/supabase/auth/Android.kt
+++ b/Auth/src/androidMain/kotlin/io/github/jan/supabase/auth/Android.kt
@@ -18,7 +18,8 @@ internal fun openUrl(uri: Uri, action: ExternalAuthAction) {
         }
         is ExternalAuthAction.CustomTabs -> {
             val intent = CustomTabsIntent.Builder().apply(action.intentBuilder).build()
-            intent.intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
+            intent.intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            intent.intent.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY)
             intent.launchUrl(applicationContext(), uri)
         }
     }

--- a/Auth/src/androidMain/kotlin/io/github/jan/supabase/auth/Android.kt
+++ b/Auth/src/androidMain/kotlin/io/github/jan/supabase/auth/Android.kt
@@ -20,6 +20,7 @@ internal fun openUrl(uri: Uri, action: ExternalAuthAction) {
             val intent = CustomTabsIntent.Builder().apply(action.intentBuilder).build()
             intent.intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
             intent.intent.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY)
+            intent.intent.apply(action.intentModifier)
             intent.launchUrl(applicationContext(), uri)
         }
     }

--- a/Auth/src/androidMain/kotlin/io/github/jan/supabase/auth/AuthConfig.kt
+++ b/Auth/src/androidMain/kotlin/io/github/jan/supabase/auth/AuthConfig.kt
@@ -1,5 +1,6 @@
 package io.github.jan.supabase.auth
 
+import android.content.Intent
 import androidx.browser.customtabs.CustomTabsIntent
 import io.github.jan.supabase.auth.providers.ExternalAuthConfig
 
@@ -31,8 +32,12 @@ sealed interface ExternalAuthAction {
     /**
      * Open the OAuth/SSO flow in a custom tab
      * @property intentBuilder The builder for the custom tabs intent
+     * @property intentModifier Modifier for the created intent
      */
-    data class CustomTabs(val intentBuilder: CustomTabsIntent.Builder.() -> Unit = {}) : ExternalAuthAction
+    data class CustomTabs(
+        val intentModifier: Intent.() -> Unit = {},
+        val intentBuilder: CustomTabsIntent.Builder.() -> Unit = {}
+    ) : ExternalAuthAction
 
     companion object {
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (closes #1277)

## What is the current behavior?

Any custom flags get overridden and the launched activity is kept in the history.

## What is the new behavior?

This is fixed.
- Added modifier for customizing the created intent

