### PR TITLE
feat(realtime): add realtime filter builder

### DIFF
--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/filter/FilterOperation.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/filter/FilterOperation.kt
@@ -27,6 +27,7 @@ fun FilterOperation.escapedValue(isInLogicalExpression: Boolean): String =
         FilterOperator.FTS,
         FilterOperator.WFTS,
         FilterOperator.PHFTS,
+        FilterOperator.ISDISTINCT,
         FilterOperator.PLFTS ->
             if (isInLogicalExpression)
                 escapeValue(value)

--- a/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/filter/FilterOperator.kt
+++ b/Postgrest/src/commonMain/kotlin/io/github/jan/supabase/postgrest/query/filter/FilterOperator.kt
@@ -33,4 +33,5 @@ enum class FilterOperator(val identifier: String) {
     PLFTS("plfts"),
     PHFTS("phfts"),
     WFTS("wfts"),
+    ISDISTINCT("isdistinct");
 }

--- a/Postgrest/src/commonTest/kotlin/PostgrestFilterBuilderTest.kt
+++ b/Postgrest/src/commonTest/kotlin/PostgrestFilterBuilderTest.kt
@@ -641,6 +641,24 @@ class PostgrestFilterBuilderTest {
     }
 
     @Test
+    fun isDistinct() {
+        val filter = filterToString {
+            filter("id", FilterOperator.ISDISTINCT, 1)
+        }
+        assertEquals("id=isdistinct.1", filter)
+    }
+
+    @Test
+    fun isDistinctLogicalExpression() {
+        val filter = filterToString {
+            and {
+                filter("id", FilterOperator.ISDISTINCT, "foo,bar")
+            }
+        }
+        assertEquals("and=(id.isdistinct.\"foo,bar\")", filter)
+    }
+
+    @Test
     fun slList() {
         val filter = filterToString {
             filter("id", FilterOperator.SL, listOf(1, 2))

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/PostgresChangeFilter.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/PostgresChangeFilter.kt
@@ -4,6 +4,7 @@ import io.github.jan.supabase.annotations.SupabaseInternal
 import io.github.jan.supabase.postgrest.query.filter.FilterOperation
 import io.github.jan.supabase.postgrest.query.filter.FilterOperator
 import io.github.jan.supabase.postgrest.query.filter.escapedValue
+import io.github.jan.supabase.realtime.postgres.RealtimePostgresFilterBuilder
 
 /**
  * Used to filter postgres changes
@@ -49,6 +50,25 @@ class PostgresChangeFilter(private val event: String, private val schema: String
      */
     fun filter(column: String, operator: FilterOperator, value: Any) {
         filter(FilterOperation(column, operator, value))
+    }
+
+    /**
+     * Fluent builder for Postgres Changes `filter` strings.
+     *
+     * Each method appends a single `column=operator.value` condition. Multiple
+     * conditions are combined with commas, which the Realtime server applies as an
+     * `AND`.
+     *
+     * The builder mirrors the `postgrest-kt` filter API (`eq`, `neq`, `in`, `like`,
+     * `not`, …) for the operators that Realtime supports. Values containing reserved
+     * characters (`,`, `(`, `)`, `"`, `\`) — or surrounding whitespace — are
+     * automatically double-quoted and escaped the same way PostgREST does, so they
+     * survive the server's filter parser; all other values are sent verbatim.
+     *
+     */
+    fun filter(builder: RealtimePostgresFilterBuilder.() -> Unit) {
+        val builder = RealtimePostgresFilterBuilder().apply(builder)
+        filter = builder.build()
     }
 
     @SupabaseInternal

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeImpl.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeImpl.kt
@@ -53,9 +53,9 @@ import kotlin.time.Duration
 
     override val logger: SupabaseLogger = supabaseClient.createLogger(Realtime.LOGGING_TAG, config)
     private val websocketFactory = config.websocketFactory ?: KtorRealtimeWebsocketFactory(supabaseClient.httpClient.httpClient)
-    private var _websocket: RealtimeWebsocket? = null
+    private var _websocket: AtomicReference<RealtimeWebsocket?> = AtomicReference(null)
     override val websocket: RealtimeWebsocket
-        get() = _websocket ?: error("Websocket not yet initialized")
+        get() = _websocket.load() ?: error("Websocket not yet initialized")
     @Suppress("MagicNumber")
     private val _status = MutableStateFlow(Realtime.Status.DISCONNECTED)
     override val status: StateFlow<Realtime.Status> = _status.asStateFlow()
@@ -96,7 +96,7 @@ import kotlin.time.Duration
         if (status.value == Realtime.Status.CONNECTED) return
         _status.value = Realtime.Status.CONNECTING
         try {
-            _websocket = websocketFactory.create(websocketUrl)
+            _websocket.store(websocketFactory.create(websocketUrl))
             _status.value = Realtime.Status.CONNECTED
             logger.i { "Connected to realtime websocket!" }
             listenForMessages()
@@ -153,9 +153,9 @@ import kotlin.time.Duration
     private fun listenForMessages() {
         messageJob = scope.launch {
             try {
-                _websocket?.let {
-                    while(_websocket?.hasIncomingMessages == true) {
-                        val frame = _websocket?.receive() ?: return@launch
+                _websocket.load()?.let {
+                    while(it.hasIncomingMessages) {
+                        val frame = it.receive() ?: return@launch
                         when(frame) {
                             is Frame.Binary -> {
                                 if(config.vsn == RealtimeProtocolVersion.V1) {
@@ -204,8 +204,8 @@ import kotlin.time.Duration
     override fun disconnect() {
         logger.d { "Closing websocket connection" }
         messageJob?.cancel()
-        _websocket?.disconnect()
-        _websocket = null
+        _websocket.load()?.disconnect()
+        _websocket.store(null)
         heartbeatJob?.cancel()
         for ((_, channel) in subscriptions) {
             channel.updateStatus(RealtimeChannel.Status.UNSUBSCRIBED)
@@ -317,7 +317,7 @@ import kotlin.time.Duration
     }
 
     override suspend fun block() {
-        _websocket?.blockUntilDisconnect() ?: error("No connection available")
+        _websocket.load()?.blockUntilDisconnect() ?: error("No connection available")
     }
 
     override suspend fun parseErrorResponse(response: HttpResponse): RestException {
@@ -352,7 +352,7 @@ import kotlin.time.Duration
 
     override suspend fun send(message: RealtimeMessage) {
         try {
-            _websocket?.send(message, config.vsn)
+            _websocket.load()?.send(message, config.vsn)
         } catch(e: Exception) {
             currentCoroutineContext().ensureActive()
             logger.w(e) { "Error while sending message $message. Reconnecting in ${config.reconnectDelay}" }
@@ -362,7 +362,7 @@ import kotlin.time.Duration
 
     override suspend fun send(data: ByteArray) {
         try {
-            _websocket?.send(data)
+            _websocket.load()?.send(data)
         } catch(e: Exception) {
             currentCoroutineContext().ensureActive()
             logger.e(e) { "Error while sending binary data. Reconnecting in ${config.reconnectDelay}" }

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/postgres/RealtimePostgresChangesFilterOperator.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/postgres/RealtimePostgresChangesFilterOperator.kt
@@ -1,0 +1,28 @@
+@file:Suppress(
+    "UndocumentedPublicClass",
+    "UndocumentedPublicFunction",
+    "UndocumentedPublicProperty"
+)
+package io.github.jan.supabase.realtime.postgres
+
+import io.github.jan.supabase.postgrest.query.filter.FilterOperator
+
+enum class RealtimePostgresChangesFilterOperator {
+    EQ, NEQ, LT, LTE, GT, GTE, IN, LIKE, ILIKE, IS, MATCH, IMATCH, ISDISTINCT
+}
+
+internal fun RealtimePostgresChangesFilterOperator.toPostgrestOperator() = when(this) {
+    RealtimePostgresChangesFilterOperator.EQ -> FilterOperator.EQ
+    RealtimePostgresChangesFilterOperator.NEQ -> FilterOperator.NEQ
+    RealtimePostgresChangesFilterOperator.LT -> FilterOperator.LT
+    RealtimePostgresChangesFilterOperator.LTE -> FilterOperator.LTE
+    RealtimePostgresChangesFilterOperator.GT -> FilterOperator.GT
+    RealtimePostgresChangesFilterOperator.GTE -> FilterOperator.GTE
+    RealtimePostgresChangesFilterOperator.IN -> FilterOperator.IN
+    RealtimePostgresChangesFilterOperator.LIKE -> FilterOperator.LIKE
+    RealtimePostgresChangesFilterOperator.ILIKE -> FilterOperator.ILIKE
+    RealtimePostgresChangesFilterOperator.IS -> FilterOperator.IS
+    RealtimePostgresChangesFilterOperator.MATCH -> FilterOperator.MATCH
+    RealtimePostgresChangesFilterOperator.IMATCH -> FilterOperator.IMATCH
+    RealtimePostgresChangesFilterOperator.ISDISTINCT -> FilterOperator.ISDISTINCT
+}

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/postgres/RealtimePostgresFilterBuilder.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/postgres/RealtimePostgresFilterBuilder.kt
@@ -1,0 +1,129 @@
+package io.github.jan.supabase.realtime.postgres
+
+import io.github.jan.supabase.postgrest.query.filter.FilterOperation
+import io.github.jan.supabase.postgrest.query.filter.escapedValue
+import io.github.jan.supabase.realtime.RealtimeChannel
+import io.github.jan.supabase.realtime.postgresChangeFlow
+
+/**
+ * Fluent builder for Postgres Changes `filter` strings.
+ *
+ * Each method appends a single `column=operator.value` condition. Multiple
+ * conditions are combined with commas, which the Realtime server applies as an
+ * `AND`. Use the DSL in [RealtimeChannel.postgresChangeFlow] — the
+ * SDK serializes it to a string automatically — or call [build] to obtain
+ * the string yourself.
+ *
+ * The builder mirrors the `postgrest-kt` filter API (`eq`, `neq`, `in`, `like`,
+ * `not`, …) for the operators that Realtime supports. Values containing reserved
+ * characters (`,`, `(`, `)`, `"`, `\`) — or surrounding whitespace — are
+ * automatically double-quoted and escaped the same way PostgREST does, so they
+ * survive the server's filter parser; all other values are sent verbatim.
+ *
+ */
+class RealtimePostgresFilterBuilder {
+
+    private val filters = mutableListOf<String>()
+
+    private fun add(column: String, operator: RealtimePostgresChangesFilterOperator, value: Any, negate: Boolean = false) {
+        val prefix = if (negate) "not." else ""
+        val operation = FilterOperation(column, operator.toPostgrestOperator(), value)
+        filters.add("${column}=$prefix${operator.name.lowercase()}.${operation.escapedValue(true)}")
+    }
+
+    /** Match rows where [column] equals [value] (`column=eq.value`). */
+    fun eq(column: String, value: Any) {
+        add(column, RealtimePostgresChangesFilterOperator.EQ, value)
+    }
+
+    /** Match rows where [column] does not equal [value] (`column=neq.value`). */
+    fun neq(column: String, value: Any) {
+        add(column, RealtimePostgresChangesFilterOperator.NEQ, value)
+    }
+
+    /** Match rows where [column] is greater than [value] (`column=gt.value`). */
+    fun gt(column: String, value: Any) {
+        add(column, RealtimePostgresChangesFilterOperator.GT, value)
+    }
+
+    /** Match rows where [column] is greater than or equal to [value] (`column=gte.value`). */
+    fun gte(column: String, value: Any) {
+        add(column, RealtimePostgresChangesFilterOperator.GTE, value)
+    }
+
+    /** Match rows where [column] is less than [value] (`column=lt.value`). */
+    fun lt(column: String, value: Any) {
+        add(column, RealtimePostgresChangesFilterOperator.LT, value)
+    }
+
+    /** Match rows where [column] is less than or equal to [value] (`column=lte.value`). */
+    fun lte(column: String, value: Any) {
+        add(column, RealtimePostgresChangesFilterOperator.LTE, value)
+    }
+
+
+    /**
+     * Match rows where [column] is one of [values] (`column=in.(a,b,c)`).
+     * Requires at least one value; duplicates are removed. An element containing a
+     * reserved character is double-quoted (`in.("a,b",c)`), so commas inside an
+     * element are preserved. `null` is intentionally not accepted (`IN (null)`
+     * never matches in SQL) — use `is`/`not('col','is',null)` for null checks.
+     */
+    fun isIn(column: String, values: List<Any>) {
+        add(column, RealtimePostgresChangesFilterOperator.IN, values)
+    }
+
+    /** Match rows where [column] matches the case-sensitive [pattern] (`column=like.pattern`). */
+    fun like(column: String, pattern: String) {
+        add(column, RealtimePostgresChangesFilterOperator.LIKE, pattern)
+    }
+
+    /** Match rows where [column] matches the case-insensitive [pattern] (`column=ilike.pattern`). */
+    fun ilike(column: String, pattern: String) {
+        add(column, RealtimePostgresChangesFilterOperator.ILIKE, pattern)
+    }
+
+    /** Match rows where [column] matches the POSIX regex [pattern] (`column=match.pattern`). */
+    fun match(column: String, pattern: String) {
+        add(column, RealtimePostgresChangesFilterOperator.MATCH, pattern)
+    }
+
+    /** Match rows where [column] matches the case-insensitive POSIX regex `pattern` (`column=imatch.pattern`). */
+    fun imatch(column: String, pattern: String) {
+        add(column, RealtimePostgresChangesFilterOperator.IMATCH, pattern)
+    }
+
+    /**
+     * Match rows where [column] `IS` the given value (`column=is.null`).
+     * Accepts `null`, a boolean, or the keywords `'null' | 'true' | 'false' | 'unknown'`.
+     */
+    fun exact(column: String, value: Any) {
+        add(column, RealtimePostgresChangesFilterOperator.IS, value)
+    }
+
+    /** Match rows where [column] is distinct from [value] (`column=isdistinct.value`). NULL-safe inequality. */
+    fun isDistinct(column: String, value: Any) {
+        add(column, RealtimePostgresChangesFilterOperator.ISDISTINCT, value)
+    }
+
+    /**
+     * Negate any operator with the `not.` prefix (`column=not.operator.value`).
+     * `in` takes an array, `is` takes an `IS` keyword/boolean/null, and every
+     * other operator takes a scalar value.
+     */
+    fun not(column: String, operator: RealtimePostgresChangesFilterOperator, value: Any) {
+        add(column, operator, value, true)
+    }
+
+    /**
+     * Serialize all conditions into the comma-separated (AND) filter string.
+     *
+     * Conditions are joined by commas, which the server applies as `AND`. A scalar
+     * value (or single `in` element) that contains a reserved character — `,`,
+     * `(`, `)`, `"`, `\` — or surrounding whitespace is double-quoted and escaped
+     * the way PostgREST does, so commas inside a value are preserved rather than
+     * read as a condition boundary.
+     */
+    fun build() = filters.joinToString(",")
+
+}

--- a/Realtime/src/commonTest/kotlin/RealtimeChannelTest.kt
+++ b/Realtime/src/commonTest/kotlin/RealtimeChannelTest.kt
@@ -12,7 +12,6 @@ import io.github.jan.supabase.realtime.PostgresJoinConfig
 import io.github.jan.supabase.realtime.Presence
 import io.github.jan.supabase.realtime.Realtime
 import io.github.jan.supabase.realtime.RealtimeChannel
-import io.github.jan.supabase.realtime.RealtimeChannel.Companion.CHANNEL_EVENT_REPLY
 import io.github.jan.supabase.realtime.RealtimeChannel.Companion.CHANNEL_EVENT_SYSTEM
 import io.github.jan.supabase.realtime.RealtimeJoinPayload
 import io.github.jan.supabase.realtime.RealtimeMessage
@@ -21,7 +20,6 @@ import io.github.jan.supabase.realtime.currentPresences
 import io.github.jan.supabase.realtime.postgresChangeFlow
 import io.github.jan.supabase.realtime.realtime
 import io.ktor.util.encodeBase64
-import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.launchIn
@@ -90,15 +88,12 @@ class RealtimeChannelTest {
     @Test
     fun testChannelStatusWithoutPostgres() {
         val channelId = "channelId"
-        val allowUnsubscribeReply = Channel<Unit>(1)
         runTest {
             createTestClient(
                 wsHandler = { i, o ->
                     i.receive().toMessage()
                     o.send(RealtimeMessage("realtime:$channelId", CHANNEL_EVENT_SYSTEM, buildJsonObject { put("status", "ok") }, "").toFrame())
-                    i.receive().toMessage()
-                    allowUnsubscribeReply.receive()
-                    o.send(RealtimeMessage("realtime:$channelId", CHANNEL_EVENT_REPLY, buildJsonObject { put("status", "ok") }, "").toFrame())
+                    handleUnsubscribe(i, o, channelId)
                 },
                 supabaseHandler = {
                     val channel = it.channel("channelId")
@@ -108,7 +103,6 @@ class RealtimeChannelTest {
                     assertEquals(channel.status.value, RealtimeChannel.Status.SUBSCRIBED)
                     channel.unsubscribe()
                     assertEquals(channel.status.value, RealtimeChannel.Status.UNSUBSCRIBING)
-                    allowUnsubscribeReply.send(Unit)
                     assertEquals(RealtimeChannel.Status.UNSUBSCRIBED, channel.status.waitForValue(RealtimeChannel.Status.UNSUBSCRIBED))
                 },
             )

--- a/Realtime/src/commonTest/kotlin/RealtimePostgresFilterBuilderTest.kt
+++ b/Realtime/src/commonTest/kotlin/RealtimePostgresFilterBuilderTest.kt
@@ -1,0 +1,40 @@
+import io.github.jan.supabase.realtime.postgres.RealtimePostgresChangesFilterOperator
+import io.github.jan.supabase.realtime.postgres.RealtimePostgresFilterBuilder
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class RealtimePostgresFilterBuilderTest {
+
+    @Test
+    fun buildSingleEqFilter() {
+        assertEquals("id=eq.1", buildFilter { eq("id", 1) })
+    }
+
+    @Test
+    fun buildMultipleFilters() {
+        assertEquals("id=eq.1,name=like.foo", buildFilter {
+            eq("id", 1)
+            like("name", "foo")
+        })
+    }
+
+    @Test
+    fun buildEscapesReservedCharacters() {
+        assertEquals("name=eq.\"foo,bar\"", buildFilter {
+            eq("name", "foo,bar")
+        })
+    }
+
+    @Test
+    fun buildInAndNotFilters() {
+        assertEquals("id=in.(1,2,3),other=not.eq.4,distinct=isdistinct.5", buildFilter {
+            isIn("id", listOf(1, 2, 3))
+            not("other", RealtimePostgresChangesFilterOperator.EQ, 4)
+            isDistinct("distinct", 5)
+        })
+    }
+
+    private fun buildFilter(block: RealtimePostgresFilterBuilder.() -> Unit): String {
+        return RealtimePostgresFilterBuilder().apply(block).build()
+    }
+}

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -411,6 +411,10 @@ features:
         - RealtimePostgresFilterBuilder.isDistinct
         - RealtimePostgresFilterBuilder.not
         - RealtimePostgresFilterBuilder.build
+  realtime.subscriptions.postgres_changes_multiple_filters:
+    status: implemented
+    symbols:
+      - RealtimePostgresFilterBuilder
   realtime.subscriptions.private_channel: implemented
   realtime.subscriptions.broadcast_self: implemented
   realtime.subscriptions.broadcast_ack: implemented

--- a/sdk-compliance.yaml
+++ b/sdk-compliance.yaml
@@ -392,8 +392,25 @@ features:
   realtime.subscriptions.postgres_changes: implemented
   realtime.subscriptions.subscribe_presence: implemented
   realtime.subscriptions.postgres_changes_filter:
-    status: partially_implemented
-    note: "Doesn't have the new filters yet"
+    realtime.subscriptions.postgres_changes:
+      status: implemented
+      symbols:
+        - RealtimePostgresFilterBuilder
+        - RealtimePostgresFilterBuilder.eq
+        - RealtimePostgresFilterBuilder.neq
+        - RealtimePostgresFilterBuilder.gt
+        - RealtimePostgresFilterBuilder.gte
+        - RealtimePostgresFilterBuilder.lt
+        - RealtimePostgresFilterBuilder.lte
+        - RealtimePostgresFilterBuilder.isIn
+        - RealtimePostgresFilterBuilder.like
+        - RealtimePostgresFilterBuilder.ilike
+        - RealtimePostgresFilterBuilder.match
+        - RealtimePostgresFilterBuilder.imatch
+        - RealtimePostgresFilterBuilder.exact
+        - RealtimePostgresFilterBuilder.isDistinct
+        - RealtimePostgresFilterBuilder.not
+        - RealtimePostgresFilterBuilder.build
   realtime.subscriptions.private_channel: implemented
   realtime.subscriptions.broadcast_self: implemented
   realtime.subscriptions.broadcast_ack: implemented


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature (closes #1343)

This pull request adds a new fluent builder API for constructing Postgres changes filter strings in Realtime channels, aligning filter support with PostgREST and improving developer experience. It introduces the `RealtimePostgresFilterBuilder` class and related types, expands filter operator support, and updates compliance documentation. Comprehensive tests are included to ensure correct behavior.

**Realtime Postgres filter builder API:**

* Added the `RealtimePostgresFilterBuilder` class, which provides a fluent DSL for building filter strings for Postgres changes subscriptions in Realtime, mirroring the `postgrest-kt` filter API. This includes methods for all supported operators, automatic value escaping, and support for combining multiple conditions. 
* Integrated the builder into `PostgresChangeFilter`, allowing users to construct filters using the new DSL.

**Filter operator support and mapping:**

* Introduced the `RealtimePostgresChangesFilterOperator` enum to enumerate all supported filter operators for Realtime Postgres changes, and provided a mapping to `FilterOperator`. 
* Added support for the `ISDISTINCT` operator in both `FilterOperator` and the filter value escaping logic. 
**Testing and compliance:**

* Added comprehensive tests for the new builder and operators in `RealtimePostgresFilterBuilderTest` and extended tests for `ISDISTINCT` in `PostgrestFilterBuilderTest`.
* Updated `sdk-compliance.yaml` to mark `realtime.subscriptions.postgres_changes_filter` as fully implemented and list all new API symbols. 
