### PR TITLE
Add tests for RestException and plugin-specific subtypes

### DIFF
--- a/Auth/src/commonTest/kotlin/AuthRestExceptionTest.kt
+++ b/Auth/src/commonTest/kotlin/AuthRestExceptionTest.kt
@@ -2,16 +2,21 @@ import io.github.jan.supabase.SupabaseClient
 import io.github.jan.supabase.SupabaseClientBuilder
 import io.github.jan.supabase.auth.Auth
 import io.github.jan.supabase.auth.auth
+import io.github.jan.supabase.auth.exception.AuthErrorCode
 import io.github.jan.supabase.auth.exception.AuthRestException
+import io.github.jan.supabase.auth.exception.AuthSessionMissingException
 import io.github.jan.supabase.auth.exception.AuthWeakPasswordException
 import io.github.jan.supabase.auth.minimalConfig
 import io.github.jan.supabase.auth.providers.builtin.Email
 import io.github.jan.supabase.exceptions.BadRequestRestException
+import io.github.jan.supabase.exceptions.UnauthorizedRestException
+import io.github.jan.supabase.exceptions.UnknownRestException
 import io.github.jan.supabase.testing.createMockedSupabaseClient
 import io.github.jan.supabase.testing.respondJson
 import io.ktor.client.engine.mock.respondError
 import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.add
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
@@ -23,6 +28,7 @@ import kotlin.test.assertFails
 import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
 import kotlin.test.assertIsNot
+import kotlin.test.assertNull
 
 class AuthRestExceptionTest {
 
@@ -50,10 +56,7 @@ class AuthRestExceptionTest {
                 }
             )
             val exception = assertFailsWith<AuthRestException> {
-                client.auth.signUpWith(Email) {
-                    email = "example@email.com"
-                    password = "password"
-                }
+                client.signUp()
             }
             assertEquals("error_code", exception.error)
             assertEquals("error_message", exception.errorDescription)
@@ -82,10 +85,7 @@ class AuthRestExceptionTest {
                 }
             )
             val exception = assertFailsWith<AuthWeakPasswordException> {
-                client.auth.signUpWith(Email) {
-                    email = "example@email.com"
-                    password = "password"
-                }
+                client.signUp()
             }
             assertEquals("weak_password", exception.error)
             assertEquals("error_message", exception.errorDescription)
@@ -108,10 +108,7 @@ class AuthRestExceptionTest {
                 }
             )
             val exception = assertFails {
-                client.auth.signUpWith(Email) {
-                    email = "example@email.com"
-                    password = "password"
-                }
+                client.signUp()
             }
             assertIsNot<AuthRestException>(exception)
             assertIs<BadRequestRestException>(exception)
@@ -128,14 +125,130 @@ class AuthRestExceptionTest {
                 }
             )
             val exception = assertFails {
-                client.auth.signUpWith(Email) {
-                    email = "example@email.com"
-                    password = "password"
-                }
+                client.signUp()
             }
             assertIsNot<AuthRestException>(exception)
             assertIs<BadRequestRestException>(exception)
         }
+    }
+
+    @Test
+    fun testKnownErrorCodeIsMappedToAuthErrorCode() {
+        runTest {
+            client = clientRespondingWith(
+                code = HttpStatusCode.BadRequest,
+                body = buildJsonObject {
+                    put("error_code", "invalid_credentials")
+                    put("message", "Invalid login credentials")
+                }
+            )
+            val exception = assertFailsWith<AuthRestException> {
+                client.signUp()
+            }
+            assertEquals(AuthErrorCode.InvalidCredentials, exception.errorCode)
+            assertEquals("invalid_credentials", exception.error)
+            assertEquals("Invalid login credentials", exception.errorDescription)
+            assertEquals(HttpStatusCode.BadRequest.value, exception.statusCode)
+        }
+    }
+
+    @Test
+    fun testUnknownErrorCodeHasNoAuthErrorCode() {
+        runTest {
+            client = clientRespondingWith(
+                code = HttpStatusCode.BadRequest,
+                body = buildJsonObject {
+                    put("error_code", "not_a_known_error_code")
+                    put("message", "error_message")
+                }
+            )
+            val exception = assertFailsWith<AuthRestException> {
+                client.signUp()
+            }
+            assertNull(exception.errorCode, "Unknown error codes should not be mapped to an AuthErrorCode")
+            assertEquals("not_a_known_error_code", exception.error)
+        }
+    }
+
+    @Test
+    fun testSessionNotFoundAuthRestException() {
+        runTest {
+            client = clientRespondingWith(
+                code = HttpStatusCode.BadRequest,
+                body = buildJsonObject {
+                    put("error_code", "session_not_found")
+                    put("message", "error_message")
+                }
+            )
+            val exception = assertFailsWith<AuthSessionMissingException> {
+                client.signUp()
+            }
+            assertEquals(AuthErrorCode.SessionNotFound, exception.errorCode)
+            assertEquals("session_not_found", exception.error)
+        }
+    }
+
+    @Test
+    fun testUnauthorizedErrorWithoutErrorCode() {
+        runTest {
+            client = clientRespondingWith(
+                code = HttpStatusCode.Unauthorized,
+                body = buildJsonObject {
+                    put("message", "error_message")
+                }
+            )
+            val exception = assertFailsWith<UnauthorizedRestException> {
+                client.signUp()
+            }
+            assertEquals("Unauthorized", exception.error)
+            assertEquals("error_message", exception.description)
+        }
+    }
+
+    @Test
+    fun testUnprocessableEntityErrorWithoutErrorCode() {
+        runTest {
+            client = clientRespondingWith(
+                code = HttpStatusCode.UnprocessableEntity,
+                body = buildJsonObject {
+                    put("message", "error_message")
+                }
+            )
+            val exception = assertFailsWith<BadRequestRestException> {
+                client.signUp()
+            }
+            assertEquals("Unprocessable Entity", exception.error)
+            assertEquals("error_message", exception.description)
+        }
+    }
+
+    @Test
+    fun testOtherStatusCodesWithoutErrorCodeAreUnknown() {
+        runTest {
+            client = clientRespondingWith(
+                code = HttpStatusCode.InternalServerError,
+                body = buildJsonObject {
+                    put("message", "error_message")
+                }
+            )
+            val exception = assertFailsWith<UnknownRestException> {
+                client.signUp()
+            }
+            assertEquals("Unknown Error", exception.error)
+            assertNull(exception.description)
+        }
+    }
+
+    private fun clientRespondingWith(code: HttpStatusCode, body: JsonObject) = createMockedSupabaseClient(
+        configuration = configuration,
+        requestHandler = {
+            respondJson(code = code, data = body)
+        }
+    )
+
+    private suspend fun SupabaseClient.signUp() = auth.signUpWith(Email) {
+        email = "example@email.com"
+        password = "password"
     }
 
     @AfterTest

--- a/Functions/src/commonTest/kotlin/FunctionsExceptionTest.kt
+++ b/Functions/src/commonTest/kotlin/FunctionsExceptionTest.kt
@@ -1,0 +1,96 @@
+import io.github.jan.supabase.SupabaseClient
+import io.github.jan.supabase.exceptions.BadRequestRestException
+import io.github.jan.supabase.exceptions.NotFoundRestException
+import io.github.jan.supabase.exceptions.RestException
+import io.github.jan.supabase.exceptions.UnauthorizedRestException
+import io.github.jan.supabase.exceptions.UnknownRestException
+import io.github.jan.supabase.functions.Functions
+import io.github.jan.supabase.functions.functions
+import io.github.jan.supabase.testing.createMockedSupabaseClient
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.test.runTest
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+
+private const val ERROR_BODY = "Missing authorization header"
+
+class FunctionsExceptionTest {
+
+    private lateinit var supabase: SupabaseClient
+
+    @Test
+    fun testUnauthorizedError() = runTest {
+        mockErrorResponse(HttpStatusCode.Unauthorized)
+        val exception = assertFailsWith<UnauthorizedRestException> {
+            supabase.functions.invoke(function = "function")
+        }
+        assertEquals(ERROR_BODY, exception.error)
+        assertEquals(HttpStatusCode.Unauthorized.value, exception.statusCode)
+    }
+
+    @Test
+    fun testNotFoundError() = runTest {
+        mockErrorResponse(HttpStatusCode.NotFound)
+        val exception = assertFailsWith<NotFoundRestException> {
+            supabase.functions.invoke(function = "function")
+        }
+        assertEquals(ERROR_BODY, exception.error)
+        assertEquals(HttpStatusCode.NotFound.value, exception.statusCode)
+    }
+
+    @Test
+    fun testBadRequestError() = runTest {
+        mockErrorResponse(HttpStatusCode.BadRequest)
+        val exception = assertFailsWith<BadRequestRestException> {
+            supabase.functions.invoke(function = "function")
+        }
+        assertEquals(ERROR_BODY, exception.error)
+        assertEquals(HttpStatusCode.BadRequest.value, exception.statusCode)
+    }
+
+    @Test
+    fun testOtherErrorsAreUnknown() = runTest {
+        mockErrorResponse(HttpStatusCode.InternalServerError)
+        val exception = assertFailsWith<UnknownRestException> {
+            supabase.functions.invoke(function = "function")
+        }
+        assertEquals(ERROR_BODY, exception.error)
+        assertEquals(HttpStatusCode.InternalServerError.value, exception.statusCode)
+    }
+
+    @Test
+    fun testErrorUsesRawResponseBody() = runTest {
+        //the functions plugin does not parse the error body, it uses the raw body as the error
+        mockErrorResponse(HttpStatusCode.BadRequest, """{"error":"boom"}""")
+        val exception = assertFailsWith<RestException> {
+            supabase.functions.invoke(function = "function")
+        }
+        assertEquals("""{"error":"boom"}""", exception.error)
+        assertNull(exception.description)
+    }
+
+    private fun mockErrorResponse(status: HttpStatusCode, body: String = ERROR_BODY) {
+        supabase = createMockedSupabaseClient(
+            configuration = {
+                install(Functions)
+            },
+            requestHandler = {
+                respond(body, status)
+            }
+        )
+    }
+
+    @AfterTest
+    fun cleanup() {
+        runTest {
+            if(::supabase.isInitialized) {
+                supabase.close()
+            }
+        }
+    }
+
+}

--- a/Postgrest/src/commonTest/kotlin/PostgrestTest.kt
+++ b/Postgrest/src/commonTest/kotlin/PostgrestTest.kt
@@ -672,6 +672,33 @@ class PostgrestTest {
     }
 
     @Test
+    fun testParseErrorResponseMessage() {
+        supabase = createMockedSupabaseClient(
+            configuration = configureClient
+        ) {
+            respond(
+                content = """{"message": "error msg", "hint": "error hint", "details": "error details", "code": "123"}""",
+                status = HttpStatusCode.BadRequest,
+                headers = headersOf(HttpHeaders.ContentType, "application/json")
+            )
+        }
+        runTest {
+            val exception = assertFailsWith<PostgrestRestException> {
+                supabase.postgrest["table"].select()
+            }
+            assertEquals(HttpStatusCode.BadRequest.value, exception.statusCode)
+            assertEquals(
+                """
+                    Code: 123
+                    Hint: error hint
+                    Details: "error details"
+                """.trimIndent(),
+                exception.description
+            )
+        }
+    }
+
+    @Test
     fun testParseErrorResponseNullBody() {
         supabase = createMockedSupabaseClient(
             configuration = configureClient

--- a/Storage/src/commonTest/kotlin/StorageExceptionTest.kt
+++ b/Storage/src/commonTest/kotlin/StorageExceptionTest.kt
@@ -1,0 +1,131 @@
+import io.github.jan.supabase.SupabaseClient
+import io.github.jan.supabase.SupabaseClientBuilder
+import io.github.jan.supabase.exceptions.BadRequestRestException
+import io.github.jan.supabase.exceptions.NotFoundRestException
+import io.github.jan.supabase.exceptions.UnauthorizedRestException
+import io.github.jan.supabase.exceptions.UnknownRestException
+import io.github.jan.supabase.storage.Storage
+import io.github.jan.supabase.storage.storage
+import io.github.jan.supabase.testing.createMockedSupabaseClient
+import io.github.jan.supabase.testing.respondJson
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class StorageExceptionTest {
+
+    private val configureClient: SupabaseClientBuilder.() -> Unit = {
+        install(Storage)
+    }
+    private lateinit var client: SupabaseClient
+
+    @Test
+    fun testUnauthorizedError() = runTest {
+        mockStorageError(statusCode = HttpStatusCode.Unauthorized.value, error = "Unauthorized", message = "Invalid jwt")
+        val exception = assertFailsWith<UnauthorizedRestException> {
+            client.storage.listBuckets()
+        }
+        assertEquals("Unauthorized", exception.error)
+        assertEquals("Invalid jwt", exception.description)
+    }
+
+    @Test
+    fun testBadRequestError() = runTest {
+        mockStorageError(statusCode = HttpStatusCode.BadRequest.value, error = "InvalidRequest", message = "Invalid bucket id")
+        val exception = assertFailsWith<BadRequestRestException> {
+            client.storage.listBuckets()
+        }
+        assertEquals("InvalidRequest", exception.error)
+        assertEquals("Invalid bucket id", exception.description)
+    }
+
+    @Test
+    fun testNotFoundError() = runTest {
+        mockStorageError(statusCode = HttpStatusCode.NotFound.value, error = "NoSuchBucket", message = "Bucket not found")
+        val exception = assertFailsWith<NotFoundRestException> {
+            client.storage.listBuckets()
+        }
+        assertEquals("NoSuchBucket", exception.error)
+        assertEquals("Bucket not found", exception.description)
+    }
+
+    @Test
+    fun testOtherStatusCodesInBodyAreUnknown() = runTest {
+        mockStorageError(statusCode = HttpStatusCode.Conflict.value, error = "Duplicate", message = "The resource already exists")
+        val exception = assertFailsWith<UnknownRestException> {
+            client.storage.listBuckets()
+        }
+        assertEquals("The resource already exists", exception.error)
+    }
+
+    @Test
+    fun testNonBadRequestResponsesAreUnknown() = runTest {
+        //the storage plugin only inspects the error body of responses with a 400 status code
+        client = createMockedSupabaseClient(
+            configuration = configureClient,
+            requestHandler = {
+                respondJson(
+                    code = HttpStatusCode.NotFound,
+                    data = buildJsonObject {
+                        put("statusCode", HttpStatusCode.NotFound.value)
+                        put("error", "NoSuchBucket")
+                        put("message", "Bucket not found")
+                    }
+                )
+            }
+        )
+        val exception = assertFailsWith<UnknownRestException> {
+            client.storage.listBuckets()
+        }
+        assertEquals(HttpStatusCode.NotFound.value, exception.statusCode)
+        assertTrue(exception.error.startsWith("Unknown error response"), "Actual error: ${exception.error}")
+    }
+
+    @Test
+    fun testUnparsableErrorBody() = runTest {
+        client = createMockedSupabaseClient(
+            configuration = configureClient,
+            requestHandler = {
+                respond("maintenance", HttpStatusCode.BadRequest)
+            }
+        )
+        val exception = assertFailsWith<BadRequestRestException> {
+            client.storage.listBuckets()
+        }
+        assertEquals("Unknown error", exception.error)
+        assertEquals(HttpStatusCode.BadRequest.value, exception.statusCode)
+    }
+
+    private fun mockStorageError(statusCode: Int, error: String, message: String) {
+        client = createMockedSupabaseClient(
+            configuration = configureClient,
+            requestHandler = {
+                respondJson(
+                    code = HttpStatusCode.BadRequest,
+                    data = buildJsonObject {
+                        put("statusCode", statusCode)
+                        put("error", error)
+                        put("message", message)
+                    }
+                )
+            }
+        )
+    }
+
+    @AfterTest
+    fun cleanup() {
+        runTest {
+            if(::client.isInitialized) {
+                client.close()
+            }
+        }
+    }
+
+}

--- a/Supabase/src/commonTest/kotlin/RestExceptionTest.kt
+++ b/Supabase/src/commonTest/kotlin/RestExceptionTest.kt
@@ -1,0 +1,151 @@
+import io.github.jan.supabase.exceptions.BadRequestRestException
+import io.github.jan.supabase.exceptions.NotFoundRestException
+import io.github.jan.supabase.exceptions.RestException
+import io.github.jan.supabase.exceptions.UnauthorizedRestException
+import io.github.jan.supabase.exceptions.UnknownRestException
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.request.header
+import io.ktor.client.request.request
+import io.ktor.client.statement.HttpResponse
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.test.runTest
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+private const val REQUEST_URL = "https://projectref.supabase.co/rest/v1/messages"
+private const val MASKED_URL = "https://pr.../rest/v1/messages"
+
+class RestExceptionTest {
+
+    private val clients = mutableListOf<HttpClient>()
+
+    @Test
+    fun testMessageContainsRequestInformation() = runTest {
+        val exception = RestException(
+            error = "error",
+            description = "description",
+            response = mockResponse(httpMethod = HttpMethod.Post)
+        )
+        val lines = assertNotNull(exception.message).lines()
+        assertEquals("error", lines[0])
+        assertEquals("description", lines[1])
+        assertEquals("URL: $MASKED_URL", lines[2])
+        assertTrue(lines[3].startsWith("Headers: "), "Expected a headers line, got '${lines[3]}'")
+        assertEquals("Http Method: POST", lines[4])
+    }
+
+    @Test
+    fun testMessageWithoutDescription() = runTest {
+        val exception = RestException(
+            error = "error",
+            description = null,
+            response = mockResponse()
+        )
+        val lines = assertNotNull(exception.message).lines()
+        assertEquals("error", lines[0])
+        assertEquals("URL: $MASKED_URL", lines[1])
+    }
+
+    @Test
+    fun testMessageMasksSensitiveInformation() = runTest {
+        val response = mockResponse(
+            requestHeaders = mapOf(
+                "apikey" to "project-anon-key",
+                HttpHeaders.Authorization to "Bearer super-secret-token",
+                "X-Client-Info" to "supabase-kt/3.7.0"
+            )
+        )
+        val message = assertNotNull(RestException("error", null, response).message)
+        assertFalse(message.contains("projectref"), "The host should be masked")
+        assertFalse(message.contains("project-anon-key"), "The api key should be masked")
+        assertFalse(message.contains("super-secret-token"), "The access token should be masked")
+        assertTrue(message.contains("pr... (len=16)"), "The api key should be masked with its length")
+        assertTrue(message.contains("Bearer su... (len=18)"), "The access token should keep its scheme")
+        assertTrue(message.contains("supabase-kt/3.7.0"), "Non-sensitive headers should not be masked")
+    }
+
+    @Test
+    fun testStatusCode() = runTest {
+        val exception = RestException("error", null, mockResponse(status = HttpStatusCode.NotFound))
+        assertEquals(HttpStatusCode.NotFound.value, exception.statusCode)
+    }
+
+    @Test
+    fun testUnauthorizedRestException() = runTest {
+        val response = mockResponse(status = HttpStatusCode.Unauthorized)
+        val exception = UnauthorizedRestException("unauthorized", response, "Invalid api key")
+        assertIs<RestException>(exception)
+        assertEquals("unauthorized", exception.error)
+        assertEquals("Invalid api key", exception.description)
+        assertEquals(HttpStatusCode.Unauthorized.value, exception.statusCode)
+    }
+
+    @Test
+    fun testBadRequestRestException() = runTest {
+        val response = mockResponse(status = HttpStatusCode.BadRequest)
+        val exception = BadRequestRestException("bad_request", response, "Missing field")
+        assertIs<RestException>(exception)
+        assertEquals("bad_request", exception.error)
+        assertEquals("Missing field", exception.description)
+        assertEquals(HttpStatusCode.BadRequest.value, exception.statusCode)
+    }
+
+    @Test
+    fun testNotFoundRestException() = runTest {
+        val response = mockResponse(status = HttpStatusCode.NotFound)
+        val exception = NotFoundRestException("not_found", response, "Unknown table")
+        assertIs<RestException>(exception)
+        assertEquals("not_found", exception.error)
+        assertEquals("Unknown table", exception.description)
+        assertEquals(HttpStatusCode.NotFound.value, exception.statusCode)
+    }
+
+    @Test
+    fun testUnknownRestException() = runTest {
+        val response = mockResponse(status = HttpStatusCode.InternalServerError)
+        val exception = UnknownRestException("unknown", response, "Something went wrong")
+        assertIs<RestException>(exception)
+        assertEquals("unknown", exception.error)
+        assertEquals("Something went wrong", exception.description)
+        assertEquals(HttpStatusCode.InternalServerError.value, exception.statusCode)
+    }
+
+    @Test
+    fun testSubclassesWithoutMessage() = runTest {
+        val response = mockResponse()
+        assertNull(UnauthorizedRestException("unauthorized", response).description)
+        assertNull(BadRequestRestException("bad_request", response).description)
+        assertNull(NotFoundRestException("not_found", response).description)
+        assertNull(UnknownRestException("unknown", response).description)
+    }
+
+    private suspend fun mockResponse(
+        status: HttpStatusCode = HttpStatusCode.BadRequest,
+        httpMethod: HttpMethod = HttpMethod.Get,
+        requestHeaders: Map<String, String> = emptyMap()
+    ): HttpResponse {
+        val client = HttpClient(MockEngine { respond("", status) })
+        clients.add(client)
+        return client.request(REQUEST_URL) {
+            method = httpMethod
+            requestHeaders.forEach { (key, value) -> header(key, value) }
+        }
+    }
+
+    @AfterTest
+    fun cleanup() {
+        clients.forEach { it.close() }
+        clients.clear()
+    }
+
+}


### PR DESCRIPTION
#1115  Covers the RestException base class and its four built-in subclasses, plus the Auth, Postgrest, Storage and Function parseErrorResponse implementations.

- new RestExceptionTest for the composed message, statusCode and header/URL masking
- new StorageExceptionTest and FunctionsExceptionTest (previously uncovered)
- six additional AuthRestException cases (error code mapping, session_not_found,
  401/422/other fallbacks)
- one PostgrestRestException case for its Code/Hint/Details description
