### PR TITLE
fix: use `loadSessionOrNull()` for `loadFromStorage()`

### DIFF
--- a/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/AuthImpl.kt
+++ b/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/AuthImpl.kt
@@ -682,7 +682,7 @@ internal class AuthImpl(
     override suspend fun loadFromStorage(autoRefresh: Boolean): Boolean = loadFromStorage(autoRefresh, false)
 
     suspend fun loadFromStorage(autoRefresh: Boolean = config.alwaysAutoRefresh, initializing: Boolean): Boolean {
-        val session = try { sessionManager.loadSession() } catch (e: Exception) {
+        val session = try { sessionManager.loadSessionOrNull() } catch (e: Exception) {
             currentCoroutineContext().ensureActive()
             logger.e(e) { "Failed to load session" }
             null

--- a/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/SessionManager.kt
+++ b/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/SessionManager.kt
@@ -21,11 +21,7 @@ interface SessionManager {
     /**
      * Loads the saved session from storage.
      */
-    suspend fun loadSessionOrNull(): UserSession? = try {
-        loadSession()
-    } catch(e: Exception) {
-        null
-    }
+    suspend fun loadSessionOrNull(): UserSession?
 
     /**
      * Deletes the saved session from storage.
@@ -46,11 +42,15 @@ class MemorySessionManager(session: UserSession? = null): SessionManager {
     }
 
     override suspend fun loadSession(): UserSession {
-        return session.load() ?: error("No session stored")
+        return loadSessionOrNull() ?: error("No session stored")
     }
 
     override suspend fun deleteSession() {
         session.store(null)
+    }
+
+    override suspend fun loadSessionOrNull(): UserSession? {
+        return session.load()
     }
 
 }

--- a/Auth/src/settingsMain/kotlin/io/github/jan/supabase/auth/SettingsSessionManager.kt
+++ b/Auth/src/settingsMain/kotlin/io/github/jan/supabase/auth/SettingsSessionManager.kt
@@ -52,6 +52,11 @@ class SettingsSessionManager(
         return json.decodeFromString(session)
     }
 
+    override suspend fun loadSessionOrNull(): UserSession? {
+        val session = suspendSettings.getStringOrNull(key) ?: return null
+        return json.decodeFromString(session)
+    }
+
     override suspend fun deleteSession() {
         suspendSettings.remove(key)
     }


### PR DESCRIPTION
## What kind of change does this PR introduce?

closes #1318, #1314

## What is the current behavior?

`loadFromStorage()` uses `loadSession()` and treats the exception thrown when no session is found as a critical exception

## What is the new behavior?

The method now correctly uses the nullable method

## Additional context

Add any other context or screenshots.
