### PR TITLE
fix(auth): catch all throwables instead of exceptions for refresh and loading

### DIFF
--- a/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/AuthImpl.kt
+++ b/Auth/src/commonMain/kotlin/io/github/jan/supabase/auth/AuthImpl.kt
@@ -628,7 +628,7 @@ internal class AuthImpl(
                 logger.e(e) { "Couldn't refresh session. The refresh token may have been revoked. Clearing session (Status code ${e.statusCode})... " }
                 clearSession()
             }
-        } catch (e: Exception) {
+        } catch (e: Throwable) {
             currentCoroutineContext().ensureActive()
             logger.d(e) { "Couldn't reach Supabase. Either the address doesn't exist or the network might not be on. Retrying in ${config.retryDelay}..." }
             updateStatus(RefreshFailureCause.NetworkError(e))
@@ -705,7 +705,7 @@ internal class AuthImpl(
         } catch (e: NoSessionFoundException) {
             logger.d { e.message ?: "No session found in storage" }
             null
-        } catch (e: Exception) {
+        } catch (e: Throwable) {
             currentCoroutineContext().ensureActive()
             logger.e(e) { "Failed to load session" }
             null


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (closes #1382)

This pull request updates error handling in the `AuthImpl` class to improve robustness by broadening the type of exceptions caught during session refresh and loading operations.

**Error handling improvements:**

* Changed catch blocks from `Exception` to `Throwable` in the session refresh and load methods of `AuthImpl`, ensuring that all errors—including non-`Exception` throwables—are properly handled and logged. 
