### PR TITLE
fix(auth): include the status code description as the fallback

### DIFF
--- a/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/AuthImpl.kt
+++ b/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/AuthImpl.kt
@@ -30,10 +30,10 @@ import io.github.jan.supabase.auth.jwt.ecdsaRawToDer
 import io.github.jan.supabase.auth.jwt.rsaJwkToDer
 import io.github.jan.supabase.auth.mfa.MfaApi
 import io.github.jan.supabase.auth.mfa.MfaApiImpl
-import io.github.jan.supabase.auth.passkey.AuthPasskeyApi
-import io.github.jan.supabase.auth.passkey.AuthPasskeyApiImpl
 import io.github.jan.supabase.auth.oauth.OAuthApi
 import io.github.jan.supabase.auth.oauth.OAuthApiImpl
+import io.github.jan.supabase.auth.passkey.AuthPasskeyApi
+import io.github.jan.supabase.auth.passkey.AuthPasskeyApiImpl
 import io.github.jan.supabase.auth.providers.AuthProvider
 import io.github.jan.supabase.auth.providers.ExternalAuthConfigDefaults
 import io.github.jan.supabase.auth.providers.IDTokenProvider
@@ -722,7 +722,7 @@ internal class AuthImpl(
 
     override suspend fun parseErrorResponse(response: HttpResponse): RestException {
         val errorBody =
-            supabaseClient.bodyOrNull<GoTrueErrorResponse>(response) ?: GoTrueErrorResponse("Unknown error", "")
+            supabaseClient.bodyOrNull<GoTrueErrorResponse>(response) ?: GoTrueErrorResponse("Unknown error", response.status.description)
         checkErrorCodes(errorBody, response)?.let { return it }
         return when (response.status) {
             HttpStatusCode.Unauthorized -> UnauthorizedRestException(


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (closes #1374)

This pull request makes a minor fix to the error handling logic in `AuthImpl`. Now, when an HTTP response does not include an explicit error message, the error body will use the HTTP status description instead of an empty string. 

- Error handling improvement:
  * Updated the fallback error message in `parseErrorResponse` to use `response.status.description` when no error body is present.

