### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,10 +183,10 @@ If you like the project and want to support it, consider sponsoring me on [Ko-fi
 
 ## Star History
 
-<a href="https://www.star-history.com/?repos=supabase-community%2Fsupabase-kt&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#supabase-community/supabase-kt&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=supabase-community/supabase-kt&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=supabase-community/supabase-kt&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=supabase-community/supabase-kt&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=supabase-community/supabase-kt&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=supabase-community/supabase-kt&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=supabase-community/supabase-kt&type=date&legend=top-left" />
  </picture>
 </a>


### PR DESCRIPTION
The star history chart at the bottom of the README is currently broken because the host serving it relies on the GitHub stargazer API, which is now restricted. This change points the chart to a working replacement that reads from another data source, so the chart renders again for all visitors.