### PR TITLE
fix(functions): forbid using new api key as fallback

### DIFF
--- a/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/api/AuthenticatedApiConfig.kt
+++ b/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/api/AuthenticatedApiConfig.kt
@@ -36,7 +36,8 @@ data class AuthenticatedApiConfig(
     data class Auth(
         val requireSession: Boolean,
         val getAccessToken: ResolveAccessToken,
-        val jwtToken: String? = null
+        val jwtToken: String? = null,
+        val useNewApiKeyAsFallback: Boolean
     )
 
     @SupabaseInternal
@@ -55,6 +56,7 @@ data class AuthenticatedApiConfig(
         var requireSession: Boolean = false
         var urlLengthLimit: Int? = null
         var getAccessToken: ResolveAccessToken? = null
+        var useNewApiKeyAsFallback: Boolean = true
 
         fun build() = AuthenticatedApiConfig(
             context = Context(
@@ -64,7 +66,8 @@ data class AuthenticatedApiConfig(
             auth = Auth(
                 requireSession = requireSession,
                 getAccessToken = getAccessToken ?: ResolveAccessToken { token, _ -> token },
-                jwtToken = jwtToken
+                jwtToken = jwtToken,
+                useNewApiKeyAsFallback = useNewApiKeyAsFallback
             ),
             request = Request(
                 defaultRequest = defaultRequest,

--- a/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/api/AuthenticatedSupabaseApi.kt
+++ b/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/api/AuthenticatedSupabaseApi.kt
@@ -26,26 +26,34 @@ class AuthenticatedSupabaseApi @SupabaseInternal constructor(
     private val jwtToken = config.auth.jwtToken
     private val requireSession = config.auth.requireSession
 
+    private fun checkIsNew(key: String) = key.startsWith("sb_publishable_") || key.startsWith("sb_secret_")
+
+    private fun String?.checkIsNewApiKey() = if(this != null && (config.auth.useNewApiKeyAsFallback || !checkIsNew(this))) this else null
+
     override suspend fun getDefaultHeaders(): Headers {
         val clientHeaders = super.getDefaultHeaders()
-        val accessToken = config.auth.getAccessToken.resolve(jwtToken, !requireSession)
-            ?: error("No access token found for default headers")
+        val accessToken = config.auth.getAccessToken.resolve(jwtToken, !requireSession).checkIsNewApiKey()
+            ?: throwIfRequired("")
         return headers {
             appendAll(clientHeaders)
-            set("Authorization", "Bearer $accessToken")
+            accessToken?.let {
+                set("Authorization", "Bearer $it")
+            }
         }
     }
 
     override suspend fun rawRequest(url: String, builder: HttpRequestBuilder.() -> Unit): HttpResponse {
-        val accessToken = config.auth.getAccessToken.resolve(jwtToken, !requireSession)
-            ?: throw SessionRequiredException(url)
+        val accessToken = config.auth.getAccessToken.resolve(jwtToken, !requireSession).checkIsNewApiKey()
+            ?: throwIfRequired(url)
         return super.rawRequest(url) {
-            bearerAuth(accessToken)
+            accessToken?.let { bearerAuth(it) }
             defaultRequest?.invoke(this)
             builder()
             checkUrlLength()
         }
     }
+
+    private fun throwIfRequired(url: String) = if(config.auth.requireSession) throw SessionRequiredException(url) else null
 
     suspend fun rawRequest(builder: HttpRequestBuilder.() -> Unit): HttpResponse = rawRequest("", builder)
 
@@ -53,10 +61,10 @@ class AuthenticatedSupabaseApi @SupabaseInternal constructor(
         url: String,
         builder: HttpRequestBuilder.() -> Unit
     ): HttpStatement {
-        val accessToken = config.auth.getAccessToken.resolve(jwtToken, !requireSession)
-            ?: throw SessionRequiredException(url)
+        val accessToken = config.auth.getAccessToken.resolve(jwtToken, !requireSession).checkIsNewApiKey()
+            ?: throwIfRequired(url)
         return super.prepareRequest(url) {
-            bearerAuth(accessToken)
+            accessToken?.let { bearerAuth(it) }
             builder()
             defaultRequest?.invoke(this)
             checkUrlLength()

--- a/Auth/src/commonTest/kotlin/api/AuthenticatedSupabaseApiTests.kt
+++ b/Auth/src/commonTest/kotlin/api/AuthenticatedSupabaseApiTests.kt
@@ -58,6 +58,28 @@ class AuthenticatedSupabaseApiTests {
     }
 
     @Test
+    fun testRequestWithNewApiKeyFail() = runTest {
+        val httpClient = MockedHttpClient {
+            respond("")
+        }
+
+        val api = AuthenticatedSupabaseApi(
+            httpClient = httpClient,
+            config = buildAuthConfig {
+                resolveUrl = { "test.url.de/$it" }
+                requireSession = true
+                useNewApiKeyAsFallback = false
+                getAccessToken = ResolveAccessToken { _, _ -> "sb_publishable_" }
+            }
+        )
+
+        assertFailsWith<SessionRequiredException> {
+            api.get("test")
+        }
+    }
+
+
+    @Test
     fun testRequestWithoutRequiredSessionUsesFallbackResolverPath() = runTest {
         val fallbackToken = "fallback-token"
 

--- a/Functions/src/commonMain/kotlin/io/github/jan/supabase/functions/Functions.kt
+++ b/Functions/src/commonMain/kotlin/io/github/jan/supabase/functions/Functions.kt
@@ -69,7 +69,9 @@ class Functions(override val config: Config, override val supabaseClient: Supaba
 
     @OptIn(SupabaseInternal::class)
     @PublishedApi
-    internal val api = supabaseClient.authenticatedSupabaseApi(this)
+    internal val api = supabaseClient.authenticatedSupabaseApi(this) {
+        useNewApiKeyAsFallback = false
+    }
 
     /**
      * Invokes a remote edge function. The authorization token is automatically added to the request.

--- a/Functions/src/commonTest/kotlin/FunctionsTest.kt
+++ b/Functions/src/commonTest/kotlin/FunctionsTest.kt
@@ -21,6 +21,7 @@ import kotlinx.serialization.json.put
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 internal val configuration: SupabaseClientBuilder.() -> Unit = {
     install(Functions)
@@ -48,6 +49,29 @@ class FunctionsTest {
             )
             supabase.auth.awaitInitialization()
             supabase.auth.importAuthToken(expectedJWT)
+            supabase.functions.invoke(
+                function = ""
+            )
+        }
+    }
+
+    @Test
+    fun testNewApiKeyFallback() {
+        runTest {
+            supabase = createMockedSupabaseClient(
+                supabaseKey = "sb_publishable_",
+                configuration ={
+                    install(Auth) {
+                        minimalConfig()
+                    }
+                    configuration()
+                },
+                requestHandler = {
+                    assertNull(it.headers[HttpHeaders.Authorization])
+                    respond("")
+                }
+            )
+            supabase.auth.awaitInitialization()
             supabase.functions.invoke(
                 function = ""
             )


### PR DESCRIPTION
## What kind of change does this PR introduce?

fix (closes #1357)

**Authentication and API key fallback logic:**
- Added a new `useNewApiKeyAsFallback` flag to the `AuthenticatedApiConfig.Auth` data class and its builder, allowing consumers to control whether new-style API keys are used as fallback tokens.
- Updated `AuthenticatedSupabaseApi` to check if a token is a new API key and, based on the configuration, either omit the Authorization header or throw a `SessionRequiredException` if a session is required.

**Functions module integration:**
- Modified the `Functions` module to explicitly set `useNewApiKeyAsFallback = false`, ensuring that new API keys are not used as fallback tokens for function calls.

**Testing:**
- Added a test in `AuthenticatedSupabaseApiTests` to verify that requests with new API keys fail as expected when fallback is disabled and a session is required.
- Added a test in `FunctionsTest` to ensure that when using a new API key, the Authorization header is not set.