### PR TITLE
add `custom_claims_allowlist` to custom providers admin api

### DIFF
--- a/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/admin/custom/provider/CustomOAuthProvider.kt
+++ b/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/admin/custom/provider/CustomOAuthProvider.kt
@@ -28,6 +28,11 @@ import kotlin.time.Instant
  * @param discoveryDocument OIDC discovery document (OIDC providers only)
  * @param createdAt Timestamp when the provider was created
  * @param updatedAt Timestamp when the provider was last updated
+ * @param customClaimsAllowlist Allowlist of raw identity provider claim keys to copy verbatim into the
+ *    user's `custom_claims` field (within `identity_data` and
+ *    `raw_user_meta_data`), e.g. `["groups", "org_id", "mail"]`. This is an
+ *    opt-in allowlist that defaults to empty (no claims captured) and operates
+ *    independently from `attribute_mapping`.
  */
 @Serializable
 data class CustomOAuthProvider(
@@ -40,6 +45,8 @@ data class CustomOAuthProvider(
     val clientId: String,
     @SerialName("acceptable_client_ids")
     val acceptableClientIds: List<String>? = null,
+    @SerialName("custom_claims_allowlist")
+    val customClaimsAllowlist: List<String>? = null,
     val scopes: List<String>? = null,
     @SerialName("pkce_enabled")
     val pkceEnabled: Boolean? = null,

--- a/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/admin/custom/provider/CustomProviderBuilder.kt
+++ b/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/admin/custom/provider/CustomProviderBuilder.kt
@@ -45,6 +45,16 @@ class CustomProviderBuilder {
     var acceptableClientIds: List<String>? = null
 
     /**
+     * Allowlist of raw identity provider claim keys to copy verbatim into the
+     * user's `custom_claims` field (within `identity_data` and
+     * `raw_user_meta_data`), e.g. `["groups", "org_id", "mail"]`. This is an
+     * opt-in allowlist that defaults to empty (no claims captured) and operates
+     * independently from `attribute_mapping`.
+     */
+    @SerialName("custom_claims_allowlist")
+    var customClaimsAllowlist: List<String>? = null
+
+    /**
      * OAuth scopes requested during authorization
      */
     var scopes: List<String>? = null

--- a/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/admin/custom/provider/CustomProviderUpdateBuilder.kt
+++ b/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/admin/custom/provider/CustomProviderUpdateBuilder.kt
@@ -24,6 +24,11 @@ import kotlinx.serialization.json.JsonObject
  * @param tokenUrl OAuth2 token URL
  * @param userinfoUrl OAuth2 userinfo URL
  * @param jwksUri JWKS URI for token verification
+ * @param customClaimsAllowlist Allowlist of raw identity provider claim keys to copy verbatim into the
+ *    user's `custom_claims` field (within `identity_data` and
+ *    `raw_user_meta_data`), e.g. `["groups", "org_id", "mail"]`. This is an
+ *    opt-in allowlist that defaults to empty (no claims captured) and operates
+ *    independently from `attribute_mapping`.
  */
 @Serializable
 data class CustomProviderUpdateBuilder(
@@ -56,5 +61,7 @@ data class CustomProviderUpdateBuilder(
     @SerialName("userinfo_url")
     var userinfoUrl: String? = null,
     @SerialName("jwks_uri")
-    var jwksUri: String? = null
+    var jwksUri: String? = null,
+    @SerialName("custom_claims_allowlist")
+    val customClaimsAllowlist: List<String>? = null
 )


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature (closes #1344)

## What is the new behavior?

* Added a new `customClaimsAllowlist` property (with serialization as `custom_claims_allowlist`) to the `CustomOAuthProvider` and `CustomProviderUpdateBuilder` data classes, allowing an explicit list of claim keys to be included in user metadata. 
