### PR TITLE
feat(core): check Api key format when creating supabase client

### DIFF
--- a/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/api/AuthenticatedSupabaseApi.kt
+++ b/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/api/AuthenticatedSupabaseApi.kt
@@ -3,6 +3,7 @@
 package io.github.jan.supabase.auth.api
 
 import io.github.jan.supabase.StringMasking
+import io.github.jan.supabase.SupabaseClient
 import io.github.jan.supabase.annotations.SupabaseInternal
 import io.github.jan.supabase.auth.exception.SessionRequiredException
 import io.github.jan.supabase.exceptions.RestException
@@ -26,9 +27,7 @@ class AuthenticatedSupabaseApi @SupabaseInternal constructor(
     private val jwtToken = config.auth.jwtToken
     private val requireSession = config.auth.requireSession
 
-    private fun checkIsNew(key: String) = key.startsWith("sb_publishable_") || key.startsWith("sb_secret_")
-
-    private fun String?.checkIsNewApiKey() = if(this != null && (config.auth.useNewApiKeyAsFallback || !checkIsNew(this))) this else null
+    private fun String?.checkIsNewApiKey() = if(this != null && (config.auth.useNewApiKeyAsFallback || !SupabaseClient.checkIsNewApiKey(this))) this else null
 
     override suspend fun getDefaultHeaders(): Headers {
         val clientHeaders = super.getDefaultHeaders()

--- a/Supabase/src/commonMain/kotlin/io/github/jan/supabase/SupabaseClient.kt
+++ b/Supabase/src/commonMain/kotlin/io/github/jan/supabase/SupabaseClient.kt
@@ -4,6 +4,7 @@ import io.github.jan.supabase.annotations.SupabaseInternal
 import io.github.jan.supabase.logging.SupabaseLogger
 import io.github.jan.supabase.logging.createLogger
 import io.github.jan.supabase.logging.i
+import io.github.jan.supabase.logging.w
 import io.github.jan.supabase.network.KtorSupabaseHttpClient
 import io.github.jan.supabase.plugins.PluginManager
 import io.github.jan.supabase.plugins.SupabasePlugin
@@ -82,6 +83,11 @@ interface SupabaseClient {
          */
         const val LOGGING_TAG = "Supabase-Core"
 
+        internal const val TEMP_KEY_PREFIX = "sb_temp_"
+
+        @SupabaseInternal
+        fun checkIsNewApiKey(key: String) = key.startsWith("sb_publishable_") || key.startsWith("sb_secret_")
+
     }
 
 }
@@ -112,6 +118,26 @@ internal class SupabaseClientImpl(
             logger.i(e) {
                 "Failed to get OS information. If this is not intentional, please report this issue."
             }
+        }
+        checkApiKeyFormat(config.supabaseKey)
+    }
+
+    /**
+     * Warn (once per subtype) when an `sb_` key isn't a subtype this SDK version recognizes.
+     * Never throws — the server, not the SDK, decides key validity. The key value is never
+     * included in the message.
+     */
+    private fun checkApiKeyFormat(supabaseKey: String) {
+        if(!supabaseKey.startsWith("sb_") || SupabaseClient.checkIsNewApiKey(supabaseKey) || supabaseKey.startsWith(
+                SupabaseClient.TEMP_KEY_PREFIX)) {
+            return
+        }
+        logger.w {
+            """
+                Unrecognized Supabase API key format. 
+                The client will proceed and send this key as-is; 
+                if you see authentication errors you may need to upgrade supabase-kt to a version that recognizes this key type.
+            """.trimIndent()
         }
     }
 


### PR DESCRIPTION
closes #1356 

This pull request refactors how the SDK checks for new Supabase API key formats and improves logging for unrecognized key types. The main logic for detecting new API keys is moved to a single utility function in `SupabaseClient`, and the client now logs a warning if it encounters an unknown key type (without exposing the key value). This helps developers identify when they might need to upgrade the SDK for compatibility.

**API key format handling:**

* Added a new internal function `checkIsNewApiKey` to `SupabaseClient` for consistent detection of new API key formats.

**Logging and developer experience:**

* Introduced a warning log in `SupabaseClientImpl` that notifies developers when an unrecognized `sb_` key format is used, suggesting an SDK upgrade if authentication errors occur. The log does not expose the key value. 