### PR TITLE
fix(auth): return refreshed token from resolveAccessToken + tolerate non-object error bodies

### DIFF
--- a/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/AccessToken.kt
+++ b/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/AccessToken.kt
@@ -15,7 +15,7 @@ import kotlin.time.Clock
  * Returns the access token used for requests. The token is resolved in the following order:
  * 1. [jwtToken] if not null
  * 2. [SupabaseClient.accessToken] if not null
- * 3. [Auth.currentAccessTokenOrNull] if the Auth plugin is installed. This method also checks if the token expired and tries to force-refresh it.
+ * 3. [Auth.currentAccessTokenOrNull] if the Auth plugin is installed. This method also checks if the token expired, tries to force-refresh it and returns the refreshed token.
  * 4. [SupabaseClient.supabaseKey] if [keyAsFallback] is true
  */
 @SupabaseInternal
@@ -24,8 +24,12 @@ suspend fun SupabaseClient.resolveAccessToken(
     keyAsFallback: Boolean = true
 ): String? {
     val key = if(keyAsFallback) supabaseKey else null
+    val auth = pluginManager.getPluginOrNull(Auth)
     return jwtToken ?: accessToken?.invoke()
-    ?: pluginManager.getPluginOrNull(Auth)?.currentAccessTokenOrNull()?.also { checkAccessToken(it) } ?: key
+    ?: auth?.currentAccessTokenOrNull()?.let { token ->
+        checkAccessToken(token)
+        auth.currentAccessTokenOrNull()
+    } ?: key
 }
 
 /**

--- a/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/GoTrueErrorResponse.kt
+++ b/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/GoTrueErrorResponse.kt
@@ -8,8 +8,8 @@ import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.decodeFromJsonElement
-import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 
 @Serializable(with = GoTrueErrorResponse.Companion::class)
@@ -33,10 +33,11 @@ internal data class GoTrueErrorResponse(
         override fun deserialize(decoder: Decoder): GoTrueErrorResponse {
             decoder as JsonDecoder
             val json = decoder.decodeJsonElement()
-            val error = json.jsonObject["error_code"]?.jsonPrimitive?.content
-            val description = json.jsonObject["error_description"]?.jsonPrimitive?.content ?: json.jsonObject["msg"]?.jsonPrimitive?.content ?: json.jsonObject["message"]?.jsonPrimitive?.content ?: json.toString()
-            val weakPassword = if(json.jsonObject.containsKey("weak_password")) {
-                Json.decodeFromJsonElement<WeakPassword>(json.jsonObject["weak_password"]!!)
+            val jsonObject = json as? JsonObject ?: return GoTrueErrorResponse(null, json.toString())
+            val error = jsonObject["error_code"]?.jsonPrimitive?.content
+            val description = jsonObject["error_description"]?.jsonPrimitive?.content ?: jsonObject["msg"]?.jsonPrimitive?.content ?: jsonObject["message"]?.jsonPrimitive?.content ?: json.toString()
+            val weakPassword = if(jsonObject.containsKey("weak_password")) {
+                Json.decodeFromJsonElement<WeakPassword>(jsonObject["weak_password"]!!)
             } else null
             return GoTrueErrorResponse(error, description, weakPassword)
         }

--- a/Auth/src/commonTest/kotlin/AccessTokenTest.kt
+++ b/Auth/src/commonTest/kotlin/AccessTokenTest.kt
@@ -4,6 +4,7 @@ import io.github.jan.supabase.auth.auth
 import io.github.jan.supabase.auth.minimalConfig
 import io.github.jan.supabase.auth.resolveAccessToken
 import io.github.jan.supabase.testing.createMockedSupabaseClient
+import io.github.jan.supabase.testing.respondJson
 import kotlinx.coroutines.test.runTest
 import kotlin.test.AfterTest
 import kotlin.test.Test
@@ -64,6 +65,24 @@ class AccessTokenTest {
         client.auth.awaitInitialization()
         client.auth.importAuthToken("myAuth")
         assertEquals("myAuth", client.resolveAccessToken())
+    }
+
+    @Test
+    fun testAccessTokenWithAuthReturnsRefreshedTokenWhenExpired() = runTest {
+        val newSession = userSession(customToken = "newToken")
+        client = createMockedSupabaseClient(
+            configuration = {
+                install(Auth) {
+                    minimalConfig()
+                    alwaysAutoRefresh = true
+                }
+            }
+        ) {
+            respondJson(newSession)
+        }
+        client.auth.awaitInitialization()
+        client.auth.importSession(userSession(expiresIn = 0), autoRefresh = false)
+        assertEquals("newToken", client.resolveAccessToken())
     }
 
     @AfterTest

--- a/Auth/src/commonTest/kotlin/AuthRestExceptionTest.kt
+++ b/Auth/src/commonTest/kotlin/AuthRestExceptionTest.kt
@@ -9,6 +9,7 @@ import io.github.jan.supabase.auth.providers.builtin.Email
 import io.github.jan.supabase.exceptions.BadRequestRestException
 import io.github.jan.supabase.testing.createMockedSupabaseClient
 import io.github.jan.supabase.testing.respondJson
+import io.ktor.client.engine.mock.respondError
 import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.add
@@ -104,6 +105,26 @@ class AuthRestExceptionTest {
                             put("message", "error_message")
                         }
                     )
+                }
+            )
+            val exception = assertFails {
+                client.auth.signUpWith(Email) {
+                    email = "example@email.com"
+                    password = "password"
+                }
+            }
+            assertIsNot<AuthRestException>(exception)
+            assertIs<BadRequestRestException>(exception)
+        }
+    }
+
+    @Test
+    fun testErrorsWithNonObjectBody() {
+        runTest {
+            client = createMockedSupabaseClient(
+                configuration = configuration,
+                requestHandler = {
+                    respondError(HttpStatusCode.BadRequest, "maintenance")
                 }
             )
             val exception = assertFails {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Two small Auth bug fixes, each with a regression test:

**1. `resolveAccessToken` returns the stale token after a successful force-refresh** — fixes #1350

`currentAccessTokenOrNull()?.also { checkAccessToken(it) }` refreshes the session when the token is expired, but `.also` returns the original expired token, so the triggering request is still sent with the expired Bearer and fails once (PostgREST `PGRST303`). The fix re-reads `currentAccessTokenOrNull()` after the check so the refreshed token is used. Behavior for the non-expired path, custom `accessToken` providers, `jwtToken`, and the key fallback is unchanged; if `checkAccessToken` throws (`TokenExpiredException` on failed refresh), that propagates exactly as before.

**2. Non-object JSON error bodies crash with `IllegalArgumentException` instead of producing a `RestException`** — fixes #1351

`GoTrueErrorResponse.Companion.deserialize` called `json.jsonObject` on the decoded element; for a body that parses as a JSON literal or array (e.g. from an intermediary proxy during an outage), that throws `IllegalArgumentException`, which escapes `bodyOrNull`'s `SerializationException` catch and surfaces to callers as a raw crash. The deserializer now degrades non-object elements to `GoTrueErrorResponse(error = null, description = json.toString())`, taking the same generic error path as unparseable text.

## Tests

- `AccessTokenTest.testAccessTokenWithAuthReturnsRefreshedTokenWhenExpired` — imports an expired session with a mocked refresh endpoint and asserts `resolveAccessToken` returns the *new* token (fails on master).
- `AuthRestExceptionTest.testErrorsWithNonObjectBody` — mocks a 400 with a bare-literal body and asserts a typed `BadRequestRestException` (on master this throws `IllegalArgumentException`).

## Context

Both were found debugging production issues in a Kotlin Multiplatform app (Android + iOS): the stale-token bug was our highest-volume error (200+ `JWT expired` events/month, all on app-resume sync paths), and the error-body crash appeared during a ~3.4h edge outage window that returned literal bodies.