### PR TITLE
fix(auth): clear session on any rest exception

### DIFF
--- a/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/AuthImpl.kt
+++ b/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/AuthImpl.kt
@@ -366,6 +366,7 @@ internal class AuthImpl(
         if(currentSessionOrNull() == null) {
             logger.i { "Skipping session logout as there is no session available." }
             clearIfValidScope()
+            return
         }
         try {
             userApi.post("logout") {

--- a/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/AuthImpl.kt
+++ b/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/AuthImpl.kt
@@ -357,27 +357,30 @@ internal class AuthImpl(
     }
 
     override suspend fun signOut(scope: SignOutScope) {
-        if (currentSessionOrNull() != null) {
-            try {
-                userApi.post("logout") {
-                    parameter("scope", scope.name.lowercase())
-                }
-            } catch(e: RestException) {
-                if(e.statusCode in SIGN_OUT_IGNORE_CODES) {
-                    logger.d { "Received error code ${e.statusCode} while signing out user. This can happen if the user doesn't exist anymore or the JWT is invalid/expired. Proceeding to clean up local data..." }
-                } else {
-                    if (scope != SignOutScope.OTHERS) clearSession()
-                    throw e
-                }
+        val clearIfValidScope = suspend {
+            if(scope != SignOutScope.OTHERS) {
+                clearSession()
+                logger.d { "Session data cleared" }
+            } else logger.d { "Skipping clearing session data as sign out scope is 'OTHERS'" }
+        }
+        if(currentSessionOrNull() == null) {
+            logger.i { "Skipping session logout as there is no session available." }
+            clearIfValidScope()
+        }
+        try {
+            userApi.post("logout") {
+                parameter("scope", scope.name.lowercase())
             }
-            logger.d { "Logged out session in Supabase" }
-        } else {
-            logger.i { "Skipping session logout as there is no session available. Proceeding to clean up local data..." }
+        } catch(e: RestException) {
+            if(e.statusCode in SIGN_OUT_IGNORE_CODES) {
+                logger.d { "Received error code ${e.statusCode} while signing out user. This can happen if the user doesn't exist anymore or the JWT is invalid/expired. Proceeding to clean up local data..." }
+            } else {
+                clearIfValidScope()
+                throw e
+            }
         }
-        if (scope != SignOutScope.OTHERS) {
-            clearSession()
-        }
-        logger.d { "Successfully logged out" }
+        logger.d { "Logged out session in Supabase" }
+        clearIfValidScope()
     }
 
     private suspend fun verify(

--- a/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/AuthImpl.kt
+++ b/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/AuthImpl.kt
@@ -365,7 +365,10 @@ internal class AuthImpl(
             } catch(e: RestException) {
                 if(e.statusCode in SIGN_OUT_IGNORE_CODES) {
                     logger.d { "Received error code ${e.statusCode} while signing out user. This can happen if the user doesn't exist anymore or the JWT is invalid/expired. Proceeding to clean up local data..." }
-                } else throw e
+                } else {
+                    if (scope != SignOutScope.OTHERS) clearSession()
+                    throw e
+                }
             }
             logger.d { "Logged out session in Supabase" }
         } else {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (closes #1358)

This pull request updates the sign-out error handling logic in the `AuthImpl` class. Now, when a `RestException` is thrown during sign-out with a status code not in `SIGN_OUT_IGNORE_CODES`, the local session will be cleared (unless the scope is `SignOutScope.OTHERS`) before rethrowing the exception.

Error handling improvements:

* Updated the `signOut` method in `AuthImpl.kt` to clear the local session when a non-ignored `RestException` occurs, except when the sign-out scope is `OTHERS`. This ensures local session data is cleaned up even if the remote sign-out fails.