### PR TITLE
fix(integration-test): grant table privileges on test_items to PostgREST roles

### DIFF
--- a/integration-test/supabase/migrations/20260319000000_create_test_tables.sql
+++ b/integration-test/supabase/migrations/20260319000000_create_test_tables.sql
@@ -7,6 +7,13 @@ CREATE TABLE IF NOT EXISTS public.test_items (
     user_id UUID REFERENCES auth.users(id)
 );
 
+-- Grant table privileges to the PostgREST roles. Row access is still
+-- restricted by the RLS policies below; without these grants every request
+-- fails with "permission denied for table test_items" (SQLSTATE 42501).
+GRANT SELECT ON public.test_items TO anon;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.test_items TO authenticated;
+GRANT ALL ON public.test_items TO service_role;
+
 ALTER TABLE public.test_items ENABLE ROW LEVEL SECURITY;
 
 -- Authenticated users can CRUD their own rows


### PR DESCRIPTION
## Summary

Fixes #1332.

The **Integration Tests** workflow has been failing on `master` (and therefore on every PR) since ~2026-06-14: all 6 `PostgrestIntegrationTest` cases fail with `PostgrestRestException`. It was green until 2026-06-03.

## Root cause

The actual PostgREST response is:

```
{"code":"42501","details":null,"hint":null,"message":"permission denied for table test_items"}
HTTP 403
```

`42501` is PostgreSQL `insufficient_privilege`. The `test_items` table is created by `integration-test/supabase/migrations/20260319000000_create_test_tables.sql`, but the migration only adds **RLS policies** — it never `GRANT`s table privileges to the PostgREST roles (`anon`, `authenticated`, `service_role`).

The local Supabase stack used to provide these grants automatically via default privileges, but the workflow pins the CLI to `version: latest`, and a recent CLI/image change stopped doing so — hence the green→red transition with no code change. The failure reproduces even with the **service-role** key (which bypasses RLS but still needs the table grant), confirming it's a missing GRANT and not an RLS or schema-cache issue.

## Fix

Add explicit grants in the migration. Row-level access is still governed by the existing RLS policies:

```sql
GRANT SELECT ON public.test_items TO anon;
GRANT SELECT, INSERT, UPDATE, DELETE ON public.test_items TO authenticated;
GRANT ALL ON public.test_items TO service_role;
```

## Verification

Reproduced and validated end-to-end on GitHub Actions (in my fork, against the real `supabase start` stack):

- **Before** the grant: `GET /rest/v1/test_items` → `403 {"code":"42501","message":"permission denied for table test_items"}`.
- **After** the grant: same request → `200 []`, and the full `:integration-test:test` suite passes (`BUILD SUCCESSFUL`).

A schema-cache reload (`NOTIFY pgrst, 'reload schema'`) was ruled out — it had no effect; only the grants fixed it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)