### PR TITLE
feat(realtime): add new filter builder support for `selectAsFlow()`

### DIFF
--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/PostgresChangeFilter.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/PostgresChangeFilter.kt
@@ -21,7 +21,6 @@ class PostgresChangeFilter(private val event: String, private val schema: String
      * E.g.: "user_id=eq.1"
      */
     var filter: String? = null
-        private set
 
     /**
      * Filters the received changes in your table.
@@ -66,8 +65,26 @@ class PostgresChangeFilter(private val event: String, private val schema: String
      * survive the server's filter parser; all other values are sent verbatim.
      *
      */
-    fun filter(builder: RealtimePostgresFilterBuilder.() -> Unit) {
+    inline fun filter(builder: RealtimePostgresFilterBuilder.() -> Unit) {
         val builder = RealtimePostgresFilterBuilder().apply(builder)
+        filter = builder.build()
+    }
+
+    /**
+     * Fluent builder for Postgres Changes `filter` strings.
+     *
+     * Each method appends a single `column=operator.value` condition. Multiple
+     * conditions are combined with commas, which the Realtime server applies as an
+     * `AND`.
+     *
+     * The builder mirrors the `postgrest-kt` filter API (`eq`, `neq`, `in`, `like`,
+     * `not`, …) for the operators that Realtime supports. Values containing reserved
+     * characters (`,`, `(`, `)`, `"`, `\`) — or surrounding whitespace — are
+     * automatically double-quoted and escaped the same way PostgREST does, so they
+     * survive the server's filter parser; all other values are sent verbatim.
+     *
+     */
+    fun filter(builder: RealtimePostgresFilterBuilder) {
         filter = builder.build()
     }
 

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/PostgrestExtensions.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/PostgrestExtensions.kt
@@ -2,8 +2,8 @@ package io.github.jan.supabase.realtime
 
 import io.github.jan.supabase.annotations.SupabaseExperimental
 import io.github.jan.supabase.postgrest.query.PostgrestQueryBuilder
-import io.github.jan.supabase.postgrest.query.filter.FilterOperation
 import io.github.jan.supabase.postgrest.query.filter.PostgrestFilterBuilder
+import io.github.jan.supabase.realtime.postgres.RealtimePostgresFilterBuilder
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
@@ -69,7 +69,7 @@ inline fun <reified Data : Any, Value> PostgrestQueryBuilder.selectSingleValueAs
 inline fun <reified Data : Any> PostgrestQueryBuilder.selectAsFlow(
     primaryKey: PrimaryKey<Data>,
     channelName: String? = null,
-    filter: FilterOperation? = null,
+    crossinline filter: RealtimePostgresFilterBuilder.() -> Unit = {}
 ): Flow<List<Data>> = selectAsFlow(listOf(primaryKey), channelName, filter)
 
 /**
@@ -83,7 +83,7 @@ inline fun <reified Data : Any> PostgrestQueryBuilder.selectAsFlow(
 inline fun <reified Data : Any> PostgrestQueryBuilder.selectAsFlow(
     primaryKeys: List<PrimaryKey<Data>>,
     channelName: String? = null,
-    filter: FilterOperation? = null,
+    crossinline filter: RealtimePostgresFilterBuilder.() -> Unit = {}
 ): Flow<List<Data>> {
     val realtime = postgrest.supabaseClient.realtime as RealtimeImpl
     val channel = realtime.channel(channelName ?: defaultChannelName(schema, table, realtime))
@@ -112,7 +112,7 @@ inline fun <reified Data : Any> PostgrestQueryBuilder.selectAsFlow(
 inline fun <reified Data : Any, Value> PostgrestQueryBuilder.selectAsFlow(
     primaryKey: KProperty1<Data, Value>,
     channelName: String? = null,
-    filter: FilterOperation? = null,
+    crossinline filter: RealtimePostgresFilterBuilder.() -> Unit = {},
 ): Flow<List<Data>> =
     selectAsFlow(listOf(primaryKey), channelName, filter)
 
@@ -128,7 +128,7 @@ inline fun <reified Data : Any, Value> PostgrestQueryBuilder.selectAsFlow(
 inline fun <reified Data : Any, Value> PostgrestQueryBuilder.selectAsFlow(
     primaryKeys: List<KProperty1<Data, Value>>,
     channelName: String? = null,
-    filter: FilterOperation? = null,
+    crossinline filter: RealtimePostgresFilterBuilder.() -> Unit = {},
 ): Flow<List<Data>> =
     selectAsFlow(primaryKeys.map { primaryKey ->
         PrimaryKey(postgrest.config.propertyConversionMethod.invoke(primaryKey)) { primaryKey.get(it).toString() }

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeExt.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeExt.kt
@@ -7,9 +7,9 @@ import io.github.jan.supabase.collections.AtomicMutableMap
 import io.github.jan.supabase.exceptions.NotFoundRestException
 import io.github.jan.supabase.exceptions.UnknownRestException
 import io.github.jan.supabase.postgrest.postgrest
-import io.github.jan.supabase.postgrest.query.filter.FilterOperation
 import io.github.jan.supabase.postgrest.query.filter.FilterOperator
 import io.github.jan.supabase.postgrest.query.filter.PostgrestFilterBuilder
+import io.github.jan.supabase.realtime.postgres.RealtimePostgresFilterBuilder
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.flow.map
@@ -83,9 +83,9 @@ inline fun <reified Data> RealtimeChannel.presenceDataFlow(): Flow<List<Data>> {
 inline fun <reified Data : Any> RealtimeChannel.postgresListDataFlow(
     schema: String = "public",
     table: String,
-    filter: FilterOperation? = null,
-    primaryKey: PrimaryKey<Data>
-): Flow<List<Data>> = postgresListDataFlow(schema, table, filter, listOf(primaryKey))
+    primaryKey: PrimaryKey<Data>,
+    crossinline filter: RealtimePostgresFilterBuilder.() -> Unit = {}
+): Flow<List<Data>> = postgresListDataFlow(schema, table, listOf(primaryKey), filter)
 
 /**
  * This function retrieves the initial data from the table and then listens for changes. It automatically handles inserts, updates and deletes.
@@ -100,22 +100,25 @@ inline fun <reified Data : Any> RealtimeChannel.postgresListDataFlow(
 inline fun <reified Data : Any> RealtimeChannel.postgresListDataFlow(
     schema: String = "public",
     table: String,
-    filter: FilterOperation? = null,
-    primaryKeys: List<PrimaryKey<Data>>
+    primaryKeys: List<PrimaryKey<Data>>,
+    crossinline filter: RealtimePostgresFilterBuilder.() -> Unit = {}
 ): Flow<List<Data>> {
     val cache = AtomicMutableMap<String, Data>()
+    val filterBuilder = RealtimePostgresFilterBuilder().apply(filter)
     val changeFlow = postgresChangeFlow<PostgresAction>(schema) {
         this.table = table
-        filter?.let {
-            filter(it)
-        }
+        this.filter(filterBuilder)
     }
     return channelFlow {
         val initialData = try {
             val result = supabaseClient.postgrest.from(schema, table).select {
-                filter?.let {
-                    filter {
-                        this.filter(it)
+                filter {
+                    filterBuilder.filters.forEach { (negate, operation) ->
+                        if(negate) {
+                            filterNot(operation)
+                        } else {
+                            filter(operation)
+                        }
                     }
                 }
             }
@@ -171,9 +174,9 @@ inline fun <reified Data : Any> RealtimeChannel.postgresListDataFlow(
 inline fun <reified Data : Any, Value> RealtimeChannel.postgresListDataFlow(
     schema: String = "public",
     table: String,
-    filter: FilterOperation? = null,
     primaryKey: KProperty1<Data, Value>,
-): Flow<List<Data>> = postgresListDataFlow(schema, table, filter, listOf(primaryKey))
+    crossinline filter: RealtimePostgresFilterBuilder.() -> Unit = {},
+): Flow<List<Data>> = postgresListDataFlow(schema, table, listOf(primaryKey), filter)
 
 /**
  * This function retrieves the initial data from the table and then listens for changes. It automatically handles inserts, updates and deletes.
@@ -189,8 +192,8 @@ inline fun <reified Data : Any, Value> RealtimeChannel.postgresListDataFlow(
 inline fun <reified Data : Any, Value> RealtimeChannel.postgresListDataFlow(
     schema: String = "public",
     table: String,
-    filter: FilterOperation? = null,
     primaryKeys: List<KProperty1<Data, Value>>,
+    crossinline filter: RealtimePostgresFilterBuilder.() -> Unit = {},
 ): Flow<List<Data>> = postgresListDataFlow<Data>(
     filter = filter,
     table = table,

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeExt.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/RealtimeExt.kt
@@ -113,11 +113,13 @@ inline fun <reified Data : Any> RealtimeChannel.postgresListDataFlow(
         val initialData = try {
             val result = supabaseClient.postgrest.from(schema, table).select {
                 filter {
-                    filterBuilder.filters.forEach { (negate, operation) ->
-                        if(negate) {
-                            filterNot(operation)
-                        } else {
-                            filter(operation)
+                    and { // realtime uses AND so we have to do the same
+                        filterBuilder.filters.forEach { (negate, operation) ->
+                            if(negate) {
+                                filterNot(operation)
+                            } else {
+                                filter(operation)
+                            }
                         }
                     }
                 }

--- a/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/postgres/RealtimePostgresFilterBuilder.kt
+++ b/Realtime/src/commonMain/kotlin/io/github/jan/supabase/realtime/postgres/RealtimePostgresFilterBuilder.kt
@@ -5,6 +5,8 @@ import io.github.jan.supabase.postgrest.query.filter.escapedValue
 import io.github.jan.supabase.realtime.RealtimeChannel
 import io.github.jan.supabase.realtime.postgresChangeFlow
 
+typealias NegatableFilterOperation = Pair<Boolean, FilterOperation>
+
 /**
  * Fluent builder for Postgres Changes `filter` strings.
  *
@@ -23,12 +25,12 @@ import io.github.jan.supabase.realtime.postgresChangeFlow
  */
 class RealtimePostgresFilterBuilder {
 
-    private val filters = mutableListOf<String>()
+    @PublishedApi
+    internal val filters = mutableListOf<NegatableFilterOperation>()
 
     private fun add(column: String, operator: RealtimePostgresChangesFilterOperator, value: Any, negate: Boolean = false) {
-        val prefix = if (negate) "not." else ""
         val operation = FilterOperation(column, operator.toPostgrestOperator(), value)
-        filters.add("${column}=$prefix${operator.name.lowercase()}.${operation.escapedValue(true)}")
+        filters.add(negate to operation)
     }
 
     /** Match rows where [column] equals [value] (`column=eq.value`). */
@@ -124,6 +126,9 @@ class RealtimePostgresFilterBuilder {
      * the way PostgREST does, so commas inside a value are preserved rather than
      * read as a condition boundary.
      */
-    fun build() = filters.joinToString(",")
+    fun build() = filters.joinToString(",") { (negate, operation) ->
+        val prefix = if (negate) "not." else ""
+        "${operation.column}=$prefix${operation.operator.name.lowercase()}.${operation.escapedValue(true)}"
+    }
 
 }

--- a/Realtime/src/commonTest/kotlin/RealtimeExtTest.kt
+++ b/Realtime/src/commonTest/kotlin/RealtimeExtTest.kt
@@ -1,7 +1,5 @@
 import app.cash.turbine.test
 import io.github.jan.supabase.postgrest.Postgrest
-import io.github.jan.supabase.postgrest.query.filter.FilterOperation
-import io.github.jan.supabase.postgrest.query.filter.FilterOperator
 import io.github.jan.supabase.realtime.CallbackManager
 import io.github.jan.supabase.realtime.PostgresAction
 import io.github.jan.supabase.realtime.PostgresJoinConfig
@@ -69,10 +67,11 @@ class RealtimeExtTest {
     @Test
     fun testPostgresListDataFlow() { //Maybe there is a better way to test this
         runTest {
-            val filter = FilterOperation("id", FilterOperator.EQ, "0")
             createTestClient(
                 wsHandler = { i, o ->
-                    handleSubscribe(i, o, "channelId")
+                    handleSubscribe(i, o, "channelId") {
+                        assertEquals("id=eq.0,age=lt.58", it.config.postgresChanges.first().filter)
+                    }
                 },
                 supabaseHandler = {
                     val channel = it.channel("channelId")
@@ -81,7 +80,7 @@ class RealtimeExtTest {
                             PostgresJoinConfig(
                                 "public",
                                 "table",
-                                "id=eq.0",
+                                "id=eq.0,age=lt.58",
                                 "*",
                                 0
                             )
@@ -90,9 +89,11 @@ class RealtimeExtTest {
                     val dataFlow = channel.postgresListDataFlow(
                         "public",
                         "table",
-                        filter = filter,
                         primaryKey = DummyData::key
-                    )
+                    ) {
+                        eq("id", 0)
+                        lt("age", 58)
+                    }
                     dataFlow.test(FLOW_TIMEOUT) {
                         assertContentEquals(listOf(DummyData(0, "first")), awaitItem()) //1. Initial data
                         channel.subscribe(true)
@@ -108,8 +109,10 @@ class RealtimeExtTest {
                 },
                 mockEngineHandler = {
                     assertEquals("/table", it.url.pathAfterVersion())
-                    val urlFilter = it.url.parameters["id"]
-                    assertEquals("eq.0", urlFilter)
+                    val idFilter = it.url.parameters["id"]
+                    assertEquals("eq.0", idFilter)
+                    val ageFilter = it.url.parameters["age"]
+                    assertEquals("lt.58", ageFilter)
                     respond(Json.encodeToJsonElement(listOf(DummyData(0, "first"))).toString()) //1.
                 },
                 supabaseConfig = {

--- a/Realtime/src/commonTest/kotlin/RealtimeExtTest.kt
+++ b/Realtime/src/commonTest/kotlin/RealtimeExtTest.kt
@@ -109,10 +109,8 @@ class RealtimeExtTest {
                 },
                 mockEngineHandler = {
                     assertEquals("/table", it.url.pathAfterVersion())
-                    val idFilter = it.url.parameters["id"]
-                    assertEquals("eq.0", idFilter)
-                    val ageFilter = it.url.parameters["age"]
-                    assertEquals("lt.58", ageFilter)
+                    val andFilter = it.url.parameters["and"]
+                    assertEquals("(id.eq.0,age.lt.58)", andFilter)
                     respond(Json.encodeToJsonElement(listOf(DummyData(0, "first"))).toString()) //1.
                 },
                 supabaseConfig = {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

This pull request refactors the way realtime Postgres change filters are built and passed throughout the codebase, moving from a single `FilterOperation` object to a more flexible, fluent builder pattern (`RealtimePostgresFilterBuilder`). This makes it easier to compose complex filters using a lambda syntax, improves consistency with the PostgREST filter API, and ensures proper escaping and negation of filter values. The changes affect both the main implementation and test code.

**API and Filtering Improvements:**

* Replaces the use of `FilterOperation` with a lambda-based `RealtimePostgresFilterBuilder` in all relevant public APIs (such as `selectAsFlow` and `postgresListDataFlow`), allowing users to define filters in a more idiomatic and composable way.
* Refactors the internal representation of filters in `RealtimePostgresFilterBuilder` to store a list of negatable filter operations, enabling support for both normal and negated conditions. The `build()` method now correctly serializes these to the expected filter string format.

**Codebase Consistency and Cleanup:**

* Removes unused imports and references to `FilterOperation` and `FilterOperator` in files where filtering is now handled via the builder.
* Updates the `PostgresChangeFilter` class to allow direct assignment of the filter string and adds overloads for the new builder-based filter setting.

**Testing and Validation:**

* Updates tests to use the new builder syntax for filters, verifies that combined filters are correctly serialized and passed to both the realtime channel and REST queries, and checks that filters are properly applied in test scenarios.
