### PR TITLE
fix(realtime): catch exceptions when resolving access token

### DIFF
--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/Realtime.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/Realtime.kt
@@ -154,7 +154,6 @@ interface Realtime : MainPlugin<Realtime.Config>, CustomSerializationPlugin {
         var rejoinDelay: Duration = 2.seconds
         var disconnectOnEmptyChannelsAfter: Duration? = null
         var maxAttempts: Int = 5
-        @Deprecated("Use requireValidSession instead")
         var disconnectOnSessionLoss: Boolean = true
         var connectOnSubscribe: Boolean = true
         @SupabaseInternal var websocketFactory: RealtimeWebsocketFactory? = null

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/Realtime.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/Realtime.kt
@@ -154,12 +154,13 @@ interface Realtime : MainPlugin<Realtime.Config>, CustomSerializationPlugin {
         var rejoinDelay: Duration = 2.seconds
         var disconnectOnEmptyChannelsAfter: Duration? = null
         var maxAttempts: Int = 5
+        @Deprecated("Use requireValidSession instead")
         var disconnectOnSessionLoss: Boolean = true
         var connectOnSubscribe: Boolean = true
         @SupabaseInternal var websocketFactory: RealtimeWebsocketFactory? = null
         var disconnectOnNoSubscriptions: Boolean = true
         var vsn = RealtimeProtocolVersion.V2
-        override var requireValidSession: Boolean = false
+        override var requireValidSession: Boolean = true
 
         internal var customAccessTokenProvider = false
         internal var coroutineScope: CoroutineScope? = null

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeChannelImpl.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeChannelImpl.kt
@@ -22,7 +22,9 @@ import io.ktor.http.appendPathSegments
 import io.ktor.http.contentType
 import io.ktor.http.headers
 import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -90,7 +92,17 @@ internal class RealtimeChannelImpl(
         joinRef.store(realtime.websocket.makeRef())
         _status.value = RealtimeChannel.Status.SUBSCRIBING
         logger.d { "Subscribing to channel $topic" }
-        val currentJwt = accessToken()
+        val currentJwt = try {
+            accessToken()
+        } catch(t: Throwable) {
+            currentCoroutineContext().ensureActive()
+            logger.e(t) { "Error occurred while fetching access token" }
+            if(realtime.config.requireValidSession) {
+                scheduleRejoin()
+                return
+            }
+            null
+        }
         val postgrestChanges = clientChanges.toList()
         presenceJoinConfig.enabled = shouldEnablePresence()
         val joinConfig = RealtimeJoinPayload(RealtimeJoinConfig(broadcastJoinConfig, presenceJoinConfig, postgrestChanges, isPrivate))


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (closes #1384)

This pull request introduces improvements to session validation and error handling when subscribing to a realtime channel. The main changes ensure that session validity is enforced by default and that errors during access token retrieval are handled more robustly.

**Session validation improvements:**
- The `requireValidSession` configuration is now enabled by default (`true`), replacing the previous default of `false`.

**Error handling enhancements:**
- In `RealtimeChannelImpl`, fetching the access token is now wrapped in a `try-catch` block. If an error occurs and `requireValidSession` is enabled, the channel will attempt to rejoin and abort further processing; otherwise, it logs the error and continues.
- Added imports for `currentCoroutineContext` and `ensureActive` to support improved coroutine cancellation and error handling.
