### PR TITLE
feat(storage): add purge methods for buckets and single objects

### DIFF
--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/BucketApi.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/BucketApi.kt
@@ -315,6 +315,9 @@ interface BucketApi {
      *
      * @param path The path (relative to the bucket) of the object to purge, e.g. `folder/avatar.png`.
      * @param options Optional purge cache options.
+     * @throws RestException or one of its subclasses if receiving an error response
+     * @throws HttpRequestTimeoutException if the request timed out
+     * @throws HttpRequestException on network related issues
      */
     suspend fun purgeCache(
         path: String,

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/BucketApi.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/BucketApi.kt
@@ -297,6 +297,31 @@ interface BucketApi {
     suspend fun changePublicStatusTo(public: Boolean)
 
     /**
+     * Purges the CDN cache for a single object in this bucket.
+     *
+     * Maps to `DELETE /cdn/{bucket}/{path}` on the Storage API. The server
+     * issues a CDN invalidation for the object and returns `{ message: 'success' }`.
+     *
+     * **Requires the `service_role` key.** The underlying endpoint enforces
+     * `service_role` JWT — calls made with the anon key or a user JWT will be
+     * rejected by the server.
+     *
+     * **Hosted CDN feature.** On self-hosted Supabase, the Storage service must
+     * have `CDN_PURGE_ENDPOINT_URL` configured and the `purgeCache` tenant
+     * feature enabled, otherwise the server returns an error.
+     *
+     * Operates on a single object path. There is no wildcard or recursion: pass
+     * the exact path of the object you want invalidated.
+     *
+     * @param path The path (relative to the bucket) of the object to purge, e.g. `folder/avatar.png`.
+     * @param options Optional purge cache options.
+     */
+    suspend fun purgeCache(
+        path: String,
+        options: PurgeCacheOptions.() -> Unit = {}
+    )
+
+    /**
      * Returns the public url of [path]
      * @throws RestException or one of its subclasses if receiving an error response
      * @throws HttpRequestTimeoutException if the request timed out

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/BucketApiImpl.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/BucketApiImpl.kt
@@ -11,6 +11,7 @@ import io.github.jan.supabase.storage.resumable.ResumableClientImpl
 import io.ktor.client.call.body
 import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.client.request.header
+import io.ktor.client.request.parameter
 import io.ktor.client.request.setBody
 import io.ktor.client.request.url
 import io.ktor.client.statement.bodyAsChannel
@@ -52,6 +53,15 @@ internal class BucketApiImpl(
     override val supabaseClient = storage.supabaseClient
 
     override val resumable = ResumableClientImpl(this, resumableCache)
+
+    override suspend fun purgeCache(path: String, options: PurgeCacheOptions.() -> Unit) {
+        val options = PurgeCacheOptions().apply(options)
+        storage.api.delete("cdn/$bucketId/$path") {
+            if(options.transformations) {
+                parameter("transformations", true)
+            }
+        }
+    }
 
     override fun setHeader(name: String, value: String): BucketApi {
         headers = headers {

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/BucketApiImpl.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/BucketApiImpl.kt
@@ -23,6 +23,7 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.Url
 import io.ktor.http.content.OutgoingContent
 import io.ktor.http.defaultForFilePath
+import io.ktor.http.encodeURLPath
 import io.ktor.http.formUrlEncode
 import io.ktor.http.headers
 import io.ktor.utils.io.ByteReadChannel
@@ -56,7 +57,7 @@ internal class BucketApiImpl(
 
     override suspend fun purgeCache(path: String, options: PurgeCacheOptions.() -> Unit) {
         val options = PurgeCacheOptions().apply(options)
-        storage.api.delete("cdn/$bucketId/$path") {
+        storage.api.delete("cdn/${storagePath(bucketId, path)}") {
             if(options.transformations) {
                 parameter("transformations", true)
             }
@@ -92,7 +93,7 @@ internal class BucketApiImpl(
     }
 
     override suspend fun createSignedUploadUrl(path: String, upsert: Boolean): UploadSignedUrl {
-        val result = api.post("upload/sign/$bucketId/$path") {
+        val result = api.post("upload/sign/${storagePath(bucketId, path)}") {
             header(UPSERT_HEADER, upsert.toString())
         }
         val urlPath = result.safeBody<JsonObject>()["url"]?.jsonPrimitive?.content?.substring(1)
@@ -116,7 +117,7 @@ internal class BucketApiImpl(
         )
 
     override suspend fun delete(paths: Collection<String>) {
-        api.deleteJson(bucketId, buildJsonObject {
+        api.deleteJson(bucketId.encodeURLPath(), buildJsonObject {
             putJsonArray("prefixes") {
                 paths.forEach(this::add)
             }
@@ -148,7 +149,7 @@ internal class BucketApiImpl(
     ): String {
         val modifier = SignedUrlBuilder().apply(builder)
         val transformation = modifier.transformation
-        val body = api.postJson("sign/$bucketId/$path", buildJsonObject {
+        val body = api.postJson("sign/${storagePath(bucketId, path)}", buildJsonObject {
             put("expiresIn", expiresIn.inWholeSeconds)
             transformation?.let {
                 val transform = buildJsonObject {
@@ -176,7 +177,7 @@ internal class BucketApiImpl(
         builder: SignedUrlsBuilder.() -> Unit
     ): List<SignedUrl> {
         val modifier = SignedUrlsBuilder().apply(builder)
-        val body = api.postJson("sign/$bucketId", buildJsonObject {
+        val body = api.postJson("sign/${storagePath(bucketId)}", buildJsonObject {
             putJsonArray("paths") {
                 paths.forEach(this::add)
             }
@@ -276,20 +277,20 @@ internal class BucketApiImpl(
         prefix: String,
         filter: StorageListFilter.Files.() -> Unit
     ): List<FileObject> {
-        return api.postJson("list/$bucketId", buildJsonObject {
+        return api.postJson("list/${storagePath(bucketId)}", buildJsonObject {
             put("prefix", prefix)
             putJsonObject(StorageListFilter.Files().apply(filter).buildBody())
         }).safeBody()
     }
 
     override suspend fun info(path: String): FileObjectV2 {
-        val response = api.get("info/$bucketId/$path")
+        val response = api.get("info/${storagePath(bucketId, path)}")
         return response.safeBody<FileObjectV2>().copy(serializer = storage.serializer)
     }
 
     override suspend fun exists(path: String): Boolean {
         try {
-            api.request("$bucketId/$path") {
+            api.request(storagePath(bucketId, path)) {
                 method = HttpMethod.Head
             }
             return true
@@ -299,9 +300,9 @@ internal class BucketApiImpl(
         }
     }
 
-    private fun defaultUploadUrl(path: String) = "$bucketId/$path"
+    private fun defaultUploadUrl(path: String) = storagePath(bucketId, path)
 
-    private fun uploadToSignedUrlUrl(path: String, token: String) = "upload/sign/$bucketId/$path?token=$token"
+    private fun uploadToSignedUrlUrl(path: String, token: String) = "upload/sign/${storagePath(bucketId, path)}?token=$token"
 
     internal suspend fun uploadOrUpdate(
         method: HttpMethod,
@@ -309,7 +310,7 @@ internal class BucketApiImpl(
         data: UploadData,
         options: UploadOptionBuilder.() -> Unit,
     ): FileUploadResponse {
-        val path = url.substringAfter("$bucketId/").substringBeforeLast("?")
+        val path = url.substringAfter("${storagePath(bucketId)}/").substringBeforeLast("?")
         val optionBuilder = UploadOptionBuilder(storage.serializer).apply(options)
         val response = api.request(url) {
             this.method = method
@@ -346,12 +347,12 @@ internal class BucketApiImpl(
     }
 
     override fun authenticatedUrl(path: String): String =
-        storage.resolveUrl("object/authenticated/$bucketId/$path")
+        storage.resolveUrl("object/authenticated/${storagePath(bucketId, path)}")
 
     override fun publicUrl(path: String, builder: PublicUrlBuilder.() -> Unit): String {
         val modifier = PublicUrlBuilder().apply(builder)
         return buildUrl(storage.resolveUrl(
-            if(modifier.transformation != null) "render/image/public/$bucketId/$path" else "object/public/$bucketId/$path"
+            if(modifier.transformation != null) "render/image/public/${storagePath(bucketId, path)}" else "object/public/${storagePath(bucketId, path)}"
         )) {
             modifier.transformation?.let { parameters.appendAll(it.query()) }
             modifier.cacheNonce?.let { parameters.append("cacheNonce", it) }
@@ -364,7 +365,7 @@ internal class BucketApiImpl(
         transform: ImageTransformation.() -> Unit
     ): String {
         val transformation = ImageTransformation().apply(transform).query().formUrlEncode()
-        return storage.resolveUrl("render/image/authenticated/$bucketId/$path${if (transformation.isNotBlank()) "?$transformation" else ""}")
+        return storage.resolveUrl("render/image/authenticated/${storagePath(bucketId, path)}${if (transformation.isNotBlank()) "?$transformation" else ""}")
     }
 
 }

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/BucketApiImpl.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/BucketApiImpl.kt
@@ -23,7 +23,6 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.Url
 import io.ktor.http.content.OutgoingContent
 import io.ktor.http.defaultForFilePath
-import io.ktor.http.encodeURLPath
 import io.ktor.http.formUrlEncode
 import io.ktor.http.headers
 import io.ktor.utils.io.ByteReadChannel
@@ -117,7 +116,7 @@ internal class BucketApiImpl(
         )
 
     override suspend fun delete(paths: Collection<String>) {
-        api.deleteJson(bucketId.encodeURLPath(), buildJsonObject {
+        api.deleteJson(storagePath(bucketId), buildJsonObject {
             putJsonArray("prefixes") {
                 paths.forEach(this::add)
             }

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/PurgeCacheOptions.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/PurgeCacheOptions.kt
@@ -1,0 +1,11 @@
+package io.github.jan.supabase.storage
+
+class PurgeCacheOptions {
+
+    /**
+     * If true, purges only the transformations (resized/formatted variants) for the object or bucket,
+     * leaving the original cached file intact. If omitted, purges all cached versions.
+     */
+    var transformations: Boolean = true
+
+}

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/PurgeCacheOptions.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/PurgeCacheOptions.kt
@@ -1,5 +1,8 @@
 package io.github.jan.supabase.storage
 
+/**
+ * Options for purging the cache in Supabase Storage.
+ */
 class PurgeCacheOptions {
 
     /**

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/Storage.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/Storage.kt
@@ -5,6 +5,7 @@ import io.github.jan.supabase.SupabaseSerializer
 import io.github.jan.supabase.annotations.SupabaseExperimental
 import io.github.jan.supabase.annotations.SupabaseInternal
 import io.github.jan.supabase.auth.AuthDependentPluginConfig
+import io.github.jan.supabase.auth.api.AuthenticatedSupabaseApi
 import io.github.jan.supabase.auth.api.authenticatedSupabaseApi
 import io.github.jan.supabase.bodyOrNull
 import io.github.jan.supabase.exceptions.BadRequestRestException
@@ -31,6 +32,7 @@ import io.github.jan.supabase.storage.vectors.StorageVectorsClient
 import io.github.jan.supabase.storage.vectors.StorageVectorsClientImpl
 import io.ktor.client.plugins.HttpRequestTimeoutException
 import io.ktor.client.plugins.timeout
+import io.ktor.client.request.parameter
 import io.ktor.client.statement.HttpResponse
 import io.ktor.http.HttpStatusCode
 import kotlinx.serialization.json.JsonArray
@@ -77,6 +79,12 @@ interface Storage : MainPlugin<Storage.Config>, CustomSerializationPlugin {
      */
     @SupabaseExperimental
     val vectors: StorageVectorsClient
+
+    /**
+     * The API used for network requests.
+     */
+    @SupabaseInternal
+    val api: AuthenticatedSupabaseApi
 
     /**
      * Creates a new bucket in the storage
@@ -137,6 +145,28 @@ interface Storage : MainPlugin<Storage.Config>, CustomSerializationPlugin {
      * Builder function for interacting with a bucket with the given [bucketId]
      */
     fun from(bucketId: String): BucketApi = get(bucketId)
+
+    /**
+     * Purges the CDN cache for an entire bucket.
+     *
+     * Maps to `DELETE /cdn/{bucket}` on the Storage API. The server
+     * issues a CDN invalidation for the bucket.
+     *
+     * **Requires the `service_role` key.** The underlying endpoint enforces
+     * `service_role` JWT — calls made with the anon key or a user JWT will be
+     * rejected by the server.
+     *
+     * **Hosted CDN feature.** On self-hosted Supabase, the Storage service must
+     * have `CDN_PURGE_ENDPOINT_URL` configured and the `purgeCache` tenant
+     * feature enabled, otherwise the server returns an error.
+     *
+     * @param id The unique identifier of the bucket you would like to purge from cache.
+     * @param options Optional purge cache options.
+     */
+    suspend fun purgeBucketCache(
+        id: String,
+        options: PurgeCacheOptions.() -> Unit = {}
+    )
 
     /**
      * Config for the storage plugin
@@ -218,7 +248,7 @@ internal class StorageImpl(override val supabaseClient: SupabaseClient, override
     override val logger: SupabaseLogger = supabaseClient.createLogger(Storage.LOGGING_TAG, config)
 
     @OptIn(SupabaseInternal::class)
-    internal val api = supabaseClient.authenticatedSupabaseApi(this, defaultRequest = {
+    override val api = supabaseClient.authenticatedSupabaseApi(this, defaultRequest = {
         timeout {
             requestTimeoutMillis = config.transferTimeout.inWholeMilliseconds
         }
@@ -299,6 +329,15 @@ internal class StorageImpl(override val supabaseClient: SupabaseClient, override
             HttpStatusCode.BadRequest.value -> throw BadRequestRestException(error.error, response, error.message)
             HttpStatusCode.NotFound.value -> throw NotFoundRestException(error.error, response, error.message)
             else -> throw UnknownRestException(error.message, response)
+        }
+    }
+
+    override suspend fun purgeBucketCache(id: String, options: PurgeCacheOptions.() -> Unit) {
+        val options = PurgeCacheOptions().apply(options)
+        api.delete("cdn/$id") {
+            if(options.transformations) {
+                parameter("transformations", true)
+            }
         }
     }
 

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/Storage.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/Storage.kt
@@ -270,10 +270,10 @@ internal class StorageImpl(override val supabaseClient: SupabaseClient, override
         return response.safeBody()
     }
 
-    override suspend fun getBucket(bucketId: String): Bucket? = api.get("bucket/$bucketId").safeBody()
+    override suspend fun getBucket(bucketId: String): Bucket? = api.get("bucket/${storagePath(bucketId)}").safeBody()
 
     override suspend fun deleteBucket(bucketId: String) {
-        api.delete("bucket/$bucketId")
+        api.delete("bucket/${storagePath(bucketId)}")
     }
 
     override suspend fun createBucket(id: String, builder: BucketBuilder.() -> Unit) {
@@ -307,11 +307,11 @@ internal class StorageImpl(override val supabaseClient: SupabaseClient, override
                 put("file_size_limit", it.value)
             }
         }
-        api.putJson("bucket/$id", body)
+        api.putJson("bucket/${storagePath(id)}", body)
     }
 
     override suspend fun emptyBucket(bucketId: String) {
-        api.post("bucket/$bucketId/empty")
+        api.post("bucket/${storagePath(bucketId)}/empty")
     }
 
     override fun get(bucketId: String): BucketApi = BucketApiImpl(bucketId, this, api.resolve("object"), config.resumable.cache ?: createDefaultResumableCache())
@@ -334,7 +334,7 @@ internal class StorageImpl(override val supabaseClient: SupabaseClient, override
 
     override suspend fun purgeBucketCache(id: String, options: PurgeCacheOptions.() -> Unit) {
         val options = PurgeCacheOptions().apply(options)
-        api.delete("cdn/$id") {
+        api.delete("cdn/${storagePath(id)}") {
             if(options.transformations) {
                 parameter("transformations", true)
             }

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/Utils.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/Utils.kt
@@ -1,5 +1,6 @@
 package io.github.jan.supabase.storage
 
+import io.ktor.http.encodeURLPath
 import kotlinx.serialization.json.JsonObjectBuilder
 import kotlinx.serialization.json.put
 
@@ -10,3 +11,10 @@ internal fun JsonObjectBuilder.putImageTransformation(transformation: ImageTrans
     transformation.quality?.let { put("quality", it) }
     transformation.format?.let { put("format", it) }
 }
+
+internal fun storagePath(bucketId: String, path: String? = null) =
+    bucketId.encodeURLPath() + if (path != null) {
+        "/${path.split("/").joinToString("/") { it.encodeURLPath() }}"
+    } else {
+        ""
+    }

--- a/Storage/src/commonTest/kotlin/BucketApiTest.kt
+++ b/Storage/src/commonTest/kotlin/BucketApiTest.kt
@@ -23,6 +23,7 @@ import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpMethod
 import io.ktor.http.HttpStatusCode
+import io.ktor.http.encodeURLPath
 import io.ktor.http.headersOf
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
@@ -239,28 +240,36 @@ class BucketApiTest {
     @Test
     fun testPurgeCache() {
         runTest {
-            val expectedPath = "data.png"
+            val specialBucketId = "bucket name #1"
+            val expectedPath = "data #1.png"
             client = createMockedSupabaseClient(configuration = configureClient) {
                 assertMethodIs(HttpMethod.Delete, it.method)
-                assertPathIs("/object/cdn/$bucketId/$expectedPath", it.url.pathAfterVersion())
+                assertPathIs(
+                    "/object/cdn/${specialBucketId.encodeURLPath()}/${expectedPath.encodeURLPath()}",
+                    it.url.pathAfterVersion()
+                )
                 assertEquals("true", it.url.parameters["transformations"], "Transformations should be true")
                 respond("")
             }
-            client.storage[bucketId].purgeCache(expectedPath)
+            client.storage[specialBucketId].purgeCache(expectedPath)
         }
     }
 
     @Test
     fun testPurgeCacheWithoutTransformations() {
         runTest {
-            val expectedPath = "data.png"
+            val specialBucketId = "bucket name #1"
+            val expectedPath = "data #1.png"
             client = createMockedSupabaseClient(configuration = configureClient) {
                 assertMethodIs(HttpMethod.Delete, it.method)
-                assertPathIs("/object/cdn/$bucketId/$expectedPath", it.url.pathAfterVersion())
+                assertPathIs(
+                    "/object/cdn/${specialBucketId.encodeURLPath()}/${expectedPath.encodeURLPath()}",
+                    it.url.pathAfterVersion()
+                )
                 assertNull(it.url.parameters["transformations"], "Transformations should not be set")
                 respond("")
             }
-            client.storage[bucketId].purgeCache(expectedPath) {
+            client.storage[specialBucketId].purgeCache(expectedPath) {
                 transformations = false
             }
         }

--- a/Storage/src/commonTest/kotlin/BucketApiTest.kt
+++ b/Storage/src/commonTest/kotlin/BucketApiTest.kt
@@ -237,6 +237,36 @@ class BucketApiTest {
     }
 
     @Test
+    fun testPurgeCache() {
+        runTest {
+            val expectedPath = "data.png"
+            client = createMockedSupabaseClient(configuration = configureClient) {
+                assertMethodIs(HttpMethod.Delete, it.method)
+                assertPathIs("/object/cdn/$bucketId/$expectedPath", it.url.pathAfterVersion())
+                assertEquals("true", it.url.parameters["transformations"], "Transformations should be true")
+                respond("")
+            }
+            client.storage[bucketId].purgeCache(expectedPath)
+        }
+    }
+
+    @Test
+    fun testPurgeCacheWithoutTransformations() {
+        runTest {
+            val expectedPath = "data.png"
+            client = createMockedSupabaseClient(configuration = configureClient) {
+                assertMethodIs(HttpMethod.Delete, it.method)
+                assertPathIs("/object/cdn/$bucketId/$expectedPath", it.url.pathAfterVersion())
+                assertNull(it.url.parameters["transformations"], "Transformations should not be set")
+                respond("")
+            }
+            client.storage[bucketId].purgeCache(expectedPath) {
+                transformations = false
+            }
+        }
+    }
+
+    @Test
     fun testMove() {
         runTest {
             val expectedFrom = "data.png"

--- a/Storage/src/commonTest/kotlin/BucketApiTest.kt
+++ b/Storage/src/commonTest/kotlin/BucketApiTest.kt
@@ -245,7 +245,7 @@ class BucketApiTest {
             client = createMockedSupabaseClient(configuration = configureClient) {
                 assertMethodIs(HttpMethod.Delete, it.method)
                 assertPathIs(
-                    "/object/cdn/${specialBucketId.encodeURLPath()}/${expectedPath.encodeURLPath()}",
+                    "/cdn/${specialBucketId.encodeURLPath()}/${expectedPath.encodeURLPath()}",
                     it.url.pathAfterVersion()
                 )
                 assertEquals("true", it.url.parameters["transformations"], "Transformations should be true")
@@ -263,7 +263,7 @@ class BucketApiTest {
             client = createMockedSupabaseClient(configuration = configureClient) {
                 assertMethodIs(HttpMethod.Delete, it.method)
                 assertPathIs(
-                    "/object/cdn/${specialBucketId.encodeURLPath()}/${expectedPath.encodeURLPath()}",
+                    "/cdn/${specialBucketId.encodeURLPath()}/${expectedPath.encodeURLPath()}",
                     it.url.pathAfterVersion()
                 )
                 assertNull(it.url.parameters["transformations"], "Transformations should not be set")

--- a/Storage/src/commonTest/kotlin/StorageTest.kt
+++ b/Storage/src/commonTest/kotlin/StorageTest.kt
@@ -15,6 +15,7 @@ import io.github.jan.supabase.testing.pathAfterVersion
 import io.github.jan.supabase.testing.toJsonElement
 import io.ktor.client.engine.mock.respond
 import io.ktor.http.HttpMethod
+import io.ktor.http.encodeURLPath
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.boolean
@@ -116,9 +117,9 @@ class StorageTest {
     @Test
     fun testPurgeBucketCache() {
         runTest {
-            val name = "test-bucket"
+            val name = "bucket name #1"
             client = createMockedSupabaseClient(configuration = configureClient) {
-                assertPathIs("/cdn/$name", it.url.pathAfterVersion())
+                assertPathIs("/cdn/${name.encodeURLPath()}", it.url.pathAfterVersion())
                 assertMethodIs(HttpMethod.Delete, it.method)
                 assertEquals("true", it.url.parameters["transformations"], "Transformations should be true")
                 respond("")
@@ -130,9 +131,9 @@ class StorageTest {
     @Test
     fun testPurgeBucketCacheWithoutTransformations() {
         runTest {
-            val name = "test-bucket"
+            val name = "bucket name #1"
             client = createMockedSupabaseClient(configuration = configureClient) {
-                assertPathIs("/cdn/$name", it.url.pathAfterVersion())
+                assertPathIs("/cdn/${name.encodeURLPath()}", it.url.pathAfterVersion())
                 assertMethodIs(HttpMethod.Delete, it.method)
                 assertNull(it.url.parameters["transformations"], "Transformations should not be set")
                 respond("")

--- a/Storage/src/commonTest/kotlin/StorageTest.kt
+++ b/Storage/src/commonTest/kotlin/StorageTest.kt
@@ -24,6 +24,7 @@ import kotlinx.serialization.json.jsonPrimitive
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlin.time.Clock
 
 class StorageTest {
@@ -109,6 +110,36 @@ class StorageTest {
                 respond("")
             }
             client.storage.emptyBucket(name)
+        }
+    }
+
+    @Test
+    fun testPurgeBucketCache() {
+        runTest {
+            val name = "test-bucket"
+            client = createMockedSupabaseClient(configuration = configureClient) {
+                assertPathIs("/cdn/$name", it.url.pathAfterVersion())
+                assertMethodIs(HttpMethod.Delete, it.method)
+                assertEquals("true", it.url.parameters["transformations"], "Transformations should be true")
+                respond("")
+            }
+            client.storage.purgeBucketCache(name)
+        }
+    }
+
+    @Test
+    fun testPurgeBucketCacheWithoutTransformations() {
+        runTest {
+            val name = "test-bucket"
+            client = createMockedSupabaseClient(configuration = configureClient) {
+                assertPathIs("/cdn/$name", it.url.pathAfterVersion())
+                assertMethodIs(HttpMethod.Delete, it.method)
+                assertNull(it.url.parameters["transformations"], "Transformations should not be set")
+                respond("")
+            }
+            client.storage.purgeBucketCache(name) {
+                transformations = false
+            }
         }
     }
 

--- a/refactor.MD
+++ b/refactor.MD
@@ -2,6 +2,13 @@
 
 This document holds suggested refactors that can be done in the transition of migrating the library to an official one. A lot of them come from the community. Features which are unlikely are highlighted as such.
 
+## Core
+
+### Separate ID value classes
+
+Currently, all IDs (UID, bucket id, etc.) are held as a string. This makes them hard to (1) distinguish (2) ensure type safety. 
+Also, if IDs need additional transformations (like ensuring correct URL encoding), a separate class would make this cleaner then using a helper method each time.
+
 ## Auth
 
 ### Separate `auth` and `auth-native` modules. This text is copied from #1291. This approach has been favorised by the community.

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -425,6 +425,14 @@ features:
   storage.file_buckets.download: implemented
   storage.file_buckets.list_files: implemented
   storage.file_buckets.move: implemented
+  storage.file_buckets.purge_bucket_cache:
+    status: implemented
+    symbols:
+      - Storage.purgeBucketCache
+  storage.file_buckets.purge_cache:
+    status: implemented
+    symbols:
+      - BucketApi.purgeCache
   storage.file_buckets.copy: implemented
   storage.file_buckets.remove: implemented
   storage.file_buckets.get_public_url: implemented


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature (closes #1345, closes #1371)

This pull request adds support for purging the CDN cache for individual objects and entire buckets in the Supabase Storage client. It introduces new API methods, options for controlling cache purging behavior, and comprehensive tests to ensure correct functionality. These features require the `service_role` key and are compatible with hosted Supabase or properly configured self-hosted instances.

**New CDN Cache Purge Features:**

* Added `purgeCache` method to `BucketApi` for purging the CDN cache of a single object, with support for optional transformation-only purges. 
* Added `purgeBucketCache` method to `Storage` for purging the CDN cache of an entire bucket, also supporting transformation-only purges.

**Options and Configuration:**

* Introduced `PurgeCacheOptions` class to specify whether to purge only transformations or all cached versions during a cache purge.

**API and Implementation Updates:**

* Exposed the underlying `AuthenticatedSupabaseApi` as a property on the `Storage` interface for internal use.

**Testing:**

* Added unit tests for both `purgeCache` and `purgeBucketCache`, covering scenarios with and without the `transformations` option. 