### PR TITLE
fix(realtime): log transient websocket reconnects at WARN instead of ERROR

### DIFF
--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeImpl.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeImpl.kt
@@ -100,7 +100,7 @@ import kotlin.time.Duration
             }
         } catch(e: Exception) {
             currentCoroutineContext().ensureActive()
-            logger.e(e) { """
+            logger.w(e) { """
                 Error while trying to connect to realtime websocket. Trying again in ${config.reconnectDelay}
                 URL: $websocketUrl
                 """.trimIndent() }
@@ -153,7 +153,7 @@ import kotlin.time.Duration
                 }
             } catch(e: Exception) {
                 currentCoroutineContext().ensureActive()
-                logger.e(e) { "Error while listening for messages. Trying again in ${config.reconnectDelay}" }
+                logger.w(e) { "Error while listening for messages. Trying again in ${config.reconnectDelay}" }
                 reconnect()
             }
         }
@@ -226,7 +226,7 @@ import kotlin.time.Duration
         if (heartbeatRef.load() != 0) {
             heartbeatRef.store(0)
             ref.store(0)
-            logger.e { "Heartbeat timeout. Trying to reconnect in ${config.reconnectDelay}" }
+            logger.w { "Heartbeat timeout. Trying to reconnect in ${config.reconnectDelay}" }
             reconnect()
             return
         }
@@ -326,7 +326,7 @@ import kotlin.time.Duration
             ws?.send(message)
         } catch(e: Exception) {
             currentCoroutineContext().ensureActive()
-            logger.e(e) { "Error while sending message $message. Reconnecting in ${config.reconnectDelay}" }
+            logger.w(e) { "Error while sending message $message. Reconnecting in ${config.reconnectDelay}" }
             reconnect()
         }
     }


### PR DESCRIPTION
Closes #1328.

### Problem

`RealtimeImpl` logs expected, automatically-recovered websocket drops at **ERROR** before calling `reconnect()`. On mobile these are routine (idle NAT/proxy timeouts, Wi-Fi <-> cellular switches, app backgrounding), so logs and crash reporters fill up with stack traces (`SocketException: Connection reset`, etc.) for events the SDK heals on its own. Because they are at ERROR, the only way to silence them is muting the entire realtime logger (`logLevel = LogLevel.NONE`), which also hides genuinely actionable errors.

### Change

Downgrade the four transient "trying again / reconnecting" logs from `logger.e` to `logger.w`, all of which are immediately followed by `reconnect()`:

- `connect()` failure
- `listenForMessages()`
- `sendHeartbeat()` (heartbeat timeout)
- `send()`

`ERROR` is kept for terminal/actionable failures (e.g. *"Failed to rejoin channel ... Giving up"* in `RErrorEvent`). No public API change. `:Realtime:compileKotlinJvm` passes.

### Notes

While investigating I noticed the `Config.maxAttempts` KDoc says *"The maximum amount of connection attempts before giving up"*, but it actually governs **channel rejoin** attempts (`RErrorEvent`), not websocket connection attempts — the socket reconnect loop retries indefinitely by design. Happy to clarify that doc in a separate PR if useful.