### PR TITLE
Update CONTRIBUTING.md with information on how to run tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,3 +36,29 @@ And add the following to your dependencies:
 ```kotlin
 implementation("io.github.jan-tennert.supabase:[module]:customVersion")
 ```
+## Running Tests
+
+It is possible to run tests across all modules using the following commands from the root directory:
+
+```shell
+# Run tests across all available targets on the platform
+./gradlew allTests 
+
+# Run tests for a specific target. They will only run if the target is supported on the platform the command is run on.
+# The following targets are supported:
+./gradlew jvmTest
+./gradlew jsBrowserTest
+./gradlew wasmJsBrowserTest
+./gradlew iosX64Test
+./gradlew iosSimulatorArm64Test
+./gradlew tvosX64Test
+./gradlew tvosSimulatorArm64Test
+./gradlew watchosX64Test
+./gradlew watchosSimulatorArm64Test
+./gradlew mingwX64Test
+```
+Some test targets have special requirements:
+- Browser tests require that Chrome, Firefox and Safari (on macOS) are installed.
+- `ios`/`watchos`/`tvos` tests only work on Mac and require that the relevant SDK is installed in Xcode.
+- Android does not have specific tests, but are tested implicitly through the `jvmTest` task.
+


### PR DESCRIPTION
## What kind of change does this PR introduce?

Update `CONTRIBUTING.md` with information on how to run tests for supported targets. 

## What is the current behavior?

No documentation on tests exists, so you either have to know the relevant Gradle commands or locate them in the GitHub Actions setup. 

## What is the new behavior?

`CONTRIBUTING.md` now contains more explicit information on how to run tests.

## Additional context

_None_
