### PR TITLE
Add PKCE support for resend

### DIFF
--- a/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/AuthImpl.kt
+++ b/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/AuthImpl.kt
@@ -310,7 +310,9 @@ internal class AuthImpl(
     private suspend fun resend(type: String,  redirectUrl: String? = null, body: JsonObjectBuilder.() -> Unit) {
         userApi.postJson("resend", buildJsonObject {
             put("type", type)
-            putJsonObject(buildJsonObject(body))
+            val innerBody = buildJsonObject(body)
+            putJsonObject(innerBody)
+            if(config.flowType == FlowType.PKCE && !innerBody.containsKey("phone")) preparePKCEIfEnabled()?.let(::putCodeChallenge)
         }) {
             redirectUrl?.let { url.parameters["redirect_to"] = it }
         }

--- a/Auth/src/commonTest/kotlin/AuthApiTest.kt
+++ b/Auth/src/commonTest/kotlin/AuthApiTest.kt
@@ -611,13 +611,15 @@ class AuthRequestTest {
     }
 
     @Test
-    fun testResendEmail() {
+    fun testResendEmailPKCE() {
         runTest {
             val expectedEmail = "example@email.com"
             val expectedType = OtpType.Email.SIGNUP
             val expectedCaptchaToken = "captchaToken"
             val expectedUrl = "https://example.com"
-            client = createMockedSupabaseClient(configuration = configuration) {
+            client = createMockedSupabaseClient(configuration = {
+                configuration()
+            }) {
                 assertMethodIs(HttpMethod.Post, it.method)
                 assertPathIs("/resend", it.url.pathAfterVersion())
                 val params = it.url.parameters
@@ -628,6 +630,8 @@ class AuthRequestTest {
                 assertEquals(expectedCaptchaToken, metaSecurity["captcha_token"]?.jsonPrimitive?.content)
                 assertEquals(expectedEmail, body["email"]?.jsonPrimitive?.content)
                 assertEquals(expectedType.name.lowercase(), body["type"]?.jsonPrimitive?.content)
+                assertNotNull(body["code_challenge"])
+                assertNotNull(body["code_challenge_method"])
                 respondJson(
                     sampleUserObject(email = expectedEmail)
                 )
@@ -650,6 +654,7 @@ class AuthRequestTest {
                 assertEquals(expectedCaptchaToken, metaSecurity["captcha_token"]?.jsonPrimitive?.content)
                 assertEquals(expectedPhone, body["phone"]?.jsonPrimitive?.content)
                 assertEquals(expectedType.name.lowercase(), body["type"]?.jsonPrimitive?.content)
+                assertNull(body["code_challenge"])
                 respondJson(
                     sampleUserObject(email = expectedPhone)
                 )


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature (closes #1307)

## What is the current behavior?

No PKCE support for `resend()`

## What is the new behavior?

PKCE support for `resend()` (the email variant) and adjusted tests
