### PR TITLE
Fix chat-demo-mpp example not compiling

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,6 +32,7 @@ kotlinx-browser = "0.5.0"
 immutable-collections = "0.4.0"
 crypto = "0.6.0"
 jwt-kt = "1.2.1"
+supabase-kt-plugins = "3.6.0" # https://github.com/supabase-community/supabase-kt-plugins
 
 [plugins]
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
@@ -118,6 +119,8 @@ filekit-compose = { module = "io.github.vinceglb:filekit-compose", version.ref =
 accompanist-permissions = { module = "com.google.accompanist:accompanist-permissions", version.ref = "accompanist-permissions" }
 coil2-svg = { module = "io.coil-kt:coil-svg", version.ref = "coil2" }
 coil2-compose = { module = "io.coil-kt:coil-compose", version.ref = "coil2" }
+compose-auth = { module = "io.github.jan-tennert.supabase:compose-auth", version.ref = "supabase-kt-plugins" }
+compose-auth-ui = { module = "io.github.jan-tennert.supabase:compose-auth-ui", version.ref = "supabase-kt-plugins" }
 
 [bundles]
 ktor-client = ["ktor-client-core", "ktor-client-content-negotiation", "ktor-json"]

--- a/sample/chat-demo-mpp/common/build.gradle.kts
+++ b/sample/chat-demo-mpp/common/build.gradle.kts
@@ -14,7 +14,6 @@ plugins {
 
 group = "io.github.jan.supabase"
 version = "1.0-SNAPSHOT"
-val pluginVersion = "3.3.0-beta-1"
 
 kotlin {
     @OptIn(ExperimentalKotlinGradlePluginApi::class)
@@ -54,8 +53,8 @@ kotlin {
                 api(compose.material3)
                 api(compose.materialIconsExtended)
                 addModules(SupabaseModule.AUTH, SupabaseModule.POSTGREST, SupabaseModule.REALTIME)
-                api("io.github.jan-tennert.supabase:compose-auth:$pluginVersion")
-                api("io.github.jan-tennert.supabase:compose-auth-ui:$pluginVersion")
+                api(libs.compose.auth)
+                api(libs.compose.auth.ui)
                 api(libs.koin.core)
             }
         }


### PR DESCRIPTION
## What kind of change does this PR introduce?

It fixes the `chat-demo-mpp` example which currently crashes on startup.

## What is the current behavior?

1. Clone supabase-kt
2. Run `./gradlew :sample:chat-demo-mpp:desktop:runDistributable`
3. Observe it crashes on startup with

```
java.lang.NoSuchMethodError: 'io.github.jan.supabase.logging.SupabaseLogger io.github.jan.supabase.SupabaseClient$Companion.createLogger$default(io.github.jan.supabase.SupabaseClient$Companion, java.lang.String, io.github.jan.supabase.logging.LogLevel, int, java.lang.Object)'
        at io.github.jan.supabase.compose.auth.ComposeAuth$Companion.<clinit>(ComposeAuth.kt:77)
        at io.github.jan.supabase.compose.auth.ComposeAuth.<clinit>(ComposeAuth.kt)
        at io.github.jan.supabase.common.di.SupabaseModuleKt.supabaseModule$lambda$0$0(supabaseModule.kt:29)
```

## What is the new behavior?

The example now launches without crashing.

## Additional context

It looks like the examples depended on an earlier version of the Supabase plugins, which are not compatible with the current master. As they are in a separate repo, it isn't possible to use local module dependencies, so I moved their versioning to the Gradle Version Catalog. At least this way, the Dependabot will pick up updates in the future.