### PR TITLE
feat(storage): add new storage exception and expose `code` parameter

### DIFF
--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/BucketApi.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/BucketApi.kt
@@ -46,7 +46,7 @@ interface BucketApi {
      * @param options Additional options for the upload
      * @return the key to the uploaded file
      * @throws IllegalArgumentException if data to upload is empty
-     * @throws RestException or one of its subclasses if receiving an error response
+     * @throws StorageRestException containing an error code, if receiving an error response
      * @throws HttpRequestTimeoutException if the request timed out
      * @throws HttpRequestException on network related issues
      */
@@ -61,7 +61,7 @@ interface BucketApi {
      * @param data The data to upload
      * @param options Additional options for the upload
      * @return the key to the uploaded file
-     * @throws RestException or one of its subclasses if receiving an error response
+     * @throws StorageRestException containing an error code, if receiving an error response
      * @throws HttpRequestTimeoutException if the request timed out
      * @throws HttpRequestException on network related issues
      */
@@ -75,6 +75,9 @@ interface BucketApi {
      * @param options Additional options for the upload
      * @return the key of the uploaded file
      * @throws IllegalArgumentException if data to upload is empty
+     * @throws StorageRestException containing an error code, if receiving an error response
+     * @throws HttpRequestTimeoutException if the request timed out
+     * @throws HttpRequestException on network related issues
      */
     suspend fun uploadToSignedUrl(
         path: String,
@@ -93,7 +96,7 @@ interface BucketApi {
      * @param data The data to upload
      * @param options Additional options for the upload
      * @return the key of the uploaded file
-     * @throws RestException or one of its subclasses if receiving an error response
+     * @throws StorageRestException containing an error code, if receiving an error response
      * @throws HttpRequestTimeoutException if the request timed out
      * @throws HttpRequestException on network related issues
      * @throws HttpRequestException on network related issues
@@ -107,7 +110,7 @@ interface BucketApi {
      * @param options Additional options for the upload
      * @return the key to the updated file
      * @throws IllegalArgumentException if data to upload is empty
-     * @throws RestException or one of its subclasses if receiving an error response
+     * @throws StorageRestException containing an error code, if receiving an error response
      * @throws HttpRequestTimeoutException if the request timed out
      * @throws HttpRequestException on network related issues
      */
@@ -122,7 +125,7 @@ interface BucketApi {
      * @param data The new data
      * @param options Additional options for the upload
      * @return the key to the updated file
-     * @throws RestException or one of its subclasses if receiving an error response
+     * @throws StorageRestException containing an error code, if receiving an error response
      * @throws HttpRequestTimeoutException if the request timed out
      * @throws HttpRequestException on network related issues
      */
@@ -131,7 +134,7 @@ interface BucketApi {
     /**
      * Deletes all files in [bucketId] with in [paths]
      * @param paths The paths to delete
-     * @throws RestException or one of its subclasses if receiving an error response
+     * @throws StorageRestException containing an error code, if receiving an error response
      * @throws HttpRequestTimeoutException if the request timed out
      * @throws HttpRequestException on network related issues
      */
@@ -140,7 +143,7 @@ interface BucketApi {
     /**
      * Deletes all files in [bucketId] with in [paths]
      * @param paths The paths to delete
-     * @throws RestException or one of its subclasses if receiving an error response
+     * @throws StorageRestException containing an error code, if receiving an error response
      * @throws HttpRequestTimeoutException if the request timed out
      * @throws HttpRequestException on network related issues
      */
@@ -151,7 +154,7 @@ interface BucketApi {
      * @param from The path to move from
      * @param to The path to move to
      * @param destinationBucket The bucket to move the file to. If null, the file will be moved within the same bucket
-     * @throws RestException or one of its subclasses if receiving an error response
+     * @throws StorageRestException containing an error code, if receiving an error response
      * @throws HttpRequestTimeoutException if the request timed out
      * @throws HttpRequestException on network related issues
      */
@@ -162,7 +165,7 @@ interface BucketApi {
      * @param from The path to copy from
      * @param to The path to copy to
      * @param destinationBucket The destination bucket to copy to. If null, the current bucket is used
-     * @throws RestException or one of its subclasses if receiving an error response
+     * @throws StorageRestException containing an error code, if receiving an error response
      * @throws HttpRequestTimeoutException if the request timed out
      * @throws HttpRequestException on network related issues
      */
@@ -183,7 +186,7 @@ interface BucketApi {
      * @param builder Optional modifier to add a [transformation][SignedUrlBuilder.transformation],
      * [force-download][SignedUrlBuilder.download] or [cacheNonce][BucketUrlBuilder.cacheNonce] to the created url
      * @return The url to download the file
-     * @throws RestException or one of its subclasses if receiving an error response
+     * @throws StorageRestException containing an error code, if receiving an error response
      * @throws HttpRequestTimeoutException if the request timed out
      * @throws HttpRequestException on network related issues
      */
@@ -195,7 +198,7 @@ interface BucketApi {
      * @param paths The paths to create urls for
      * @param builder Optional modifier to add a [force-download][SignedUrlsBuilder.download] or [cacheNonce][BucketUrlBuilder.cacheNonce] to the created urls
      * @return A list of [SignedUrl]s
-     * @throws RestException or one of its subclasses if receiving an error response
+     * @throws StorageRestException containing an error code, if receiving an error response
      * @throws HttpRequestTimeoutException if the request timed out
      * @throws HttpRequestException on network related issues
      */
@@ -207,7 +210,7 @@ interface BucketApi {
      * @param paths The paths to create urls for
      * @param builder Optional modifier to add a [force-download][SignedUrlsBuilder.download] or [cacheNonce][BucketUrlBuilder.cacheNonce] to the created urls
      * @return A list of [SignedUrl]s
-     * @throws RestException or one of its subclasses if receiving an error response
+     * @throws StorageRestException containing an error code, if receiving an error response
      * @throws HttpRequestTimeoutException if the request timed out
      * @throws HttpRequestException on network related issues
      */
@@ -218,7 +221,7 @@ interface BucketApi {
      * @param path The path to download
      * @param options Additional options for the download
      * @return The file as a byte array
-     * @throws RestException or one of its subclasses if receiving an error response
+     * @throws StorageRestException containing an error code, if receiving an error response
      * @throws HttpRequestTimeoutException if the request timed out
      * @throws HttpRequestException on network related issues
      */
@@ -229,7 +232,7 @@ interface BucketApi {
      * @param path The path to download
      * @param channel The channel to write the data to
      * @param options Additional options for the download
-     * @throws RestException or one of its subclasses if receiving an error response
+     * @throws StorageRestException containing an error code, if receiving an error response
      * @throws HttpRequestTimeoutException if the request timed out
      * @throws HttpRequestException on network related issues
      */
@@ -240,7 +243,7 @@ interface BucketApi {
      * @param path The path to download
      * @param options Additional options for the download
      * @return The file as a byte array
-     * @throws RestException or one of its subclasses if receiving an error response
+     * @throws StorageRestException containing an error code, if receiving an error response
      * @throws HttpRequestTimeoutException if the request timed out
      * @throws HttpRequestException on network related issues
      */
@@ -251,7 +254,7 @@ interface BucketApi {
      * @param path The path to download
      * @param channel The channel to write the data to
      * @param options Additional options for the download
-     * @throws RestException or one of its subclasses if receiving an error response
+     * @throws StorageRestException containing an error code, if receiving an error response
      * @throws HttpRequestTimeoutException if the request timed out
      * @throws HttpRequestException on network related issues
      */
@@ -260,7 +263,7 @@ interface BucketApi {
 
     /**
      * Searches for files with the given [prefix] and [filter]
-     * @throws RestException or one of its subclasses if receiving an error response
+     * @throws StorageRestException containing an error code, if receiving an error response
      * @throws HttpRequestTimeoutException if the request timed out
      * @throws HttpRequestException on network related issues
      */
@@ -273,7 +276,7 @@ interface BucketApi {
      * Returns information about the file under [path]
      * @param path The path to get information about
      * @return The file object
-     * @throws RestException or one of its subclasses if receiving an error response
+     * @throws StorageRestException containing an error code, if receiving an error response
      * @throws HttpRequestTimeoutException if the request timed out
      * @throws HttpRequestException on network related issues
      */
@@ -282,7 +285,7 @@ interface BucketApi {
     /**
      * Checks if a file exists under [path]
      * @return true if the file exists, false otherwise
-     * @throws RestException or one of its subclasses if receiving an error response
+     * @throws StorageRestException containing an error code, if receiving an error response
      * @throws HttpRequestTimeoutException if the request timed out
      * @throws HttpRequestException on network related issues
      */
@@ -290,7 +293,7 @@ interface BucketApi {
 
     /**
      * Changes the bucket's public status to [public]
-     * @throws RestException or one of its subclasses if receiving an error response
+     * @throws StorageRestException containing an error code, if receiving an error response
      * @throws HttpRequestTimeoutException if the request timed out
      * @throws HttpRequestException on network related issues
      */
@@ -326,33 +329,21 @@ interface BucketApi {
 
     /**
      * Returns the public url of [path]
-     * @throws RestException or one of its subclasses if receiving an error response
-     * @throws HttpRequestTimeoutException if the request timed out
-     * @throws HttpRequestException on network related issues
      */
     fun publicUrl(path: String, builder: PublicUrlBuilder.() -> Unit = {}): String
 
     /**
      * Returns the authenticated url of [path]. Requires bearer token authentication using the user's access token
-     * @throws RestException or one of its subclasses if receiving an error response
-     * @throws HttpRequestTimeoutException if the request timed out
-     * @throws HttpRequestException on network related issues
      */
     fun authenticatedUrl(path: String): String
 
     /**
      * Returns the authenticated render url of [path] with the given [transform]
-     * @throws RestException or one of its subclasses if receiving an error response
-     * @throws HttpRequestTimeoutException if the request timed out
-     * @throws HttpRequestException on network related issues
      */
     fun authenticatedRenderUrl(path: String, transform: ImageTransformation.() -> Unit = {}): String
 
     /**
      * Returns the public render url of [path] with the given [transform]
-     * @throws RestException or one of its subclasses if receiving an error response
-     * @throws HttpRequestTimeoutException if the request timed out
-     * @throws HttpRequestException on network related issues
      */
     @Deprecated("Use publicUrl instead", ReplaceWith("publicUrl"))
     fun publicRenderUrl(path: String, transform: ImageTransformation.() -> Unit = {}): String = publicUrl(path) {

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/Storage.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/Storage.kt
@@ -7,12 +7,8 @@ import io.github.jan.supabase.annotations.SupabaseInternal
 import io.github.jan.supabase.auth.AuthDependentPluginConfig
 import io.github.jan.supabase.auth.api.authenticatedSupabaseApi
 import io.github.jan.supabase.bodyOrNull
-import io.github.jan.supabase.exceptions.BadRequestRestException
 import io.github.jan.supabase.exceptions.HttpRequestException
-import io.github.jan.supabase.exceptions.NotFoundRestException
 import io.github.jan.supabase.exceptions.RestException
-import io.github.jan.supabase.exceptions.UnauthorizedRestException
-import io.github.jan.supabase.exceptions.UnknownRestException
 import io.github.jan.supabase.logging.SupabaseLogger
 import io.github.jan.supabase.logging.createLogger
 import io.github.jan.supabase.logging.w
@@ -32,7 +28,6 @@ import io.github.jan.supabase.storage.vectors.StorageVectorsClientImpl
 import io.ktor.client.plugins.HttpRequestTimeoutException
 import io.ktor.client.plugins.timeout
 import io.ktor.client.statement.HttpResponse
-import io.ktor.http.HttpStatusCode
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
@@ -291,15 +286,16 @@ internal class StorageImpl(override val supabaseClient: SupabaseClient, override
         val error = supabaseClient.bodyOrNull<StorageErrorResponse>(response) ?: StorageErrorResponse(
             response.status.value,
             "Unknown error",
+            "",
             ""
         )
-        if (statusCode != HttpStatusCode.BadRequest) return UnknownRestException("Unknown error response $error", response)
-        when (error.statusCode) {
-            HttpStatusCode.Unauthorized.value -> throw UnauthorizedRestException(error.error, response, error.message)
-            HttpStatusCode.BadRequest.value -> throw BadRequestRestException(error.error, response, error.message)
-            HttpStatusCode.NotFound.value -> throw NotFoundRestException(error.error, response, error.message)
-            else -> throw UnknownRestException(error.message, response)
-        }
+        throw StorageRestException(
+            error.error,
+            error.message,
+            response,
+            error.statusCode,
+            error.code
+        )
     }
 
 }

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/Storage.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/Storage.kt
@@ -86,49 +86,46 @@ interface Storage : MainPlugin<Storage.Config>, CustomSerializationPlugin {
      * @param id the id of the bucket
      * @param builder overrides bucket config options (like whether the bucket should be public,
      * file size limit, etc.)
-     * @throws RestException or one of its subclasses if receiving an error response
+     * @throws StorageRestException containing an error code, if receiving an error response
      * @throws HttpRequestTimeoutException if the request timed out
-     * @throws HttpRequestException on network related issues
-     */
+     * @throws HttpRequestException on network related issues     */
     suspend fun createBucket(id: String, builder: BucketBuilder.() -> Unit = {})
 
     /**
      * Updates a bucket in the storage
      * @param id the id of the bucket
      * @param builder the builder for the bucket
-     */
+     * @throws StorageRestException containing an error code, if receiving an error response
+     * @throws HttpRequestTimeoutException if the request timed out
+     * @throws HttpRequestException on network related issues     */
     suspend fun updateBucket(id: String, builder: BucketBuilder.() -> Unit = {})
 
     /**
      * Returns all buckets in the storage
-     * @throws RestException or one of its subclasses if receiving an error response
+     * @throws StorageRestException containing an error code, if receiving an error response
      * @throws HttpRequestTimeoutException if the request timed out
-     * @throws HttpRequestException on network related issues
-     */
+     * @throws HttpRequestException on network related issues     */
     suspend fun listBuckets(filter: StorageListFilter.Buckets.() -> Unit = {}): List<Bucket>
 
     /**
      * Retrieves a bucket by its [bucketId]
-     * @throws RestException or one of its subclasses if receiving an error response
+     * @throws StorageRestException containing an error code, if receiving an error response
      * @throws HttpRequestTimeoutException if the request timed out
-     * @throws HttpRequestException on network related issues
-     */
+     * @throws HttpRequestException on network related issues     */
     suspend fun getBucket(bucketId: String): Bucket?
 
     /**
      * Empties a bucket by its [bucketId]
-     * @throws RestException or one of its subclasses if receiving an error response
+     * @throws StorageRestException containing an error code, if receiving an error response
      * @throws HttpRequestTimeoutException if the request timed out
-     * @throws HttpRequestException on network related issues
-     */
+     * @throws HttpRequestException on network related issues     */
     suspend fun emptyBucket(bucketId: String)
 
     /**
      * Deletes a bucket by its [bucketId]
-     * @throws RestException or one of its subclasses if receiving an error response
+     * @throws StorageRestException containing an error code, if receiving an error response
      * @throws HttpRequestTimeoutException if the request timed out
-     * @throws HttpRequestException on network related issues
-     */
+     * @throws HttpRequestException on network related issues     */
     suspend fun deleteBucket(bucketId: String)
 
     /**

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/StorageErrorResponse.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/StorageErrorResponse.kt
@@ -6,5 +6,6 @@ import kotlinx.serialization.Serializable
 internal data class StorageErrorResponse(
     val statusCode: Int,
     val error: String,
-    val message: String
+    val message: String,
+    val code: String
 )

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/StorageRestException.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/StorageRestException.kt
@@ -1,0 +1,22 @@
+package io.github.jan.supabase.storage
+
+import io.github.jan.supabase.exceptions.RestException
+import io.ktor.client.statement.HttpResponse
+
+/**
+ * Represents an exception thrown if the storage API returns an error response.
+ * @param error A short error identifier string returned by the API, if available
+ * @param description A human-readable description of the error.
+ * @param statusCode The HTTP status code returned by the API
+ * @param code Service-specific error code from the Storage API response body, such as
+ * `NoSuchKey`, `AccessDenied` or `ResourceAlreadyExists`. Use this to branch
+ * on the specific error rather than parsing the message.
+ * See https://supabase.com/docs/guides/storage/debugging/error-codes for a list of codes.
+ */
+class StorageRestException(
+    error: String,
+    description: String,
+    response: HttpResponse,
+    override val statusCode: Int,
+    val code: String
+): RestException(error, description, response)

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/analytics/StorageAnalyticsClient.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/analytics/StorageAnalyticsClient.kt
@@ -1,8 +1,11 @@
 package io.github.jan.supabase.storage.analytics
 
 import io.github.jan.supabase.auth.api.AuthenticatedSupabaseApi
+import io.github.jan.supabase.exceptions.HttpRequestException
 import io.github.jan.supabase.safeBody
 import io.github.jan.supabase.storage.StorageListFilter
+import io.github.jan.supabase.storage.StorageRestException
+import io.ktor.client.plugins.HttpRequestTimeoutException
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.contentOrNull
@@ -21,6 +24,9 @@ interface StorageAnalyticsClient {
      * **Public alpha:** This API is part of a public alpha release and may not be available to your account type.
      *
      * @param name A unique name for the bucket you are creating
+     * @throws StorageRestException containing an error code, if receiving an error response
+     * @throws HttpRequestTimeoutException if the request timed out
+     * @throws HttpRequestException on network related issues
      */
     suspend fun createBucket(name: String): AnalyticBucket
 
@@ -31,6 +37,9 @@ interface StorageAnalyticsClient {
      * **Public alpha:** This API is part of a public alpha release and may not be available to your account type.
      *
      * @param filter Query parameters for listing buckets
+     * @throws StorageRestException containing an error code, if receiving an error response
+     * @throws HttpRequestTimeoutException if the request timed out
+     * @throws HttpRequestException on network related issues
      */
     suspend fun listBuckets(filter: StorageListFilter.Buckets.() -> Unit = {}): List<AnalyticBucket>
 
@@ -42,6 +51,9 @@ interface StorageAnalyticsClient {
      * **Public alpha:** This API is part of a public alpha release and may not be available to your account type.
      *
      * @param name The unique identifier of the bucket you would like to delete
+     * @throws StorageRestException containing an error code, if receiving an error response
+     * @throws HttpRequestTimeoutException if the request timed out
+     * @throws HttpRequestException on network related issues
      */
     suspend fun deleteBucket(name: String): String
 

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/vectors/StorageVectorsClient.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/vectors/StorageVectorsClient.kt
@@ -1,12 +1,15 @@
 package io.github.jan.supabase.storage.vectors
 
 import io.github.jan.supabase.auth.api.AuthenticatedSupabaseApi
+import io.github.jan.supabase.exceptions.HttpRequestException
 import io.github.jan.supabase.safeBody
+import io.github.jan.supabase.storage.StorageRestException
 import io.github.jan.supabase.storage.vectors.bucket.ListVectorBucketsResponse
 import io.github.jan.supabase.storage.vectors.bucket.VectorBucket
 import io.github.jan.supabase.storage.vectors.bucket.VectorBucketFilter
 import io.github.jan.supabase.storage.vectors.index.VectorIndexApi
 import io.github.jan.supabase.storage.vectors.index.VectorIndexApiImpl
+import io.ktor.client.plugins.HttpRequestTimeoutException
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
@@ -20,23 +23,35 @@ interface StorageVectorsClient {
 
     /**
      * Creates a new vector bucket with the given [name]
+     * @throws StorageRestException containing an error code, if receiving an error response
+     * @throws HttpRequestTimeoutException if the request timed out
+     * @throws HttpRequestException on network related issues
      */
     suspend fun createBucket(name: String)
 
     /**
      * Retrieves metadata for a specific vector bucket
      * @param name The unique bucket name
+     * @throws StorageRestException containing an error code, if receiving an error response
+     * @throws HttpRequestTimeoutException if the request timed out
+     * @throws HttpRequestException on network related issues
      */
     suspend fun getBucket(name: String): VectorBucket
 
     /**
      * Lists vector buckets with optional filtering and pagination
      * @param filter An optional filter
+     * @throws StorageRestException containing an error code, if receiving an error response
+     * @throws HttpRequestTimeoutException if the request timed out
+     * @throws HttpRequestException on network related issues
      */
     suspend fun listBuckets(filter: VectorBucketFilter.() -> Unit = {}): ListVectorBucketsResponse
 
     /**
      * Deletes a vector bucket (must be empty first)
+     * @throws StorageRestException containing an error code, if receiving an error response
+     * @throws HttpRequestTimeoutException if the request timed out
+     * @throws HttpRequestException on network related issues
      */
     suspend fun deleteBucket(name: String)
 

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/vectors/data/VectorDataApi.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/vectors/data/VectorDataApi.kt
@@ -1,9 +1,12 @@
 package io.github.jan.supabase.storage.vectors.data
 
 import io.github.jan.supabase.auth.api.AuthenticatedSupabaseApi
+import io.github.jan.supabase.exceptions.HttpRequestException
 import io.github.jan.supabase.safeBody
+import io.github.jan.supabase.storage.StorageRestException
 import io.github.jan.supabase.storage.vectors.data.VectorDataApi.Companion.SEGMENT_COUNT_RANGE
 import io.github.jan.supabase.storage.vectors.data.VectorDataApi.Companion.VECTOR_RANGE
+import io.ktor.client.plugins.HttpRequestTimeoutException
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
@@ -18,26 +21,41 @@ interface VectorDataApi {
 
     /**
      * Inserts or updates [vectors] in batch (1-500 per request)
+     * @throws StorageRestException containing an error code, if receiving an error response
+     * @throws HttpRequestTimeoutException if the request timed out
+     * @throws HttpRequestException on network related issues
      */
     suspend fun putVectors(vectors: List<VectorObject>)
 
     /**
      * Retrieves vectors by their keys in batch using the given [options]
+     * @throws StorageRestException containing an error code, if receiving an error response
+     * @throws HttpRequestTimeoutException if the request timed out
+     * @throws HttpRequestException on network related issues
      */
     suspend fun getVectors(options: GetVectorOptions.() -> Unit): List<VectorMatch>
 
     /**
      * Lists vectors in an index with pagination using the given [options]
+     * @throws StorageRestException containing an error code, if receiving an error response
+     * @throws HttpRequestTimeoutException if the request timed out
+     * @throws HttpRequestException on network related issues
      */
     suspend fun listVectors(options: ListVectorsOptions.() -> Unit = {}): ListVectorsResponse
 
     /**
      * Queries for similar vectors using approximate nearest neighbor search using the given [options]
+     * @throws StorageRestException containing an error code, if receiving an error response
+     * @throws HttpRequestTimeoutException if the request timed out
+     * @throws HttpRequestException on network related issues
      */
     suspend fun queryVectors(options: QueryVectorsOptions.() -> Unit): QueryVectorsResponse
 
     /**
      * Deletes vectors by their [keys] in batch (1-500 per request)
+     * @throws StorageRestException containing an error code, if receiving an error response
+     * @throws HttpRequestTimeoutException if the request timed out
+     * @throws HttpRequestException on network related issues
      */
     suspend fun deleteVectors(keys: List<String>)
 

--- a/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/vectors/index/VectorIndexApi.kt
+++ b/Storage/src/commonMain/kotlin/io/github/jan/supabase/storage/vectors/index/VectorIndexApi.kt
@@ -1,9 +1,12 @@
 package io.github.jan.supabase.storage.vectors.index
 
 import io.github.jan.supabase.auth.api.AuthenticatedSupabaseApi
+import io.github.jan.supabase.exceptions.HttpRequestException
 import io.github.jan.supabase.safeBody
+import io.github.jan.supabase.storage.StorageRestException
 import io.github.jan.supabase.storage.vectors.data.VectorDataApi
 import io.github.jan.supabase.storage.vectors.data.VectorDataApiImpl
+import io.ktor.client.plugins.HttpRequestTimeoutException
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
@@ -23,6 +26,9 @@ interface VectorIndexApi {
      * **Public alpha:** This API is part of a public alpha release and may not be available to your account type.
      *
      * @param options - Index configuration (vectorBucketName is automatically set)
+     * @throws StorageRestException containing an error code, if receiving an error response
+     * @throws HttpRequestTimeoutException if the request timed out
+     * @throws HttpRequestException on network related issues
      */
     suspend fun createIndex(options: CreateIndexOptions.() -> Unit)
 
@@ -33,6 +39,9 @@ interface VectorIndexApi {
      * **Public alpha:** This API is part of a public alpha release and may not be available to your account type.
      *
      * @param options Listing options (vectorBucketName is automatically set)
+     * @throws StorageRestException containing an error code, if receiving an error response
+     * @throws HttpRequestTimeoutException if the request timed out
+     * @throws HttpRequestException on network related issues
      */
     suspend fun listIndexes(options: ListIndexesOptions.() -> Unit = {}): ListIndexesResponse
 
@@ -43,6 +52,9 @@ interface VectorIndexApi {
      * **Public alpha:** This API is part of a public alpha release and may not be available to your account type.
      *
      * @param indexName Name of the index to retrieve
+     * @throws StorageRestException containing an error code, if receiving an error response
+     * @throws HttpRequestTimeoutException if the request timed out
+     * @throws HttpRequestException on network related issues
      */
     suspend fun getIndex(indexName: String): VectorIndex
 
@@ -53,6 +65,9 @@ interface VectorIndexApi {
      * **Public alpha:** This API is part of a public alpha release and may not be available to your account type.
      *
      * @param indexName Name of the index to delete
+     * @throws StorageRestException containing an error code, if receiving an error response
+     * @throws HttpRequestTimeoutException if the request timed out
+     * @throws HttpRequestException on network related issues
      */
     suspend fun deleteIndex(indexName: String)
 

--- a/Storage/src/commonTest/kotlin/StorageRestExceptionTest.kt
+++ b/Storage/src/commonTest/kotlin/StorageRestExceptionTest.kt
@@ -1,0 +1,78 @@
+import io.github.jan.supabase.SupabaseClient
+import io.github.jan.supabase.SupabaseClientBuilder
+import io.github.jan.supabase.storage.Storage
+import io.github.jan.supabase.storage.StorageRestException
+import io.github.jan.supabase.storage.storage
+import io.github.jan.supabase.testing.assertMethodIs
+import io.github.jan.supabase.testing.assertPathIs
+import io.github.jan.supabase.testing.createMockedSupabaseClient
+import io.github.jan.supabase.testing.pathAfterVersion
+import io.github.jan.supabase.testing.respondJson
+import io.ktor.client.engine.mock.respondError
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.test.runTest
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class StorageRestExceptionTest {
+
+    private val configureClient: SupabaseClientBuilder.() -> Unit = {
+        install(Storage)
+    }
+
+    private lateinit var client: SupabaseClient
+
+    @Test
+    fun testCreateBucketThrowsStorageRestException() {
+        runTest {
+            client = createMockedSupabaseClient(configuration = configureClient) {
+                assertPathIs("/bucket", it.url.pathAfterVersion())
+                assertMethodIs(HttpMethod.Post, it.method)
+                respondJson(
+                    """{"statusCode":409,"error":"bucket_already_exists","message":"Bucket already exists","code":"ResourceAlreadyExists"}""",
+                    HttpStatusCode.Conflict
+                )
+            }
+
+            val exception = assertFailsWith<StorageRestException> {
+                client.storage.createBucket("bucket")
+            }
+
+            assertEquals("bucket_already_exists", exception.error)
+            assertEquals("Bucket already exists", exception.description)
+            assertEquals(409, exception.statusCode)
+            assertEquals("ResourceAlreadyExists", exception.code)
+        }
+    }
+
+    @Test
+    fun testCreateBucketFallsBackToUnknownErrorWhenBodyCannotBeParsed() {
+        runTest {
+            client = createMockedSupabaseClient(configuration = configureClient) {
+                respondError(HttpStatusCode.InternalServerError, "maintenance")
+            }
+
+            val exception = assertFailsWith<StorageRestException> {
+                client.storage.createBucket("bucket")
+            }
+
+            assertEquals("Unknown error", exception.error)
+            assertEquals("", exception.description)
+            assertEquals(HttpStatusCode.InternalServerError.value, exception.statusCode)
+            assertEquals("", exception.code)
+        }
+    }
+
+    @AfterTest
+    fun cleanup() {
+        runTest {
+            if(::client.isInitialized) {
+                client.close()
+            }
+        }
+    }
+
+}

--- a/Supabase/src/commonMain/kotlin/io/github/jan/supabase/exceptions/RestException.kt
+++ b/Supabase/src/commonMain/kotlin/io/github/jan/supabase/exceptions/RestException.kt
@@ -29,7 +29,7 @@ open class RestException(val error: String, val description: String?, val respon
     /**
      * The status code of the response
      */
-    val statusCode = response.status.value
+    open val statusCode = response.status.value
 
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature (closes #1372)

This pull request refactors error handling in the Storage module to provide more detailed and structured exceptions for storage API errors. Instead of using generic or HTTP-based exceptions, a new `StorageRestException` is introduced, which includes a service-specific error code for improved error handling and debugging. Imports are cleaned up, and the error response data class is updated to include the new code field.

**Error handling improvements:**

* Replaced previous exception handling logic in `StorageImpl` to always throw a new `StorageRestException`, which provides a more detailed and consistent error structure, including the storage-specific error code.
* Added new `StorageRestException` class to encapsulate storage-specific error details, including the API error code, message, and HTTP status code.
* Updated `StorageErrorResponse` data class to include a `code` field for the service-specific error code from the Storage API.

**Codebase cleanup:**

* Removed unused exception and HTTP imports from `Storage.kt` to simplify dependencies. 
* Made the `statusCode` property in `RestException` open, allowing subclasses like `StorageRestException` to override it.