### PR TITLE
implement structured X-Client-Info header

### DIFF
--- a/Supabase/src/commonMain/kotlin/io/github/jan/supabase/network/KtorSupabaseHttpClient.kt
+++ b/Supabase/src/commonMain/kotlin/io/github/jan/supabase/network/KtorSupabaseHttpClient.kt
@@ -126,6 +126,7 @@ class KtorSupabaseHttpClient @SupabaseInternal constructor(
                 }
             }
             put("runtime", "kotlin")
+            put("runtime-version", KotlinVersion.CURRENT.toString())
         }
         append("X-Client-Info", "supabase-kt/${BuildConfig.PROJECT_VERSION}" + metadata.toList().joinToString("; ", prefix = "; ") { "${it.first}=${it.second}" })
     }

--- a/Supabase/src/commonMain/kotlin/io/github/jan/supabase/network/KtorSupabaseHttpClient.kt
+++ b/Supabase/src/commonMain/kotlin/io/github/jan/supabase/network/KtorSupabaseHttpClient.kt
@@ -127,7 +127,7 @@ class KtorSupabaseHttpClient @SupabaseInternal constructor(
             }
             put("runtime", "kotlin")
         }
-        append("X-Client-Info", "supabase-kt/${BuildConfig.PROJECT_VERSION}" + metadata.toList().joinToString("; "))
+        append("X-Client-Info", "supabase-kt/${BuildConfig.PROJECT_VERSION}" + metadata.toList().joinToString("; ", prefix = "; ") { "${it.first}=${it.second}" })
     }
 
     private fun HttpClientConfig<*>.applyDefaultConfiguration(modifiers: List<HttpClientConfig<*>.() -> Unit>) {

--- a/Supabase/src/commonMain/kotlin/io/github/jan/supabase/network/KtorSupabaseHttpClient.kt
+++ b/Supabase/src/commonMain/kotlin/io/github/jan/supabase/network/KtorSupabaseHttpClient.kt
@@ -118,14 +118,16 @@ class KtorSupabaseHttpClient @SupabaseInternal constructor(
         if(supabaseKey.isNotBlank()) {
             append("apikey", supabaseKey)
         }
-        append("X-Client-Info", "supabase-kt/${BuildConfig.PROJECT_VERSION}")
-        osInformation?.let {
-            append("X-Supabase-Client-Platform", it.name)
-
-            it.version?.let { version ->
-                append("X-Supabase-Client-Platform-Version", version)
+        val metadata = buildMap {
+            osInformation?.let { os ->
+                put("platform", os.name)
+                os.version?.let { version ->
+                    put("platform-version", version)
+                }
             }
+            put("runtime", "kotlin")
         }
+        append("X-Client-Info", "supabase-kt/${BuildConfig.PROJECT_VERSION}" + metadata.toList().joinToString("; "))
     }
 
     private fun HttpClientConfig<*>.applyDefaultConfiguration(modifiers: List<HttpClientConfig<*>.() -> Unit>) {

--- a/test-common/src/commonTest/kotlin/SupabaseClientTest.kt
+++ b/test-common/src/commonTest/kotlin/SupabaseClientTest.kt
@@ -23,33 +23,9 @@ class SupabaseClientTest {
                 supabaseKey = "somekey",
                 requestHandler = {
                     assertEquals(
-                        "supabase-kt/${BuildConfig.PROJECT_VERSION}",
+                        "supabase-kt/${BuildConfig.PROJECT_VERSION}; platform=TestOS; platform-version=1.0.0; runtime=kotlin",
                         it.headers["X-Client-Info"],
                         "X-Client-Info header should be set to 'supabase-kt/${BuildConfig.PROJECT_VERSION}'"
-                    )
-                    respond("")
-                },
-                clientHandler = { it.httpClient.get("") }
-            )
-        }
-    }
-
-    @Test
-    fun testOSVersionHeader() {
-        runTest {
-            withMockedSupabaseClient(
-                supabaseUrl = "https://example.supabase.co",
-                supabaseKey = "somekey",
-                requestHandler = {
-                    assertEquals(
-                        "TestOS",
-                        it.headers["X-Supabase-Client-Platform"],
-                        "X-Supabase-Client-Platform header should be set to 'TestOS'"
-                    )
-                    assertEquals(
-                        "1.0.0",
-                        it.headers["X-Supabase-Client-Platform-Version"],
-                        "X-Supabase-Client-Platform-Version header should be set to '1.0.0'"
                     )
                     respond("")
                 },

--- a/test-common/src/commonTest/kotlin/SupabaseClientTest.kt
+++ b/test-common/src/commonTest/kotlin/SupabaseClientTest.kt
@@ -23,7 +23,7 @@ class SupabaseClientTest {
                 supabaseKey = "somekey",
                 requestHandler = {
                     assertEquals(
-                        "supabase-kt/${BuildConfig.PROJECT_VERSION}; platform=TestOS; platform-version=1.0.0; runtime=kotlin",
+                        "supabase-kt/${BuildConfig.PROJECT_VERSION}; platform=TestOS; platform-version=1.0.0; runtime=kotlin; runtime-version=${KotlinVersion.CURRENT}",
                         it.headers["X-Client-Info"],
                         "X-Client-Info header should be set to 'supabase-kt/${BuildConfig.PROJECT_VERSION}'"
                     )

--- a/test-common/src/commonTest/kotlin/SupabaseClientTest.kt
+++ b/test-common/src/commonTest/kotlin/SupabaseClientTest.kt
@@ -24,8 +24,7 @@ class SupabaseClientTest {
                 requestHandler = {
                     assertEquals(
                         "supabase-kt/${BuildConfig.PROJECT_VERSION}; platform=TestOS; platform-version=1.0.0; runtime=kotlin; runtime-version=${KotlinVersion.CURRENT}",
-                        it.headers["X-Client-Info"],
-                        "X-Client-Info header should be set to 'supabase-kt/${BuildConfig.PROJECT_VERSION}'"
+                        it.headers["X-Client-Info"]
                     )
                     respond("")
                 },


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature (closes #1297)

## What is the current behavior?

Old header structure

## What is the new behavior?

New header structure as described in #1297 

## Additional context

`framework`, `framework-version` is not detectable.
