### PR TITLE
docs(realtime): clarify that maxAttempts governs channel rejoin attempts

### DIFF
--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/Realtime.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/Realtime.kt
@@ -129,7 +129,7 @@ interface Realtime : MainPlugin<Realtime.Config>, CustomSerializationPlugin {
      * @property serializer A serializer used for serializing/deserializing objects e.g. in [PresenceAction.decodeJoinsAs] or [RealtimeChannel.broadcast]. Defaults to [KotlinXSerializer]
      * @property websocketFactory A custom websocket factory. If this is set, the [websocketConfig] will be ignored
      * @property rejoinDelay The interval between channel rejoin attempts
-     * @property maxAttempts The maximum amount of connection attempts before giving up. Defaults to 5
+     * @property maxAttempts The maximum number of times a channel will try to rejoin after an error before giving up. Defaults to 5
      * @property disconnectOnEmptyChannelsAfter Delay before disconnecting from the realtime socket after the last channel was removed. If null, it defaults to `2*heartbeatInterval`
      */
     @Suppress("MagicNumber")


### PR DESCRIPTION
Closes #1330.

### Problem

`Realtime.Config.maxAttempts` is documented as *"The maximum amount of connection attempts before giving up"*, which implies a websocket connection-attempt limit. In reality it is only read in `RErrorEvent`, where it bounds **channel rejoin** attempts after a channel error; the websocket reconnect loop (`RealtimeImpl.connect(reconnect = true)`) does not consult it and retries indefinitely.

### Change

Doc-only: reword the `@property maxAttempts` KDoc to describe the actual behavior (it is the channel-rejoin counterpart to `rejoinDelay`). No code or API change.