### PR TITLE
feat(realtime): add system flow, `replicationReady` option

### DIFF
--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/CallbackManager.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/CallbackManager.kt
@@ -23,6 +23,8 @@ sealed class RealtimeCallbackId(val value: Int) {
 
     class Broadcast(value: Int) : RealtimeCallbackId(value)
 
+    class System(value: Int) : RealtimeCallbackId(value)
+
 }
 
 @SupabaseInternal
@@ -34,6 +36,8 @@ interface CallbackManager {
 
     fun triggerPresenceDiff(joins: Map<String, Presence>, leaves: Map<String, Presence>)
 
+    fun triggerSystem(data: RealtimeSystemPayload)
+
     fun hasPresenceCallback(): Boolean
 
     /**
@@ -42,6 +46,8 @@ interface CallbackManager {
     fun presenceState(): Map<String, Presence>
 
     fun addBroadcastCallback(event: String, callback: (RealtimeBroadcast) -> Unit): RealtimeCallbackId.Broadcast
+
+    fun addSystemCallback(callback: (RealtimeSystemPayload) -> Unit): RealtimeCallbackId.System
 
     fun addPostgresCallback(filter: PostgresJoinConfig, callback: (PostgresAction) -> Unit): RealtimeCallbackId.Postgres
 
@@ -56,6 +62,7 @@ interface CallbackManager {
 }
 
 private typealias BroadcastMap = PersistentMap<String, PersistentList<RealtimeCallback.BroadcastCallback>>
+private typealias SystemMap = PersistentMap<Int, RealtimeCallback.SystemCallback>
 private typealias PresenceMap = PersistentMap<Int, RealtimeCallback.PresenceCallback>
 private typealias PostgresMap = PersistentMap<Int, RealtimeCallback.PostgresCallback>
 
@@ -76,12 +83,15 @@ internal class CallbackManagerImpl(
 
     private val postgresCallbacks = AtomicReference<PostgresMap>(persistentHashMapOf())
 
+    private val systemCallbacks = AtomicReference<SystemMap>(persistentHashMapOf())
+
     override fun reset() {
         postgresCallbacks.store(persistentHashMapOf())
         broadcastEventId.store(persistentHashMapOf())
         broadcastCallbacks.store(persistentHashMapOf())
         presenceCallbacks.store(persistentHashMapOf())
         currentPresenceState.store(persistentHashMapOf())
+        systemCallbacks.store(persistentHashMapOf())
         _serverChanges.store(emptyList())
         nextId.store(0)
     }
@@ -90,10 +100,10 @@ internal class CallbackManagerImpl(
         val id = nextId.fetchAndIncrement()
         broadcastCallbacks.update {
             val current = it[event] ?: persistentListOf()
-            it.put(event, current + RealtimeCallback.BroadcastCallback(callback, event, id))
+            it.putting(event, current + RealtimeCallback.BroadcastCallback(callback, event, id))
         }
         broadcastEventId.update {
-            it.put(id, event)
+            it.putting(id, event)
         }
         return RealtimeCallbackId.Broadcast(id)
     }
@@ -101,9 +111,21 @@ internal class CallbackManagerImpl(
     override fun addPostgresCallback(filter: PostgresJoinConfig, callback: (PostgresAction) -> Unit): RealtimeCallbackId.Postgres {
         val id = nextId.fetchAndIncrement()
         postgresCallbacks.update {
-            it.put(id, RealtimeCallback.PostgresCallback(callback, filter, id))
+            it.putting(id, RealtimeCallback.PostgresCallback(callback, filter, id))
         }
         return RealtimeCallbackId.Postgres(id)
+    }
+
+    override fun addSystemCallback(callback: (RealtimeSystemPayload) -> Unit): RealtimeCallbackId.System {
+        val id = nextId.fetchAndIncrement()
+        systemCallbacks.update {
+            it.putting(id, RealtimeCallback.SystemCallback(callback, id))
+        }
+        return RealtimeCallbackId.System(id)
+    }
+
+    override fun triggerSystem(data: RealtimeSystemPayload) {
+        systemCallbacks.load().values.forEach { it.callback(data) }
     }
 
     override fun triggerPostgresChange(ids: List<Int>, data: PostgresAction) {
@@ -136,7 +158,7 @@ internal class CallbackManagerImpl(
     override fun addPresenceCallback(callback: (PresenceAction) -> Unit):  RealtimeCallbackId.Presence {
         val id = nextId.fetchAndIncrement()
         presenceCallbacks.update {
-            it.put(id, RealtimeCallback.PresenceCallback(callback, id))
+            it.putting(id, RealtimeCallback.PresenceCallback(callback, id))
         }
         return RealtimeCallbackId.Presence(id)
     }
@@ -144,22 +166,28 @@ internal class CallbackManagerImpl(
     fun removeBroadcastCallbackById(id: Int) {
         val event = broadcastEventId.load()[id] ?: return
         broadcastCallbacks.update {
-            it.put(event, it[event]?.removeAll { c -> c.id == id } ?: persistentListOf())
+            it.putting(event, it[event]?.removingAll { c -> c.id == id } ?: persistentListOf())
         }
         broadcastEventId.update {
-            it.remove(id)
+            it.removing(id)
         }
     }
 
     fun removePresenceCallbackById(id: Int) {
         presenceCallbacks.update {
-            it.remove(id)
+            it.removing(id)
         }
     }
 
     fun removePostgresCallbackById(id: Int) {
         postgresCallbacks.update {
-            it.remove(id)
+            it.removing(id)
+        }
+    }
+
+    fun removeSystemCallbackById(id: Int) {
+        systemCallbacks.update {
+            it.removing(id)
         }
     }
 
@@ -168,6 +196,7 @@ internal class CallbackManagerImpl(
             is RealtimeCallbackId.Broadcast -> removeBroadcastCallbackById(id.value)
             is RealtimeCallbackId.Presence -> removePresenceCallbackById(id.value)
             is RealtimeCallbackId.Postgres -> removePostgresCallbackById(id.value)
+            is RealtimeCallbackId.System -> removeSystemCallbackById(id.value)
         }
     }
 

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeCallback.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeCallback.kt
@@ -26,4 +26,9 @@ sealed interface RealtimeCallback <T> {
         override val id: Int
     ): RealtimeCallback<PresenceAction>
 
+    class SystemCallback(
+        override val callback: (RealtimeSystemPayload) -> Unit,
+        override val id: Int
+    ): RealtimeCallback<RealtimeSystemPayload>
+
 }

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeChannel.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeChannel.kt
@@ -133,6 +133,15 @@ interface RealtimeChannel {
      */
     fun presenceChangeFlow(): Flow<PresenceAction>
 
+    /**
+     * Listen for `system` events on this channel.
+     *
+     * Opt in to the replication-ready notification with [BroadcastJoinConfig.replicationReady]: `true` when creating the channel, then
+     * watch for [RealtimeSystemPayload.status] == `"ok"` to know the Postgres replication connection is ready.
+     *
+     */
+    fun systemFlow(): Flow<RealtimeSystemPayload>
+
     @SupabaseInternal
     fun RealtimeChannel.addPostgresChange(data: PostgresJoinConfig)
 

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeChannelBuilder.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeChannelBuilder.kt
@@ -11,7 +11,7 @@ class RealtimeChannelBuilder @PublishedApi internal constructor(
     private val topic: String,
 ) {
 
-    private var broadcastJoinConfig = BroadcastJoinConfig(acknowledgeBroadcasts = false, receiveOwnBroadcasts = false)
+    private var broadcastJoinConfig = BroadcastJoinConfig(acknowledgeBroadcasts = false, receiveOwnBroadcasts = false, replicationReady = false)
     private var presenceJoinConfig = PresenceJoinConfig("", false)
 
     /**
@@ -23,7 +23,7 @@ class RealtimeChannelBuilder @PublishedApi internal constructor(
      * Sets the broadcast join config
      */
     fun broadcast(block: BroadcastJoinConfig.() -> Unit) {
-        broadcastJoinConfig = BroadcastJoinConfig(acknowledgeBroadcasts = false, receiveOwnBroadcasts = false).apply(block)
+        broadcastJoinConfig = BroadcastJoinConfig(acknowledgeBroadcasts = false, receiveOwnBroadcasts = false, replicationReady = false).apply(block)
     }
 
     /**

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeChannelImpl.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeChannelImpl.kt
@@ -296,6 +296,13 @@ internal class RealtimeChannelImpl(
         awaitClose { callbackManager.removeCallbackById(id) }
     }
 
+    override fun systemFlow(): Flow<RealtimeSystemPayload> = callbackFlow {
+        val id = callbackManager.addSystemCallback {
+            trySend(it)
+        }
+        awaitClose { callbackManager.removeCallbackById(id) }
+    }
+
   /*  override fun <T : Any> RealtimeChannel.broadcastFlowInternal(type: KType, event: String): Flow<T> = callbackFlow {
         val id = callbackManager.addBroadcastCallback(event) {
             val decodedValue = try {

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeJoinPayload.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeJoinPayload.kt
@@ -27,9 +27,18 @@ data class RealtimeJoinConfig(
 /**
  * @param acknowledgeBroadcasts Whether the server should send an acknowledgment message for each broadcast message
  * @param receiveOwnBroadcasts Whether you should receive your own broadcasts
+ * @param replicationReady replication_ready option instructs the server to emit a `system` event once the
+ * Postgres replication connection backing this channel is established and ready to
+ * stream changes. Listen for it with `channel.on('system', {}, (payload) => ...)`; TODO: fix docs
+ * the payload's `status` is `'ok'` (`message: 'Replication connection established'`)
+ * on success or `'error'` if the connection is not ready in time.
  */
 @Serializable
-data class BroadcastJoinConfig(@SerialName("ack") var acknowledgeBroadcasts: Boolean, @SerialName("self") var receiveOwnBroadcasts: Boolean)
+data class BroadcastJoinConfig(
+    @SerialName("ack") var acknowledgeBroadcasts: Boolean,
+    @SerialName("self") var receiveOwnBroadcasts: Boolean,
+    @SerialName("replication_ready") var replicationReady: Boolean
+)
 
 /**
  * @param key Used to track presence payloads. Can be e.g. a user id

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeSystemPayload.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeSystemPayload.kt
@@ -1,0 +1,23 @@
+package io.github.jan.supabase.realtime
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Payload of a `system` event emitted by the server.
+ *
+ * Most notably, when a channel is created with [BroadcastJoinConfig.replicationReady]: `true`,
+ * the server sends one of these once the Postgres replication connection is ready
+ * (`status: 'ok'`) or fails to become ready in time (`status: 'error'`).
+ *
+ * @param extension The extension that produced the message, e.g. `'system'` or `'postgres_changes'`.
+ * @param status `'ok'` on success, `'error'` on failure.
+ * @param message Human-readable description, e.g. `'Replication connection established'`.
+ * @param channel The channel (sub)topic the message refers to.
+ */
+@Serializable
+data class RealtimeSystemPayload(
+    val extension: String,
+    val status: String,
+    val message: String,
+    val channel: String
+)

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/event/RSystemEvent.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/event/RSystemEvent.kt
@@ -3,6 +3,9 @@ package io.github.jan.supabase.realtime.event
 import io.github.jan.supabase.logging.d
 import io.github.jan.supabase.realtime.RealtimeChannel
 import io.github.jan.supabase.realtime.RealtimeMessage
+import io.github.jan.supabase.realtime.RealtimeSystemPayload
+import io.github.jan.supabase.supabaseJson
+import kotlinx.serialization.json.decodeFromJsonElement
 import kotlinx.serialization.json.jsonPrimitive
 
 /**
@@ -13,6 +16,8 @@ data object RSystemEvent : RealtimeEvent {
     override suspend fun handle(channel: RealtimeChannel, message: RealtimeMessage) {
         channel.logger.d { "Subscribed to channel ${message.topic}" }
         channel.updateStatus(RealtimeChannel.Status.SUBSCRIBED)
+        val payload = supabaseJson.decodeFromJsonElement<RealtimeSystemPayload>(message.payload)
+        channel.callbackManager.triggerSystem(payload)
     }
 
     override fun appliesTo(message: RealtimeMessage): Boolean {

--- a/Realtime/src/commonTest/kotlin/CallbackManagerTest.kt
+++ b/Realtime/src/commonTest/kotlin/CallbackManagerTest.kt
@@ -4,6 +4,7 @@ import io.github.jan.supabase.realtime.HasRecord
 import io.github.jan.supabase.realtime.PostgresAction
 import io.github.jan.supabase.realtime.PostgresJoinConfig
 import io.github.jan.supabase.realtime.Presence
+import io.github.jan.supabase.realtime.RealtimeSystemPayload
 import io.github.jan.supabase.realtime.broadcast.BroadcastPayload
 import io.github.jan.supabase.realtime.broadcast.RealtimeBroadcast
 import io.github.jan.supabase.serializer.KotlinXSerializer
@@ -37,6 +38,26 @@ class CallbackManagerTest {
         cm.removeCallbackById(id)
         called = false
         cm.triggerBroadcast(RealtimeBroadcast("", expectedEvent, BroadcastPayload.Json(expectedPayload)))
+        assertFalse { called }
+    }
+
+    @Test
+    fun testSystemCallback() {
+        val cm = CallbackManagerImpl()
+
+        var called = false
+        val id = cm.addSystemCallback {
+            assertEquals("system", it.extension)
+            assertEquals("ok", it.status)
+            assertEquals("myChannel", it.channel)
+            assertEquals("Message!", it.message)
+            called = true
+        }
+        cm.triggerSystem(RealtimeSystemPayload("system", "ok", "Message!", "myChannel"))
+        assertTrue { called }
+        cm.removeCallbackById(id)
+        called = false
+        cm.triggerSystem(RealtimeSystemPayload("system", "ok", "Message!", "myChannel"))
         assertFalse { called }
     }
 

--- a/Realtime/src/commonTest/kotlin/RealtimeChannelTest.kt
+++ b/Realtime/src/commonTest/kotlin/RealtimeChannelTest.kt
@@ -38,6 +38,8 @@ import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 import kotlin.time.Clock
 
 val EXAMPLE_JWT = buildString {
@@ -211,7 +213,9 @@ class RealtimeChannelTest {
         runTest {
             createTestClient(
                 wsHandler = { i, o ->
-                    handleSubscribe(i, o, channelId, true)
+                    handleSubscribe(i, o, channelId) {
+                        assertTrue { it.config.presence.enabled }
+                    }
                     for(i in 0..amount) {
                         o.sendPresence(
                             channelId,
@@ -239,6 +243,44 @@ class RealtimeChannelTest {
                                     assertEquals(index, joins.values.first().state["key"]?.jsonPrimitive?.int)
                                     assertEquals(index-1, leaves.values.first().state["key"]?.jsonPrimitive?.int)
                                 }
+                            }
+                        }
+                        launch {
+                            channel.subscribe(true)
+                        }
+                    }.join()
+                }
+            )
+        }
+    }
+
+    @Test
+    fun testReceivingSystem() {
+        val channelId = "channelId"
+        runTest {
+            createTestClient(
+                wsHandler = { i, o ->
+                    handleSubscribe(i, o, channelId) {
+                        assertTrue { it.config.broadcast.replicationReady }
+                    }
+                    o.sendSystem("channelId", "extension", "Message!", "ok")
+                },
+                supabaseHandler = {
+                    val channel = it.channel("channelId") {
+                        broadcast {
+                            replicationReady = true
+                        }
+                    }
+                    coroutineScope {
+                        launch {
+                            val systemFlow = channel.systemFlow()
+                            systemFlow.test(FLOW_TIMEOUT) {
+                                awaitItem() // this is the join payload
+                                val payload = awaitItem()
+                                assertEquals("channelId", payload.channel)
+                                assertEquals("ok", payload.status)
+                                assertEquals("Message!", payload.message)
+                                assertEquals("extension", payload.extension)
                             }
                         }
                         launch {
@@ -296,9 +338,13 @@ class RealtimeChannelTest {
         runTest {
             createTestClient(
                 wsHandler = { i, o ->
-                    handleSubscribe(i, o, channelId, false)
+                    handleSubscribe(i, o, channelId) {
+                        assertFalse { it.config.presence.enabled }
+                    }
                     handleUnsubscribe(i, o, channelId)
-                    handleSubscribe(i, o, channelId, true)
+                    handleSubscribe(i, o, channelId) {
+                        assertTrue { it.config.presence.enabled }
+                    }
                 },
                 realtimeConfig = {
                     disconnectOnNoSubscriptions = false
@@ -331,7 +377,9 @@ class RealtimeChannelTest {
         runTest {
             createTestClient(
                 wsHandler = { i, o ->
-                    handleSubscribe(i, o, channelId, true)
+                    handleSubscribe(i, o, channelId) {
+                        assertTrue { it.config.presence.enabled }
+                    }
                     // Send presence join for user1 and user2, then leave for user1
                     o.sendPresence(
                         channelId,

--- a/Realtime/src/commonTest/kotlin/RealtimeExtTest.kt
+++ b/Realtime/src/commonTest/kotlin/RealtimeExtTest.kt
@@ -21,6 +21,7 @@ import kotlinx.serialization.json.jsonObject
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 import kotlin.time.Clock
 
 @Serializable
@@ -44,7 +45,9 @@ class RealtimeExtTest {
             )
             createTestClient(
                 wsHandler = { i, o ->
-                    handleSubscribe(i, o, "channelId", true)
+                    handleSubscribe(i, o, "channelId") {
+                        assertTrue { it.config.presence.enabled }
+                    }
                 },
                 supabaseHandler = {
                     val channel = it.channel("channelId")

--- a/Realtime/src/commonTest/kotlin/RealtimeTestUtils.kt
+++ b/Realtime/src/commonTest/kotlin/RealtimeTestUtils.kt
@@ -39,18 +39,38 @@ import kotlin.time.Duration.Companion.seconds
 val FLOW_TIMEOUT = 6.seconds
 
 suspend fun Auth.importAuthTokenValid(token: String) {
-    importSession(UserSession(token, "", expiresAt = Clock.System.now() + 1.hours, expiresIn = 1.hours.inWholeSeconds, tokenType = ""))
+    importSession(
+        UserSession(
+            token,
+            "",
+            expiresAt = Clock.System.now() + 1.hours,
+            expiresIn = 1.hours.inWholeSeconds,
+            tokenType = ""
+        )
+    )
 }
 
 suspend fun handleSubscribe(
     incoming: ReceiveChannel<Frame>,
     outgoing: SendChannel<Frame>,
     channelId: String,
-    expectEnabledPresence: Boolean = false
+    handleJoinPayload: (RealtimeJoinPayload) -> Unit = {}
 ) {
     val payload = Json.decodeFromJsonElement<RealtimeJoinPayload>(incoming.receive().toMessage().payload)
-    assertEquals(expectEnabledPresence, payload.config.presence.enabled)
-    outgoing.send(RealtimeMessage(RealtimeTopic.withChannelId(channelId), CHANNEL_EVENT_SYSTEM, buildJsonObject { put("status", "ok") }, "").toFrame())
+    handleJoinPayload(payload)
+    outgoing.send(
+        RealtimeMessage(
+            RealtimeTopic.withChannelId(channelId),
+            CHANNEL_EVENT_SYSTEM,
+            buildJsonObject {
+                put("status", "ok")
+                put("extension", "system")
+                put("channel", channelId)
+                put("message", "Subscribed")
+            },
+            ""
+        ).toFrame()
+    )
 }
 
 suspend fun handleUnsubscribe(
@@ -60,7 +80,14 @@ suspend fun handleUnsubscribe(
 ) {
     val message = incoming.receive().toMessage()
     assertEquals(RealtimeTopic.withChannelId(channelId), message.topic)
-    outgoing.send(RealtimeMessage(RealtimeTopic.withChannelId(channelId), RealtimeChannel.CHANNEL_EVENT_CLOSE, buildJsonObject {  }, "").toFrame())
+    outgoing.send(
+        RealtimeMessage(
+            RealtimeTopic.withChannelId(channelId),
+            RealtimeChannel.CHANNEL_EVENT_CLOSE,
+            buildJsonObject { },
+            ""
+        ).toFrame()
+    )
 }
 
 suspend fun SendChannel<Frame>.sendBroadcast(channelId: String, event: String, message: JsonObject) {
@@ -68,23 +95,42 @@ suspend fun SendChannel<Frame>.sendBroadcast(channelId: String, event: String, m
 }
 
 suspend fun SendChannel<Frame>.sendBroadcastPayload(channelId: String, event: String, payload: BroadcastPayload) {
-    send(Frame.Binary(false, RealtimeBroadcast(RealtimeTopic.withChannelId(channelId), event, payload).encodeBroadcast(null, null,
-        false, BinaryKind.USER_BROADCAST)))
+    send(
+        Frame.Binary(
+            false, RealtimeBroadcast(RealtimeTopic.withChannelId(channelId), event, payload).encodeBroadcast(
+                null, null,
+                false, BinaryKind.USER_BROADCAST
+            )
+        )
+    )
 }
 
 internal fun RealtimeMessage.toFrame() = Frame.Text(this.encodeV2Text())
 
-internal fun Frame.toMessage(vsn: RealtimeProtocolVersion = RealtimeProtocolVersion.V2) = if(this is Frame.Text) {
-    when(vsn) {
+internal fun Frame.toMessage(vsn: RealtimeProtocolVersion = RealtimeProtocolVersion.V2) = if (this is Frame.Text) {
+    when (vsn) {
         RealtimeProtocolVersion.V1 -> supabaseJson.decodeFromString(readText())
         RealtimeProtocolVersion.V2 -> readText().decodeV2Text()
     }
 } else error("Not a text")
 
-suspend fun SendChannel<Frame>.sendPresence(channelId: String, joins: Map<String, Presence>, leaves: Map<String, Presence>) {
+suspend fun SendChannel<Frame>.sendPresence(
+    channelId: String,
+    joins: Map<String, Presence>,
+    leaves: Map<String, Presence>
+) {
     send(RealtimeMessage(RealtimeTopic.withChannelId(channelId), CHANNEL_EVENT_PRESENCE_DIFF, buildJsonObject {
         put("joins", transformPresenceMap(joins))
         put("leaves", transformPresenceMap(leaves))
+    }, "").toFrame())
+}
+
+suspend fun SendChannel<Frame>.sendSystem(channelId: String, extension: String, message: String, status: String) {
+    send(RealtimeMessage(RealtimeTopic.withChannelId(channelId), CHANNEL_EVENT_SYSTEM, buildJsonObject {
+        put("extension", extension)
+        put("message", message)
+        put("status", status)
+        put("channel", channelId)
     }, "").toFrame())
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature (closes #1346) 

This pull request adds support for handling "system" events in the realtime module, particularly for receiving replication-ready notifications from the server. The main changes introduce a new `system` callback and flow, update the join config to support the `replicationReady` option, and add tests for this new functionality.

**Support for system events and replication-ready notifications:**

* Added a new `RealtimeSystemPayload` data class to represent system event payloads from the server.
* Introduced `system` callback management in `CallbackManager`, including methods to add, trigger, and remove system callbacks, and a new `RealtimeCallbackId.System` type.
* Updated `RealtimeChannel` and its implementation to provide a `systemFlow()` method for clients to observe system events, with documentation explaining how to use it for replication-ready notifications.
* Modified `BroadcastJoinConfig` to add the `replicationReady` option, enabling clients to request replication-ready notifications when joining a channel. 
* Updated event handling to decode and trigger system events, and added comprehensive tests for the new callback and flow behaviors.

These changes collectively allow clients to opt-in to and handle system-level notifications, such as when the Postgres replication connection is established, improving observability and reliability for realtime features.
