### PR TITLE
feat(auth): add resetStatusOnBackground config to keep session status on background

### DIFF
--- a/Auth/src/androidMain/kotlin/io/github/jan/supabase/auth/setupPlatform.kt
+++ b/Auth/src/androidMain/kotlin/io/github/jan/supabase/auth/setupPlatform.kt
@@ -6,7 +6,6 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
 import androidx.startup.Initializer
 import io.github.jan.supabase.annotations.SupabaseInternal
-import io.github.jan.supabase.auth.status.SessionStatus
 import io.github.jan.supabase.logging.d
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -60,7 +59,7 @@ private fun addLifecycleCallbacks(auth: Auth) {
                         auth.logger.d { "Cancelling auto refresh because app is switching to the background" }
                         scope.launch {
                             auth.stopAutoRefreshForCurrentSession()
-                            auth.setSessionStatus(SessionStatus.Initializing)
+                            auth.resetSessionStatusForBackground()
                         }
                     }
                 }

--- a/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/AuthConfig.kt
+++ b/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/AuthConfig.kt
@@ -7,6 +7,7 @@ import io.github.jan.supabase.annotations.SupabaseExperimental
 import io.github.jan.supabase.annotations.SupabaseInternal
 import io.github.jan.supabase.auth.jwt.JwkCache
 import io.github.jan.supabase.auth.jwt.SharedJwkCache
+import io.github.jan.supabase.auth.status.SessionStatus
 import io.github.jan.supabase.auth.user.UserSession
 import io.github.jan.supabase.plugins.CustomSerializationConfig
 import io.github.jan.supabase.plugins.MainConfig
@@ -105,6 +106,19 @@ open class AuthConfigDefaults : MainConfig(), AuthDependentPluginConfig, CustomS
      * Currently only supported on Android.
      */
     var enableLifecycleCallbacks: Boolean = true
+
+    /**
+     * Whether to reset [Auth.sessionStatus] to [SessionStatus.Initializing] when the app moves to
+     * the background.
+     *
+     * When `true` (default), the status is reset on background and re-established on resume, which
+     * means consumers observe a transient [SessionStatus.Initializing] after every resume. When
+     * `false`, the last known status (e.g. [SessionStatus.Authenticated]) is kept while auto-refresh
+     * is paused, avoiding that transient state.
+     *
+     * Only has an effect when [enableLifecycleCallbacks] is `true`. Currently only supported on Android.
+     */
+    var resetStatusOnBackground: Boolean = true
 
     /**
      * The URL launcher used to open OAuth links in the system browser.

--- a/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/Utils.kt
+++ b/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/Utils.kt
@@ -23,6 +23,12 @@ internal fun Auth.initDone() {
     }
 }
 
+internal fun Auth.resetSessionStatusForBackground() {
+    if(config.resetStatusOnBackground) {
+        setSessionStatus(SessionStatus.Initializing)
+    }
+}
+
 internal suspend fun Auth.tryToGetUser(accessToken: String) = try {
     retrieveUser(accessToken)
 } catch (e: Exception) {

--- a/Auth/src/commonTest/kotlin/AuthTest.kt
+++ b/Auth/src/commonTest/kotlin/AuthTest.kt
@@ -7,6 +7,7 @@ import io.github.jan.supabase.auth.auth
 import io.github.jan.supabase.auth.event.AuthEvent
 import io.github.jan.supabase.auth.minimalConfig
 import io.github.jan.supabase.auth.providers.Github
+import io.github.jan.supabase.auth.resetSessionStatusForBackground
 import io.github.jan.supabase.auth.status.RefreshFailureCause
 import io.github.jan.supabase.auth.status.SessionSource
 import io.github.jan.supabase.auth.status.SessionStatus
@@ -102,6 +103,35 @@ class AuthTest {
             assertIs<SessionStatus.Authenticated>(client.auth.sessionStatus.value)
             assertEquals(session, sessionManager.loadSessionOrNull())
         }
+    }
+
+    @Test
+    fun testBackgroundKeepsAuthenticatedStatusWhenResetDisabled() = runTest {
+        client = createMockedSupabaseClient(configuration = {
+            install(Auth) {
+                minimalConfig()
+                resetStatusOnBackground = false
+            }
+        })
+        client.auth.awaitInitialization()
+        client.auth.importSession(userSession())
+        assertIs<SessionStatus.Authenticated>(client.auth.sessionStatus.value)
+        client.auth.resetSessionStatusForBackground()
+        assertIs<SessionStatus.Authenticated>(client.auth.sessionStatus.value)
+    }
+
+    @Test
+    fun testBackgroundResetsStatusToInitializingByDefault() = runTest {
+        client = createMockedSupabaseClient(configuration = {
+            install(Auth) {
+                minimalConfig()
+            }
+        })
+        client.auth.awaitInitialization()
+        client.auth.importSession(userSession())
+        assertIs<SessionStatus.Authenticated>(client.auth.sessionStatus.value)
+        client.auth.resetSessionStatusForBackground()
+        assertIs<SessionStatus.Initializing>(client.auth.sessionStatus.value)
     }
 
     @Test


### PR DESCRIPTION
Closes #1338

## Problem

On Android, the lifecycle observer resets `Auth.sessionStatus` to `SessionStatus.Initializing` when the app moves to the background (`onStop` in `Auth/src/androidMain/.../setupPlatform.kt`), before it settles back to `Authenticated` on resume. Any consumer that renders UI from `sessionStatus` therefore observes a transient `Initializing` after **every** resume, which causes flicker — e.g. an authenticated user briefly appears as "loading"/"signed out".

This is Android-only: `appleMain` / `jvmMain` / `webMain` / `linuxMain` / `mingwMain` `setupPlatform()` just call `initDone()` and never reset to `Initializing` on background, so the status stays `Authenticated` across background/resume on those targets. The only existing opt-out, `enableLifecycleCallbacks = false`, is too coarse — it also disables pausing auto-refresh on background and reloading/refreshing the session on foreground.

## Change

Add an opt-out config flag (additive, default = current behavior, no breaking change):

```kotlin
install(Auth) {
    resetStatusOnBackground = false
}
```

- `true` (default): unchanged — status is reset to `Initializing` on background.
- `false`: the last resolved status (e.g. `Authenticated`) is kept while auto-refresh is still paused on background; `loadFromStorage()` / refresh on resume continue to work exactly as before.

The `onStop` reset is now routed through an internal `Auth.resetSessionStatusForBackground()` helper (in `Utils.kt`, next to `initDone()`), so the behavior is unit-testable without driving `ProcessLifecycleOwner`.

## Tests

Added two tests in `AuthTest`:
- default keeps current behavior (background → `Initializing`);
- with `resetStatusOnBackground = false`, the status stays `Authenticated` after backgrounding.

## Notes

- Only affects Android, and only when `enableLifecycleCallbacks = true`.
- I didn't touch `CHANGELOG.md` since there's no unreleased section — happy to add an entry wherever you prefer.
- Alternative discussed in #1338: simply not resetting to `Initializing` on background (making Android consistent with the other targets). I went with an opt-out flag to avoid any behavior change by default, but happy to switch approaches if you'd rather.
