### PR TITLE
feat(postgrest): add dryRun(), maybeSingle() modifiers, notIn filter

### DIFF
--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/executor/RestRequestExecutor.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/executor/RestRequestExecutor.kt
@@ -1,7 +1,6 @@
 package io.github.jan.supabase.postgrest.executor
 
 import io.github.jan.supabase.exceptions.HttpRequestException
-import io.github.jan.supabase.exceptions.RestException
 import io.github.jan.supabase.postgrest.Postgrest
 import io.github.jan.supabase.postgrest.PostgrestImpl
 import io.github.jan.supabase.postgrest.exception.PostgrestRestException
@@ -47,11 +46,11 @@ internal data object RestRequestExecutor : RequestExecutor {
                     }
                 }
                 return response.asPostgrestResult(postgrest)
-            } catch (e: RestException) {
+            } catch (e: PostgrestRestException) {
                 lastException = e
                 if (attempt < retryCount && e.statusCode in RETRYABLE_STATUS_CODES) {
                     delay(getRetryDelay(attempt))
-                } else if(e is PostgrestRestException && e.code == "PGRST116" && request.acceptHeader is AcceptHeader.Single && (request.acceptHeader as AcceptHeader.Single).maybe) {
+                } else if(e.code == "PGRST116" && request.acceptHeader is AcceptHeader.Single && (request.acceptHeader as AcceptHeader.Single).maybe) {
                     return PostgrestResult("", e.response.headers, postgrest)
                 } else {
                     throw e

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/executor/RestRequestExecutor.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/executor/RestRequestExecutor.kt
@@ -4,11 +4,16 @@ import io.github.jan.supabase.exceptions.HttpRequestException
 import io.github.jan.supabase.exceptions.RestException
 import io.github.jan.supabase.postgrest.Postgrest
 import io.github.jan.supabase.postgrest.PostgrestImpl
+import io.github.jan.supabase.postgrest.exception.PostgrestRestException
+import io.github.jan.supabase.postgrest.query.AcceptHeader
 import io.github.jan.supabase.postgrest.query.PostgrestRequestBuilder
 import io.github.jan.supabase.postgrest.result.PostgrestResult
+import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpMethod
 import kotlinx.coroutines.delay
 import kotlin.math.pow
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
 
 @PublishedApi
 internal data object RestRequestExecutor : RequestExecutor {
@@ -47,6 +52,8 @@ internal data object RestRequestExecutor : RequestExecutor {
                 lastException = e
                 if (attempt < retryCount && e.statusCode in RETRYABLE_STATUS_CODES) {
                     delay(getRetryDelay(attempt))
+                } else if(e is PostgrestRestException && e.code == "PGRST116" && request.acceptHeader is AcceptHeader.Single && (request.acceptHeader as AcceptHeader.Single).maybe) {
+                    return PostgrestResult(e.response.bodyAsText(), e.response.headers, postgrest)
                 } else {
                     throw e
                 }
@@ -62,9 +69,9 @@ internal data object RestRequestExecutor : RequestExecutor {
         throw lastException!!
     }
 
-    private fun getRetryDelay(attempt: Int): Long {
+    private fun getRetryDelay(attempt: Int): Duration {
         val exponentialDelay = BASE_DELAY_MS * BACKOFF_MULTIPLIER.pow(attempt).toLong()
-        return minOf(exponentialDelay, MAX_RETRY_DELAY_MS)
+        return minOf(exponentialDelay, MAX_RETRY_DELAY_MS).milliseconds
     }
 
 }

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/executor/RestRequestExecutor.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/executor/RestRequestExecutor.kt
@@ -8,7 +8,6 @@ import io.github.jan.supabase.postgrest.exception.PostgrestRestException
 import io.github.jan.supabase.postgrest.query.AcceptHeader
 import io.github.jan.supabase.postgrest.query.PostgrestRequestBuilder
 import io.github.jan.supabase.postgrest.result.PostgrestResult
-import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpMethod
 import kotlinx.coroutines.delay
 import kotlin.math.pow
@@ -53,7 +52,7 @@ internal data object RestRequestExecutor : RequestExecutor {
                 if (attempt < retryCount && e.statusCode in RETRYABLE_STATUS_CODES) {
                     delay(getRetryDelay(attempt))
                 } else if(e is PostgrestRestException && e.code == "PGRST116" && request.acceptHeader is AcceptHeader.Single && (request.acceptHeader as AcceptHeader.Single).maybe) {
-                    return PostgrestResult(e.response.bodyAsText(), e.response.headers, postgrest)
+                    return PostgrestResult("", e.response.headers, postgrest)
                 } else {
                     throw e
                 }

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/AcceptHeader.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/AcceptHeader.kt
@@ -1,19 +1,21 @@
 package io.github.jan.supabase.postgrest.query
 
 internal sealed interface AcceptHeader {
-    data object Single: AcceptHeader {
-        operator fun invoke(stripNulls: Boolean) =
-            "application/vnd.pgrst.object+json" + if(stripNulls) ";nulls=stripped" else ""
+    data class Single(val maybe: Boolean): AcceptHeader {
+        companion object {
+            fun headerValue(stripNulls: Boolean) =
+                "application/vnd.pgrst.object+json" + if(stripNulls) ";nulls=stripped" else ""
+        }
     }
     data object Json: AcceptHeader {
-        operator fun invoke(stripNulls: Boolean) =
+        fun headerValue(stripNulls: Boolean) =
             if(stripNulls) "application/vnd.pgrst.array+json;nulls=stripped" else "application/json"
     }
     data object CSV: AcceptHeader {
-        operator fun invoke() = "text/csv"
+        fun headerValue() = "text/csv"
     }
     data object GeoJson: AcceptHeader {
-        operator fun invoke() = "application/geo+json"
+        fun headerValue() = "application/geo+json"
     }
 
 }
@@ -23,7 +25,7 @@ internal data class ExplainData(
     val format: String
 ) {
 
-    operator fun invoke(
+    fun headerValue(
         mediaType: String,
     ) = "application/vnd.pgrst.plan+${format}; for=\"${mediaType}\"; options=${options};"
 

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/PostgrestRequestBuilder.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/PostgrestRequestBuilder.kt
@@ -51,7 +51,8 @@ abstract class PostgrestRequestBuilder(
     internal var httpMethod: HttpMethod = HttpMethod.Get
 
     private var shouldStripNulls: Boolean = false
-    private var acceptHeader: AcceptHeader = AcceptHeader.Json
+    private var dryRun: Boolean = false
+    internal var acceptHeader: AcceptHeader = AcceptHeader.Json
     private var explainData: ExplainData? = null
     @PublishedApi internal var body: JsonElement? = null
 
@@ -114,7 +115,39 @@ abstract class PostgrestRequestBuilder(
      */
     @JsName("singleValue")
     fun single() {
-        acceptHeader = AcceptHeader.Single
+        acceptHeader = AcceptHeader.Single(false)
+    }
+
+    /**
+     * Return `data` as a single object instead of an array of objects.
+     *
+     * Instructs PostgREST to return a single JSON object, returning `nil` when no row matches.
+     *
+     * Like ``single()``, this sets the `application/vnd.pgrst.object+json` accept header so the
+     * server enforces a single result. Unlike ``single()``, when the query does not match exactly
+     * one row the resulting `PGRST116` error is not thrown — ``PostgrestResponse/value`` is `null`
+     * instead.
+     *
+     * > Note: PostgREST returns `PGRST116` both when zero rows match and when more than one row
+     * > matches. This method returns `null` for either case; use ``single()`` for the strict variant
+     * > that always throws when the query does not match exactly one row.
+     */
+    @JsName("maybeSingleValue")
+    fun maybeSingle() {
+        acceptHeader = AcceptHeader.Single(true)
+    }
+
+    /**
+     * Executes the query but rolls back the transaction instead of committing it.
+     *
+     * The mutation runs and its result (including any side effects such as triggers) is returned
+     * in the response, but the transaction is rolled back afterward, so no changes are persisted.
+     * This is useful for testing mutations without touching real data.
+     *
+     * Requires PostgREST's `db-tx-end` setting to allow client-controlled transaction rollback.
+     */
+    fun dryRun() {
+        dryRun = true
     }
 
     /**
@@ -225,6 +258,7 @@ abstract class PostgrestRequestBuilder(
 
     internal fun buildPrefer() = buildSet {
         if (count != null) add("count=${count!!.identifier}")
+        if( dryRun) add("tx=rollback")
         addAll(customPrefer())
     }
 
@@ -244,16 +278,16 @@ abstract class PostgrestRequestBuilder(
         }
 
         val mediaType = when(acceptHeader) {
-            AcceptHeader.CSV -> AcceptHeader.CSV()
-            AcceptHeader.GeoJson -> AcceptHeader.GeoJson()
-            AcceptHeader.Json -> AcceptHeader.Json(shouldStripNulls)
-            AcceptHeader.Single -> AcceptHeader.Single(shouldStripNulls)
+            AcceptHeader.CSV -> AcceptHeader.CSV.headerValue()
+            AcceptHeader.GeoJson -> AcceptHeader.GeoJson.headerValue()
+            AcceptHeader.Json -> AcceptHeader.Json.headerValue(shouldStripNulls)
+            is AcceptHeader.Single -> AcceptHeader.Single.headerValue(shouldStripNulls)
         }
 
         // Accept header
         header(
             HttpHeaders.Accept,
-            if(explainData != null) explainData!!(mediaType) else mediaType
+            if(explainData != null) explainData!!.headerValue(mediaType) else mediaType
         )
 
         header(PostgrestQueryBuilder.HEADER_PREFER, buildPrefer().joinToString(","))

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/PostgrestRequestBuilder.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/PostgrestRequestBuilder.kt
@@ -121,7 +121,7 @@ abstract class PostgrestRequestBuilder(
     /**
      * Return `data` as a single object instead of an array of objects.
      *
-     * Instructs PostgREST to return a single JSON object, returning `nil` when no row matches.
+     * Instructs PostgREST to return a single JSON object, returning `null`/blank data when no row matches.
      *
      * Like ``single()``, this sets the `application/vnd.pgrst.object+json` accept header so the
      * server enforces a single result. Unlike ``single()``, when the query does not match exactly

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/PostgrestRequestBuilder.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/PostgrestRequestBuilder.kt
@@ -258,7 +258,7 @@ abstract class PostgrestRequestBuilder(
 
     internal fun buildPrefer() = buildSet {
         if (count != null) add("count=${count!!.identifier}")
-        if( dryRun) add("tx=rollback")
+        if (dryRun) add("tx=rollback")
         addAll(customPrefer())
     }
 

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/filter/PostgrestFilterBuilder.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/filter/PostgrestFilterBuilder.kt
@@ -152,6 +152,11 @@ class PostgrestFilterBuilder(
     fun isIn(column: String, values: List<Any>) = filter(column, FilterOperator.IN, values)
 
     /**
+     * Finds all rows where the value of the [column] is not a member of [values]
+     */
+    fun notIn(column: String, values: List<Any>) = filterNot(column, FilterOperator.IN, values)
+
+    /**
      * Finds all rows where the value of the [column] is strictly left of [range]
      */
     fun sl(column: String, range: Pair<Any, Any>) = filter(column, FilterOperator.SL, range)
@@ -346,6 +351,11 @@ class PostgrestFilterBuilder(
      * Finds all rows where the value of the column with the name of the [KProperty1] converted using [propertyConversionMethod] is in the specified [list]
      */
     infix fun <T, V> KProperty1<T, V>.isIn(list: List<V>) = filter(FilterOperation(propertyConversionMethod(this), FilterOperator.IN, list))
+
+    /**
+     * Finds all rows where the value of the column with the name of the [KProperty1] converted using [propertyConversionMethod] is not in the specified [list]
+     */
+    infix fun <T, V> KProperty1<T, V>.notIn(list: List<V>) = filterNot(FilterOperation(propertyConversionMethod(this), FilterOperator.IN, list))
 
     /**
      * Finds all rows where the value of the column with the name of the [KProperty1] converted using [propertyConversionMethod] is strictly left of [range]

--- a/Postgrest/src/commonTest/kotlin/PostgrestFilterBuilderTest.kt
+++ b/Postgrest/src/commonTest/kotlin/PostgrestFilterBuilderTest.kt
@@ -236,6 +236,14 @@ class PostgrestFilterBuilderTest {
     }
 
     @Test
+    fun notIn() {
+        val filter = filterToString {
+            notIn("id", listOf(1, 2, 3))
+        }
+        assertEquals("id=not.in.(1,2,3)", filter)
+    }
+
+    @Test
     fun exact() {
         val filter = filterToString {
             exact("id", null)

--- a/Postgrest/src/commonTest/kotlin/PostgrestRequestBuilderTest.kt
+++ b/Postgrest/src/commonTest/kotlin/PostgrestRequestBuilderTest.kt
@@ -1,3 +1,4 @@
+import io.github.jan.supabase.postgrest.query.AcceptHeader
 import io.github.jan.supabase.postgrest.query.Columns
 import io.github.jan.supabase.postgrest.query.Count
 import io.github.jan.supabase.postgrest.query.Order
@@ -34,6 +35,18 @@ class PostgrestRequestBuilderTest {
             },
             httpRequestHandler = {
                 assertEquals("count=exact,prefer=test", headers[PostgrestQueryBuilder.HEADER_PREFER])
+            }
+        )
+    }
+
+    @Test
+    fun testPreferDryRun() {
+        testRequestBuilder(
+            requestBuilder = {
+                dryRun()
+            },
+            httpRequestHandler = {
+                assertEquals("tx=rollback,prefer=test", headers[PostgrestQueryBuilder.HEADER_PREFER])
             }
         )
     }
@@ -171,6 +184,33 @@ class PostgrestRequestBuilderTest {
             requestBuilder = {
                 single()
                 stripNulls()
+            },
+            httpRequestHandler = {
+                assertEquals("application/vnd.pgrst.object+json;nulls=stripped", headers[HttpHeaders.Accept])
+            }
+        )
+    }
+
+    @Test
+    fun testAcceptMaybeSingleNoStrip() {
+        testRequestBuilder(
+            requestBuilder = {
+                maybeSingle()
+                assertEquals(AcceptHeader.Single(true), acceptHeader)
+            },
+            httpRequestHandler = {
+                assertEquals("application/vnd.pgrst.object+json", headers[HttpHeaders.Accept])
+            }
+        )
+    }
+
+    @Test
+    fun testAcceptMaybeSingleStrip() {
+        testRequestBuilder(
+            requestBuilder = {
+                maybeSingle()
+                stripNulls()
+                assertEquals(AcceptHeader.Single(true), acceptHeader)
             },
             httpRequestHandler = {
                 assertEquals("application/vnd.pgrst.object+json;nulls=stripped", headers[HttpHeaders.Accept])

--- a/Postgrest/src/commonTest/kotlin/PostgrestResultTest.kt
+++ b/Postgrest/src/commonTest/kotlin/PostgrestResultTest.kt
@@ -1,7 +1,6 @@
-package io.github.jan.supabase.postgrest.result
-
 import io.github.jan.supabase.postgrest.Postgrest
 import io.github.jan.supabase.postgrest.postgrest
+import io.github.jan.supabase.postgrest.result.PostgrestResult
 import io.github.jan.supabase.testing.createMockedSupabaseClient
 import io.ktor.http.Headers
 import io.ktor.http.headersOf

--- a/Postgrest/src/commonTest/kotlin/PostgrestTest.kt
+++ b/Postgrest/src/commonTest/kotlin/PostgrestTest.kt
@@ -103,9 +103,7 @@ class PostgrestTest {
                 val result = from(table).select() {
                     maybeSingle()
                 }
-                assertEquals("""
-                    { "code": "PGRST116", "details": "The result contains 0 rows", "hint": null, "message": "JSON object requested, multiple (or no) rows returned"}
-                """.trimIndent(), result.data)
+                assertEquals("", result.data)
                 result
             },
             requestHandler = {

--- a/Postgrest/src/commonTest/kotlin/PostgrestTest.kt
+++ b/Postgrest/src/commonTest/kotlin/PostgrestTest.kt
@@ -2,12 +2,13 @@ import io.github.jan.supabase.SupabaseClient
 import io.github.jan.supabase.SupabaseClientBuilder
 import io.github.jan.supabase.postgrest.Postgrest
 import io.github.jan.supabase.postgrest.RpcMethod
+import io.github.jan.supabase.postgrest.exception.PostgrestRestException
 import io.github.jan.supabase.postgrest.from
 import io.github.jan.supabase.postgrest.postgrest
-import io.github.jan.supabase.postgrest.rpc
 import io.github.jan.supabase.postgrest.query.Columns
 import io.github.jan.supabase.postgrest.query.Count
 import io.github.jan.supabase.postgrest.result.PostgrestResult
+import io.github.jan.supabase.postgrest.rpc
 import io.github.jan.supabase.testing.assertMethodIs
 import io.github.jan.supabase.testing.assertPathIs
 import io.github.jan.supabase.testing.createMockedSupabaseClient
@@ -17,11 +18,10 @@ import io.ktor.client.engine.mock.MockRequestHandleScope
 import io.ktor.client.engine.mock.respond
 import io.ktor.client.request.HttpRequestData
 import io.ktor.client.request.HttpResponseData
+import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpMethod
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
-import io.ktor.http.HttpHeaders
-import io.github.jan.supabase.postgrest.exception.PostgrestRestException
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerializationException
@@ -74,6 +74,44 @@ class PostgrestTest {
                 assertMethodIs(HttpMethod.Get, it.method)
                 assertEquals(columns.value, it.url.parameters["select"])
                 respond("")
+            }
+        )
+    }
+
+    @Test
+    fun testSingleThrowsOnErrorResponse() {
+        assertFailsWith<PostgrestRestException> {
+            testClient(
+                request = { table ->
+                    from(table).select() {
+                        single()
+                    }
+                },
+                requestHandler = {
+                    respond("""
+                    { "code": "PGRST116", "details": "The result contains 0 rows", "hint": null, "message": "JSON object requested, multiple (or no) rows returned"}
+                """.trimIndent(), HttpStatusCode.BadRequest)
+                }
+            )
+        }
+    }
+
+    @Test
+    fun testMaybeSingleDoesntThrowOnErrorResponse() {
+        testClient(
+            request = { table ->
+                val result = from(table).select() {
+                    maybeSingle()
+                }
+                assertEquals("""
+                    { "code": "PGRST116", "details": "The result contains 0 rows", "hint": null, "message": "JSON object requested, multiple (or no) rows returned"}
+                """.trimIndent(), result.data)
+                result
+            },
+            requestHandler = {
+                respond("""
+                    { "code": "PGRST116", "details": "The result contains 0 rows", "hint": null, "message": "JSON object requested, multiple (or no) rows returned"}
+                """.trimIndent(), HttpStatusCode.BadRequest)
             }
         )
     }

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -309,7 +309,10 @@ features:
   database.using_filters.regex: implemented
   database.using_filters.regex_icase: implemented
   database.using_filters.is_distinct: implemented
-  database.using_filters.not_in: implemented
+  database.using_filters.not_in:
+    status: implemented
+    symbols:
+      - PostgrestFilterBuilder.notIn
   database.using_filters.like_all: implemented
   database.using_filters.like_any: implemented
   database.using_filters.ilike_all: implemented
@@ -319,20 +322,23 @@ features:
   database.using_modifiers.limit: implemented
   database.using_modifiers.range: implemented
   database.using_modifiers.single_row: implemented
-  database.using_modifiers.maybe_single_row: not_implemented
+  database.using_modifiers.maybe_single_row:
+    status: implemented
+    symbols:
+      - PostgrestRequestBuilder.maybeSingle
   database.using_modifiers.strip_nulls: implemented
   database.using_modifiers.format_csv: implemented
   database.using_modifiers.format_geojson: implemented
-  database.using_modifiers.explain:
-    status: implemented
-    symbols:
-      - ExplainFormat
+  database.using_modifiers.explain: implemented
   database.using_modifiers.max_affected_rows: implemented
   database.using_modifiers.request_cancellation: implemented
   database.using_modifiers.relationship_embed:
     status: partially_implemented
     note: "Supported via query-string syntax in select() (e.g. 'user(*)'); no dedicated relationship builder API."
-  database.using_modifiers.dry_run: not_implemented
+  database.using_modifiers.dry_run:
+    status: implemented
+    symbols:
+      - PostgrestRequestBuilder.dryRun
 
   database.configuration.auto_retry: implemented
   database.configuration.request_timeout: implemented


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

This pull request introduces several new features and improvements to the PostgREST Kotlin client, focusing on enhanced query modifiers and filter operations, as well as improved error handling and test coverage. The most important changes are summarized below.

### Query Modifiers and Features

* Added support for the `maybeSingle()` modifier in `PostgrestRequestBuilder`, allowing queries to return `null` instead of throwing an error when zero or multiple rows match. This is handled by the new `AcceptHeader.Single(maybe: Boolean)` class and updated logic in the request executor to return a result instead of throwing on `PGRST116` when `maybeSingle` is used. 

* Implemented the `dryRun()` modifier, which executes mutations in a rolled-back transaction for testing purposes. The modifier sets the appropriate Prefer header (`tx=rollback`).

### Filter Operations

* Added the `notIn()` filter method to `PostgrestFilterBuilder` and its property-based variant, enabling "NOT IN" SQL queries. Compliance documentation and tests were updated accordingly. 

### Internal Refactoring and API Consistency

* Refactored `AcceptHeader` to use data classes and companion objects for consistent header value construction, and updated all usages to match the new API.

### Testing and Compliance

* Added unit tests for `maybeSingle()`, `dryRun()`, and `notIn()` to ensure correct behavior and error handling. Updated `sdk-compliance.yaml` to mark these features as implemented and document their corresponding symbols.
